### PR TITLE
Version 106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 106:
 WebSocket:
 
 * websocket test improvements
+* Remove obsolete write_op
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ WebSocket:
 * Refactor read_op + fail_op
 * Websocket close will automatically drain
 * Autobahn|Testsuite fixes
+* Tidy up utf8_checker and tests
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ WebSocket:
 * Refactor read_op
 * Refactor close_op
 * Refactor read_op + fail_op
+* Websocket close will automatically drain
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ WebSocket:
 * Remove obsolete write_op
 * Refactor write_op
 * Refactor ping_op
+* Refactor fail_op
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ WebSocket:
 
 * websocket test improvements
 * Remove obsolete write_op
+* Refactor write_op
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ WebSocket:
 * Refactor ping_op
 * Refactor fail_op
 * Refactor read_op
+* Refactor close_op
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ WebSocket:
 * websocket test improvements
 * Remove obsolete write_op
 * Refactor write_op
+* Refactor ping_op
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Version 106:
 * Dynamic buffer input areas are mutable
 * Add flat_static_buffer::reset
 
+HTTP:
+
+* Fix for basic_parser::skip(true) and docs
+
 WebSocket:
 
 * websocket test improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 106:
+
+* Dynamic buffer input areas are mutable
+
+--------------------------------------------------------------------------------
+
 Version 105:
 
 * Fix compile error in websocket snippet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ WebSocket:
 * Refactor write_op
 * Refactor ping_op
 * Refactor fail_op
+* Refactor read_op
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 106:
 
 * Dynamic buffer input areas are mutable
+* Add flat_static_buffer::reset
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Version 106:
 * Dynamic buffer input areas are mutable
 * Add flat_static_buffer::reset
 
+WebSocket:
+
+* websocket test improvements
+
 --------------------------------------------------------------------------------
 
 Version 105:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ WebSocket:
 * Refactor fail_op
 * Refactor read_op
 * Refactor close_op
+* Refactor read_op + fail_op
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ WebSocket:
 * Refactor close_op
 * Refactor read_op + fail_op
 * Websocket close will automatically drain
+* Autobahn|Testsuite fixes
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.5.2)
 
