### PR TITLE
Version 92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 92:
 
 * Fix typo in test/CMakeLists.txt
 * basic_fields::value_type is not copyable
+* Update repository links in source comments
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 92:
 
 * Fix typo in test/CMakeLists.txt
+* basic_fields::value_type is not copyable
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 92:
 * Update repository links in source comments
 * Ignore Content-Length in some cases
 * Tidy up doc snippet paths
+* Use off-site doc link
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 92:
 * basic_fields::value_type is not copyable
 * Update repository links in source comments
 * Ignore Content-Length in some cases
+* Tidy up doc snippet paths
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 92:
+
+* Fix typo in test/CMakeLists.txt
+
+--------------------------------------------------------------------------------
+
 Version 91:
 
 * Adjust redirect html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 92:
 * Fix typo in test/CMakeLists.txt
 * basic_fields::value_type is not copyable
 * Update repository links in source comments
+* Ignore Content-Length in some cases
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.5.2)
 
-project (Beast VERSION 91)
+project (Beast VERSION 92)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_BENCH "Build bench" ON)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ without conditions. The first official release of Beast will
 appear in Boost 1.66.0, due in December.
 
 * [Official Site](https://github.com/boostorg/beast)
-* [Documentation](http://www.boost.org/doc/libs/master/libs/bind/doc/html/beast.html)
+* [Documentation](http://vinniefalco.github.io/beast/index.html)
 * [Autobahn.testsuite results](http://vinniefalco.github.io/autobahn/index.html)
 
 ## Requirements

--- a/doc/qbk/00_main.qbk
+++ b/doc/qbk/00_main.qbk
@@ -89,10 +89,10 @@
 
 [import ../../include/boost/beast/http/basic_file_body.hpp]
 
-[import ../../test/exemplars.cpp]
-[import ../../test/core/doc_snippets.cpp]
-[import ../../test/http/doc_snippets.cpp]
-[import ../../test/websocket/doc_snippets.cpp]
+[import ../../test/doc/exemplars.cpp]
+[import ../../test/doc/core_snippets.cpp]
+[import ../../test/doc/http_snippets.cpp]
+[import ../../test/doc/websocket_snippets.cpp]
 
 [include 01_intro.qbk]
 [include 02_examples.qbk]

--- a/include/boost/beast/core/handler_ptr.hpp
+++ b/include/boost/beast/core/handler_ptr.hpp
@@ -61,7 +61,7 @@ class handler_ptr
         // without exposing ourselves to race conditions
         // and all sorts of ugliness.
         // See:
-        //  https://github.com/vinniefalco/Beast/issues/215
+        //  https://github.com/boostorg/beast/issues/215
         Handler handler;
 
         template<class DeducedHandler, class... Args>

--- a/include/boost/beast/http/fields.hpp
+++ b/include/boost/beast/http/fields.hpp
@@ -85,6 +85,12 @@ public:
         field f_;
 
     public:
+        /// Constructor (deleted)
+        value_type(value_type const&) = delete;
+
+        /// Assignment (deleted)
+        value_type& operator=(value_type const&) = delete;
+
         /// Returns the field enum, which can be @ref field::unknown
         field
         name() const;

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 91
+#define BOOST_BEAST_VERSION 92
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/zlib/detail/deflate_stream.hpp
+++ b/include/boost/beast/zlib/detail/deflate_stream.hpp
@@ -1021,7 +1021,7 @@ doParams(z_params& zs, int level, Strategy strategy, error_code& ec)
 
 // VFALCO boost::optional param is a workaround for
 //        gcc "maybe uninitialized" warning
-//        https://github.com/vinniefalco/Beast/issues/532
+//        https://github.com/boostorg/beast/issues/532
 //
 template<class>
 void

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,5 +14,3 @@ endif()
 add_subdirectory (beast)
 add_subdirectory (doc)
 add_subdirectory (example)
-
-alias fat-tests : ;

--- a/test/beast/core/handler_alloc.cpp
+++ b/test/beast/core/handler_alloc.cpp
@@ -28,7 +28,7 @@ public:
         }
     };
 
-    // https://github.com/vinniefalco/Beast/issues/432
+    // https://github.com/boostorg/beast/issues/432
     void
     testRegression432()
     {

--- a/test/beast/http/basic_parser.cpp
+++ b/test/beast/http/basic_parser.cpp
@@ -1106,6 +1106,24 @@ public:
             });
     }
 
+    // https://github.com/boostorg/beast/issues/692
+    void
+    testIssue692()
+    {
+        error_code ec;
+        test_parser<false> p;
+        p.eager(true);
+        string_view s =
+            "HTTP/1.1 101 Switching Protocols\r\n"
+            "Content-Length: 2147483648\r\n"
+            "\r\n";
+        p.put(boost::asio::buffer(
+            s.data(), s.size()), ec);
+        if(! BEAST_EXPECTS(! ec, ec.message()))
+            return;
+        BEAST_EXPECT(p.is_done());
+    }
+
     //--------------------------------------------------------------------------
 
     void
@@ -1216,6 +1234,7 @@ public:
         testIssue430();
         testIssue452();
         testIssue496();
+        testIssue692();
         testFuzz();
         testRegression1();
     }

--- a/test/beast/http/basic_parser.cpp
+++ b/test/beast/http/basic_parser.cpp
@@ -1056,7 +1056,7 @@ public:
 
     //--------------------------------------------------------------------------
 
-    // https://github.com/vinniefalco/Beast/issues/430
+    // https://github.com/boostorg/beast/issues/430
     void
     testIssue430()
     {
@@ -1069,7 +1069,7 @@ public:
             "0\r\n\r\n");
     }
 
-    // https://github.com/vinniefalco/Beast/issues/452
+    // https://github.com/boostorg/beast/issues/452
     void
     testIssue452()
     {
@@ -1087,7 +1087,7 @@ public:
         BEAST_EXPECT(p.is_done());
     }
 
-    // https://github.com/vinniefalco/Beast/issues/496
+    // https://github.com/boostorg/beast/issues/496
     void
     testIssue496()
     {

--- a/test/beast/http/read.cpp
+++ b/test/beast/http/read.cpp
@@ -366,7 +366,7 @@ public:
         }
     }
 
-    // https://github.com/vinniefalco/Beast/issues/430
+    // https://github.com/boostorg/beast/issues/430
     void
     testRegression430()
     {

--- a/test/beast/websocket/stream.cpp
+++ b/test/beast/websocket/stream.cpp
@@ -1534,7 +1534,7 @@ public:
 #endif
 
     /*
-        https://github.com/vinniefalco/Beast/issues/300
+        https://github.com/boostorg/beast/issues/300
 
         Write a message as two individual frames
     */


### PR DESCRIPTION
* Fix typo in test/CMakeLists.txt
* basic_fields::value_type is not copyable
* Update repository links in source comments
* Ignore Content-Length in some cases
* Tidy up doc snippet paths
* Use off-site doc link
