### PR TITLE
Try to fix test build

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -79,7 +79,7 @@ project beast
     <include>./extras
     #<use>/boost//headers
     <library>/boost/system//boost_system
-    <library>/boost/coroutine//boost_coroutine/<define>BOOST_COROUTINES_NO_DEPRECATION_WARNING=1
+    <library>/boost/coroutine//boost_coroutine
     <library>/boost/filesystem//boost_filesystem
     <link>static
     <define>BOOST_ALL_NO_LIB=1


### PR DESCRIPTION
When I run b2 in the status directory, I'm getting this error:

    error: Name clash for
    '<p../bin.v2/libs/coroutine/build/gcc-6.3.0/debug/link-static/threading-multi>libboost_coroutine.a'
    error:
    error: Tried to build the target twice, with property sets having
    error: these incompatible properties:
    error:
    error:     -  <define>BOOST_COROUTINES_NO_DEPRECATION_WARNING=1
    error:     -  none
    error:
    error: Please make sure to have consistent requirements for these
    error: properties everywhere in your project, especially for install
    error: targets.

This seems to be caused by different libraries depending on
boost_coroutine and only one of them using this feature. This fixes
that.

Btw. I think your jamfile should be in a 'build' subdirectory.