-project (Beast VERSION 105)
+project (Beast VERSION 106)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Branch      | Linux/OSX | Windows | Coverage | Documentation | Matrix
 - [Requirements](#requirements)
 - [Building](#building)
 - [Usage](#usage)
-- [Licence](#licence)
+- [License](#license)
 - [Contact](#contact)
 - [Contributing](#Contributing)
 

--- a/doc/qbk/05_http_examples.qbk
+++ b/doc/qbk/05_http_examples.qbk
@@ -78,7 +78,11 @@ The
 [@https://tools.ietf.org/html/rfc7231#section-4.3.2 HEAD request]
 method indicates to the server that the client wishes to receive the
 entire header that would be delivered if the method was GET, except
-that the body is omitted.
+that the body is omitted. When a client wishes to receive the response
+to a HEAD request, it is necessary to inform the parser not to expect
+a body. This is done by calling
+[link beast.ref.boost__beast__http__basic_parser.skip `basic_parser::skip`]
+with the value `true`, as shown in this example:
 
 [example_http_do_head_request]
 

--- a/example/doc/http_examples.hpp
+++ b/example/doc/http_examples.hpp
@@ -411,11 +411,18 @@ do_head_request(
         return {};
 
     // Create a parser to read the response.
-    // Responses to HEAD requests MUST NOT include
-    // a body, so we use the `empty_body` type and
-    // only attempt to read the header.
-    parser<false, empty_body> p;
-    read_header(stream, buffer, p, ec);
+    // We use the `empty_body` type since
+    // a response to a HEAD request MUST NOT
+    // include a body.
+    response_parser<empty_body> p;
+
+    // Inform the parser that there will be no body.
+    p.skip(true);
+
+    // Read the message. Even though fields like
+    // Content-Length or Transfer-Encoding may be
+    // set, the message will not contain a body.
+    read(stream, buffer, p, ec);
     if(ec)
         return {};
 

--- a/example/websocket/server/fast/websocket_server_fast.cpp
+++ b/example/websocket/server/fast/websocket_server_fast.cpp
@@ -104,7 +104,6 @@ do_sync_session(tcp::socket& socket)
             break;
         if(ec)
             return fail(ec, "read");
-
         ws.text(ws.got_text());
         ws.write(buffer.data(), ec);
         if(ec)

--- a/include/boost/beast/core/flat_buffer.hpp
+++ b/include/boost/beast/core/flat_buffer.hpp
@@ -84,7 +84,7 @@ public:
     using allocator_type = Allocator;
 
     /// The type used to represent the input sequence as a list of buffers.
-    using const_buffers_type = boost::asio::const_buffers_1;
+    using const_buffers_type = boost::asio::mutable_buffers_1;
 
     /// The type used to represent the output sequence as a list of buffers.
     using mutable_buffers_type = boost::asio::mutable_buffers_1;

--- a/include/boost/beast/core/flat_static_buffer.hpp
+++ b/include/boost/beast/core/flat_static_buffer.hpp
@@ -114,6 +114,10 @@ public:
     mutable_data_type
     mutable_data();
 
+    /// Set the input and output sequences to size 0
+    void
+    reset();
+
     /** Get a list of buffers that represent the output sequence, with the given size.
 
         @throws std::length_error if the size would exceed the limit
@@ -147,10 +151,10 @@ protected:
     /** Constructor
 
         The buffer will be in an undefined state. It is necessary
-        for the derived class to call @ref reset in order to
-        initialize the object.
+        for the derived class to call @ref reset with a pointer
+        and size in order to initialize the object.
     */
-    flat_static_buffer_base();
+    flat_static_buffer_base() = default;
 
     /** Reset the pointed-to buffer.
 
@@ -174,6 +178,10 @@ private:
     {
         return static_cast<std::size_t>(last - first);
     }
+
+    template<class = void>
+    void
+    reset_impl();
 
     template<class = void>
     void

--- a/include/boost/beast/core/flat_static_buffer.hpp
+++ b/include/boost/beast/core/flat_static_buffer.hpp
@@ -52,7 +52,7 @@ public:
 
         This buffer sequence is guaranteed to have length 1.
     */
-    using const_buffers_type = boost::asio::const_buffers_1;
+    using const_buffers_type = boost::asio::mutable_buffers_1;
 
     /** The type used to represent the mutable input sequence as a list of buffers.
 

--- a/include/boost/beast/core/flat_static_buffer.hpp
+++ b/include/boost/beast/core/flat_static_buffer.hpp
@@ -54,12 +54,6 @@ public:
     */
     using const_buffers_type = boost::asio::mutable_buffers_1;
 
-    /** The type used to represent the mutable input sequence as a list of buffers.
-
-        This buffer sequence is guaranteed to have length 1.
-    */
-    using mutable_data_type = boost::asio::mutable_buffers_1;
-
     /** The type used to represent the output sequence as a list of buffers.
 
         This buffer sequence is guaranteed to have length 1.
@@ -106,13 +100,6 @@ public:
     */
     const_buffers_type
     data() const;
-
-    /** Get a list of mutable buffers that represent the input sequence.
-
-        @note These buffers remain valid across subsequent calls to `prepare`.
-    */
-    mutable_data_type
-    mutable_data();
 
     /// Set the input and output sequences to size 0
     void

--- a/include/boost/beast/core/impl/buffers_adapter.ipp
+++ b/include/boost/beast/core/impl/buffers_adapter.ipp
@@ -17,7 +17,6 @@
 #include <cstring>
 #include <iterator>
 #include <stdexcept>
-#include <type_traits>
 
 namespace boost {
 namespace beast {
@@ -29,7 +28,7 @@ class buffers_adapter<MutableBufferSequence>::
     buffers_adapter const* ba_;
 
 public:
-    using value_type = boost::asio::const_buffer;
+    using value_type = boost::asio::mutable_buffer;
 
     class const_iterator;
 

--- a/include/boost/beast/core/impl/flat_static_buffer.ipp
+++ b/include/boost/beast/core/impl/flat_static_buffer.ipp
@@ -36,15 +36,6 @@ data() const ->
 }
 
 inline
-auto
-flat_static_buffer_base::
-mutable_data() ->
-    mutable_data_type
-{
-    return {in_, dist(in_, out_)};
-}
-
-inline
 void
 flat_static_buffer_base::
 reset()

--- a/include/boost/beast/core/impl/flat_static_buffer.ipp
+++ b/include/boost/beast/core/impl/flat_static_buffer.ipp
@@ -45,6 +45,14 @@ mutable_data() ->
 }
 
 inline
+void
+flat_static_buffer_base::
+reset()
+{
+    reset_impl();
+}
+
+inline
 auto
 flat_static_buffer_base::
 prepare(std::size_t n) ->
@@ -59,6 +67,16 @@ flat_static_buffer_base::
 reset(void* p, std::size_t n)
 {
     reset_impl(p, n);
+}
+
+template<class>
+void
+flat_static_buffer_base::
+reset_impl()
+{
+    in_ = begin_;
+    out_ = begin_;
+    last_ = begin_;
 }
 
 template<class>

--- a/include/boost/beast/core/impl/multi_buffer.ipp
+++ b/include/boost/beast/core/impl/multi_buffer.ipp
@@ -132,8 +132,7 @@ class basic_multi_buffer<Allocator>::const_buffers_type
     const_buffers_type(basic_multi_buffer const& b);
 
 public:
-    // Why?
-    using value_type = boost::asio::const_buffer;
+    using value_type = boost::asio::mutable_buffer;
 
     class const_iterator;
 

--- a/include/boost/beast/core/impl/static_buffer.ipp
+++ b/include/boost/beast/core/impl/static_buffer.ipp
@@ -35,14 +35,19 @@ static_buffer_base::
 data() const ->
     const_buffers_type
 {
-    using boost::asio::const_buffer;
+    using boost::asio::mutable_buffer;
+    const_buffers_type result;
     if(in_off_ + in_size_ <= capacity_)
-        return {{
-            {const_buffer{begin_ + in_off_, in_size_}},
-            {const_buffer{begin_, 0}}}};
-    return {{
-        {const_buffer{begin_ + in_off_, capacity_ - in_off_}},
-        {const_buffer{begin_, in_size_ - (capacity_ - in_off_)}}}};
+    {
+        result[0] = mutable_buffer{begin_ + in_off_, in_size_};
+        result[1] = mutable_buffer{begin_, 0};
+    }
+    else
+    {
+        result[0] = mutable_buffer{begin_ + in_off_, capacity_ - in_off_};
+        result[1] = mutable_buffer{begin_, in_size_ - (capacity_ - in_off_)};
+    }
+    return result;
 }
 
 inline
@@ -52,13 +57,18 @@ mutable_data() ->
     mutable_data_type
 {
     using boost::asio::mutable_buffer;
+    mutable_data_type result;
     if(in_off_ + in_size_ <= capacity_)
-        return {{
-            {mutable_buffer{begin_ + in_off_, in_size_}},
-            {mutable_buffer{begin_, 0}}}};
-    return {{
-        {mutable_buffer{begin_ + in_off_, capacity_ - in_off_}},
-        {mutable_buffer{begin_, in_size_ - (capacity_ - in_off_)}}}};
+    {
+        result[0] = mutable_buffer{begin_ + in_off_, in_size_};
+        result[1] = mutable_buffer{begin_, 0};
+    }
+    else
+    {
+        result[0] = mutable_buffer{begin_ + in_off_, capacity_ - in_off_};
+        result[1] = mutable_buffer{begin_, in_size_ - (capacity_ - in_off_)};
+    }
+    return result;
 }
 
 inline
@@ -73,13 +83,18 @@ prepare(std::size_t size) ->
             "buffer overflow"});
     out_size_ = size;
     auto const out_off = (in_off_ + in_size_) % capacity_;
+    mutable_buffers_type result;
     if(out_off + out_size_ <= capacity_ )
-        return {{
-            {mutable_buffer{begin_ + out_off, out_size_}},
-            {mutable_buffer{begin_, 0}}}};
-    return {{
-        {mutable_buffer{begin_ + out_off, capacity_ - out_off}},
-        {mutable_buffer{begin_, out_size_ - (capacity_ - out_off)}}}};
+    {
+        result[0] = mutable_buffer{begin_ + out_off, out_size_};
+        result[1] = mutable_buffer{begin_, 0};
+    }
+    else
+    {
+        result[0] = mutable_buffer{begin_ + out_off, capacity_ - out_off};
+        result[1] = mutable_buffer{begin_, out_size_ - (capacity_ - out_off)};
+    }
+    return result;
 }
 
 inline

--- a/include/boost/beast/core/impl/static_buffer.ipp
+++ b/include/boost/beast/core/impl/static_buffer.ipp
@@ -53,27 +53,6 @@ data() const ->
 inline
 auto
 static_buffer_base::
-mutable_data() ->
-    mutable_data_type
-{
-    using boost::asio::mutable_buffer;
-    mutable_data_type result;
-    if(in_off_ + in_size_ <= capacity_)
-    {
-        result[0] = mutable_buffer{begin_ + in_off_, in_size_};
-        result[1] = mutable_buffer{begin_, 0};
-    }
-    else
-    {
-        result[0] = mutable_buffer{begin_ + in_off_, capacity_ - in_off_};
-        result[1] = mutable_buffer{begin_, in_size_ - (capacity_ - in_off_)};
-    }
-    return result;
-}
-
-inline
-auto
-static_buffer_base::
 prepare(std::size_t size) ->
     mutable_buffers_type
 {

--- a/include/boost/beast/core/static_buffer.hpp
+++ b/include/boost/beast/core/static_buffer.hpp
@@ -54,10 +54,6 @@ public:
     using const_buffers_type =
         std::array<boost::asio::mutable_buffer, 2>;
 
-    /// The type used to represent the mutable input sequence as a list of buffers.
-    using mutable_data_type =
-        std::array<boost::asio::mutable_buffer, 2>;
-
     /// The type used to represent the output sequence as a list of buffers.
     using mutable_buffers_type =
         std::array<boost::asio::mutable_buffer, 2>;
@@ -97,11 +93,6 @@ public:
     */
     const_buffers_type
     data() const;
-
-    /** Get a list of mutable buffers that represent the input sequence.
-    */
-    mutable_data_type
-    mutable_data();
 
     /** Get a list of buffers that represent the output sequence, with the given size.
 

--- a/include/boost/beast/core/static_buffer.hpp
+++ b/include/boost/beast/core/static_buffer.hpp
@@ -52,7 +52,7 @@ class static_buffer_base
 public:
     /// The type used to represent the input sequence as a list of buffers.
     using const_buffers_type =
-        std::array<boost::asio::const_buffer, 2>;
+        std::array<boost::asio::mutable_buffer, 2>;
 
     /// The type used to represent the mutable input sequence as a list of buffers.
     using mutable_data_type =

--- a/include/boost/beast/http/impl/basic_parser.ipp
+++ b/include/boost/beast/http/impl/basic_parser.ipp
@@ -587,10 +587,8 @@ finish_header(error_code& ec, std::false_type)
         //        treat the message as not having a body.
         //        https://github.com/boostorg/beast/issues/692
         state_ = state::complete;
-        return;
     }
-
-    if(f_ & flagContentLength)
+    else if(f_ & flagContentLength)
     {
         if(len_ > body_limit_)
         {

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 105
+#define BOOST_BEAST_VERSION 106
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/detail/pausation.hpp
+++ b/include/boost/beast/websocket/detail/pausation.hpp
@@ -11,6 +11,7 @@
 #define BOOST_BEAST_WEBSOCKET_DETAIL_PAUSATION_HPP
 
 #include <boost/beast/core/handler_ptr.hpp>
+#include <boost/asio/coroutine.hpp>
 #include <boost/assert.hpp>
 #include <array>
 #include <memory>
@@ -68,7 +69,7 @@ class pausation
         }
     };
 
-    struct exemplar
+    struct exemplar : boost::asio::coroutine
     {
         struct H
         {

--- a/include/boost/beast/websocket/impl/close.ipp
+++ b/include/boost/beast/websocket/impl/close.ipp
@@ -251,7 +251,7 @@ close(close_reason const& cr, error_code& ec)
                 rd_close_ = true;
                 auto const mb = buffer_prefix(
                     clamp(rd_.fh.len),
-                    rd_.buf.mutable_data());
+                    rd_.buf.data());
                 if(rd_.fh.len > 0 && rd_.fh.mask)
                     detail::mask_inplace(mb, rd_.key);
                 detail::read_close(cr_, mb, code);

--- a/include/boost/beast/websocket/impl/fail.ipp
+++ b/include/boost/beast/websocket/impl/fail.ipp
@@ -202,10 +202,7 @@ operator()(error_code ec, std::size_t)
     upcall:
         BOOST_ASSERT(d.ws.wr_block_ == d.tok);
         d.ws.wr_block_.reset();
-        d.ws.close_op_.maybe_invoke() ||
-            d.ws.ping_op_.maybe_invoke() ||
-            d.ws.wr_op_.maybe_invoke();
-        d_.invoke(ec, 0);
+        d_.invoke(ec);
     }
 }
 

--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -560,6 +560,7 @@ operator()(
     upcall:
         BOOST_ASSERT(ws_.rd_block_ == tok_);
         ws_.rd_block_.reset();
+        ws_.r_close_op_.maybe_invoke();
         ws_.close_op_.maybe_invoke() ||
             ws_.ping_op_.maybe_invoke() ||
             ws_.wr_op_.maybe_invoke();

--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -976,6 +976,12 @@ read_some(
     using boost::asio::buffer;
     using boost::asio::buffer_cast;
     using boost::asio::buffer_size;
+    // Make sure the stream is open
+    if(failed_)
+    {
+        ec = boost::asio::error::operation_aborted;
+        return 0;
+    }
     close_code code{};
     std::size_t bytes_written = 0;
 loop:

--- a/include/boost/beast/websocket/impl/stream.ipp
+++ b/include/boost/beast/websocket/impl/stream.ipp
@@ -177,11 +177,13 @@ open(role_type role)
     rd_.cont = false;
     rd_.done = true;
     // Can't clear this because accept uses it
-    //rd_.buf.consume(rd_.buf.size());
+    //rd_.buf.reset();
     rd_.fh.fin = false;
     rd_close_ = false;
     wr_close_ = false;
     wr_block_.reset();
+    rd_block_.reset();
+    cr_.code = close_code::none;
     ping_data_ = nullptr;   // should be nullptr on close anyway
 
     wr_.cont = false;
@@ -240,6 +242,8 @@ reset()
     wr_close_ = false;
     wr_.cont = false;
     wr_block_.reset();
+    rd_block_.reset();
+    cr_.code = close_code::none;
     ping_data_ = nullptr;   // should be nullptr on close anyway
 }
 

--- a/include/boost/beast/websocket/impl/write.ipp
+++ b/include/boost/beast/websocket/impl/write.ipp
@@ -522,8 +522,8 @@ operator()(error_code ec,
     //--------------------------------------------------------------------------
 
     upcall:
-        if(ws_.wr_block_ == tok_)
-            ws_.wr_block_.reset();
+        BOOST_ASSERT(ws_.wr_block_ == tok_);
+        ws_.wr_block_.reset();
         ws_.close_op_.maybe_invoke() ||
             ws_.rd_op_.maybe_invoke() ||
             ws_.ping_op_.maybe_invoke();

--- a/include/boost/beast/websocket/stream.hpp
+++ b/include/boost/beast/websocket/stream.hpp
@@ -3766,11 +3766,11 @@ private:
 
     template<class DynamicBuffer>
     void
-    write_close(DynamicBuffer& db, close_reason const& rc);
+    write_close(DynamicBuffer& b, close_reason const& rc);
 
     template<class DynamicBuffer>
     void
-    write_ping(DynamicBuffer& db,
+    write_ping(DynamicBuffer& b,
         detail::opcode op, ping_data const& data);
 
     template<class Decorator>

--- a/include/boost/beast/websocket/stream.hpp
+++ b/include/boost/beast/websocket/stream.hpp
@@ -200,6 +200,8 @@ class stream
         // The buffer is allocated or reallocated at the beginning of
         // sending a message.
         std::unique_ptr<std::uint8_t[]> buf;
+
+        detail::fh_streambuf fb;
     };
 
     // State information for the permessage-deflate extension

--- a/include/boost/beast/websocket/stream.hpp
+++ b/include/boost/beast/websocket/stream.hpp
@@ -230,12 +230,15 @@ class stream
     bool rd_close_;                         // read close frame
     bool wr_close_;                         // sent close frame
     token wr_block_;                        // op currenly writing
+    token rd_block_;                        // op currenly reading
 
     ping_data* ping_data_;                  // where to put the payload
     detail::pausation rd_op_;               // paused read op
     detail::pausation wr_op_;               // paused write op
     detail::pausation ping_op_;             // paused ping op
     detail::pausation close_op_;            // paused close op
+    detail::pausation r_rd_op_;             // paused read op (read)
+    detail::pausation r_close_op_;          // paused close op (read)
     close_reason cr_;                       // set from received close frame
     rd_t rd_;                               // read state
     wr_t wr_;                               // write state

--- a/include/boost/beast/websocket/stream.hpp
+++ b/include/boost/beast/websocket/stream.hpp
@@ -154,7 +154,7 @@ class stream
         detail::prepared_key key;       // current stateful mask key
         std::uint64_t size;             // total size of current message so far
         std::uint64_t remain;           // message frame bytes left in current frame
-        detail::frame_streambuf fb;     // to write control frames
+        detail::frame_streambuf fb;     // to write control frames (during reads)
         detail::utf8_checker utf8;      // to validate utf8
 
         // A small, circular buffer to read frame headers.

--- a/test/beast/core/flat_static_buffer.cpp
+++ b/test/beast/core/flat_static_buffer.cpp
@@ -105,7 +105,6 @@ public:
                 ba.commit(buffer_copy(d, buffer(s.data()+x+y, z)));
             }
             ba.commit(2);
-            BEAST_EXPECT(buffer_size(ba.data()) == buffer_size(ba.mutable_data()));
             BEAST_EXPECT(ba.size() == x + y + z);
             BEAST_EXPECT(buffer_size(ba.data()) == ba.size());
             BEAST_EXPECT(to_string(ba.data()) == s);

--- a/test/beast/core/static_buffer.cpp
+++ b/test/beast/core/static_buffer.cpp
@@ -105,7 +105,6 @@ public:
                 ba.commit(buffer_copy(d, buffer(s.data()+x+y, z)));
             }
             ba.commit(2);
-            BEAST_EXPECT(buffer_size(ba.data()) == buffer_size(ba.mutable_data()));
             BEAST_EXPECT(ba.size() == x + y + z);
             BEAST_EXPECT(buffer_size(ba.data()) == ba.size());
             BEAST_EXPECT(to_string(ba.data()) == s);

--- a/test/beast/http/basic_parser.cpp
+++ b/test/beast/http/basic_parser.cpp
@@ -325,8 +325,8 @@ public:
                     "GET / HTTP/1.1\r\n"
                     "f: " + s + "\r\n"
                     "\r\n";
-                parsegrind<parser<true, string_body>>(m,
-                    [&](parser<true, string_body> const& p)
+                parsegrind<request_parser<string_body>>(m,
+                    [&](request_parser<string_body> const& p)
                     {
                         BEAST_EXPECT(p.get()["f"] == value);
                     });

--- a/test/beast/http/read.cpp
+++ b/test/beast/http/read.cpp
@@ -385,7 +385,7 @@ public:
           "0\r\n\r\n";
         error_code ec;
         flat_buffer fb;
-        parser<false, dynamic_body> p;
+        response_parser<dynamic_body> p;
         read(c.server, fb, p, ec);
         BEAST_EXPECTS(! ec, ec.message());
     }

--- a/test/beast/websocket/utf8_checker.cpp
+++ b/test/beast/websocket/utf8_checker.cpp
@@ -42,14 +42,12 @@ public:
         BEAST_EXPECT(utf8.finish());
 
         // Invalid range 128-193
-        for(auto it = std::next(buf.begin(), 128);
-            it != std::next(buf.begin(), 194); ++it)
-                BEAST_EXPECT(! utf8.write(&(*it), 1));
+        for(unsigned char c = 128; c < 194; ++c)
+            BEAST_EXPECT(! utf8.write(&c, 1));
 
         // Invalid range 245-255
-        for(auto it = std::next(buf.begin(), 245);
-            it != buf.end(); ++it)
-                BEAST_EXPECT(! utf8.write(&(*it), 1));
+        for(unsigned char c = 245; c; ++c)
+            BEAST_EXPECT(! utf8.write(&c, 1));
 
         // Invalid sequence
         std::fill(buf.begin(), buf.end(), '\xff');
@@ -79,6 +77,7 @@ public:
                 // Second byte invalid range 0-127
                 buf[1] = static_cast<std::uint8_t>(j);
                 BEAST_EXPECT(! utf8.write(buf, 2));
+                utf8.reset();
             }
 
             for(auto j = 192; j <= 255; ++j)
@@ -86,6 +85,7 @@ public:
                 // Second byte invalid range 192-255
                 buf[1] = static_cast<std::uint8_t>(j);
                 BEAST_EXPECT(! utf8.write(buf, 2));
+                utf8.reset();
             }
 
             // Segmented sequence second byte invalid
@@ -134,6 +134,7 @@ public:
                             // Second byte invalid range 0-127 or 0-159
                             buf[1] = static_cast<std::uint8_t>(l);
                             BEAST_EXPECT(! utf8.write(buf, 3));
+                            utf8.reset();
                             if (l > 127)
                             {
                                 // Segmented sequence second byte invalid
@@ -149,7 +150,8 @@ public:
                         {
                             // Second byte invalid range 160-255 or 192-255
                             buf[1] = static_cast<std::uint8_t>(l);
-                            BEAST_EXPECT(!utf8.write(buf, 3));
+                            BEAST_EXPECT(! utf8.write(buf, 3));
+                            utf8.reset();
                             if (l > 159)
                             {
                                 // Segmented sequence second byte invalid
@@ -166,6 +168,7 @@ public:
                     // Third byte invalid range 0-127
                     buf[2] = static_cast<std::uint8_t>(k);
                     BEAST_EXPECT(! utf8.write(buf, 3));
+                    utf8.reset();
                 }
 
                 for(auto k = 192; k <= 255; ++k)
@@ -173,6 +176,7 @@ public:
                     // Third byte invalid range 192-255
                     buf[2] = static_cast<std::uint8_t>(k);
                     BEAST_EXPECT(! utf8.write(buf, 3));
+                    utf8.reset();
                 }
 
                 // Segmented sequence third byte invalid
@@ -186,6 +190,7 @@ public:
                 // Second byte invalid range 0-127 or 0-159
                 buf[1] = static_cast<std::uint8_t>(j);
                 BEAST_EXPECT(! utf8.write(buf, 3));
+                utf8.reset();
             }
 
             for(auto j = e + 1; j <= 255; ++j)
@@ -193,6 +198,7 @@ public:
                 // Second byte invalid range 160-255 or 192-255
                 buf[1] = static_cast<std::uint8_t>(j);
                 BEAST_EXPECT(! utf8.write(buf, 3));
+                utf8.reset();
             }
 
             // Segmented sequence second byte invalid
@@ -251,6 +257,7 @@ public:
                             {
                                 buf[1] = static_cast<std::uint8_t>(r);
                                 BEAST_EXPECT(! utf8.write(buf, 4));
+                                utf8.reset();
                                 if (r > 127)
                                 {
                                     // Segmented sequence second byte invalid
@@ -267,6 +274,7 @@ public:
                             {
                                 buf[1] = static_cast<std::uint8_t>(r);
                                 BEAST_EXPECT(! utf8.write(buf, 4));
+                                utf8.reset();
                                 // Segmented sequence second byte invalid
                                 BEAST_EXPECT(! utf8.write(buf, 2));
                                 utf8.reset();
@@ -280,6 +288,7 @@ public:
                     {
                         buf[3] = static_cast<std::uint8_t>(r);
                         BEAST_EXPECT(! utf8.write(buf, 4));
+                        utf8.reset();
                     }
 
                     // Segmented sequence fourth byte invalid
@@ -293,6 +302,7 @@ public:
                 {
                     buf[2] = static_cast<std::uint8_t>(r);
                     BEAST_EXPECT(! utf8.write(buf, 4));
+                    utf8.reset();
                 }
 
                 // Segmented sequence third byte invalid
@@ -306,6 +316,7 @@ public:
             {
                 buf[1] = static_cast<std::uint8_t>(r);
                 BEAST_EXPECT(! utf8.write(buf, 4));
+                utf8.reset();
             }
 
             // Second byte invalid range 144-255 or 192-255
@@ -313,6 +324,7 @@ public:
             {
                 buf[1] = static_cast<std::uint8_t>(r);
                 BEAST_EXPECT(! utf8.write(buf, 4));
+                utf8.reset();
             }
 
             // Segmented sequence second byte invalid
@@ -326,6 +338,7 @@ public:
         {
             buf[0] = static_cast<std::uint8_t>(r);
             BEAST_EXPECT(! utf8.write(buf, 4));
+            utf8.reset();
         }
     }
 


### PR DESCRIPTION
* Dynamic buffer input areas are mutable
* Add flat_static_buffer::reset

WebSocket:

* websocket test improvements
* Remove obsolete write_op
* Refactor write_op
* Refactor ping_op
* Refactor fail_op
* Refactor read_op
* Refactor close_op
* Refactor read_op + fail_op
* Websocket close will automatically drain
* Autobahn|Testsuite fixes
* Tidy up utf8_checker and tests
