### PR TITLE
Add lowest_layer() to test::stream

### DIFF
--- a/test/extras/include/boost/beast/test/stream.hpp
+++ b/test/extras/include/boost/beast/test/stream.hpp
@@ -112,6 +112,8 @@ class stream
 
 public:
     using buffer_type = flat_buffer;
+    /// The type of the lowest layer.
+    using lowest_layer_type = stream;
 
     /// Destructor
     ~stream()
@@ -273,6 +275,34 @@ public:
     nwrite() const
     {
         return in_->nwrite;
+    }
+
+    /** Get a reference to the lowest layer
+
+        This function returns a reference to the lowest layer
+        in a stack of stream layers, with this being the lowest layer.
+
+        @return A reference to the lowest layer (*this).
+        Ownership is not transferred to the caller.
+    */
+    stream&
+    lowest_layer() 
+    {
+        return *this;
+    }
+
+    /** Get a reference to the lowest layer
+
+        This function returns a reference to the lowest layer
+        in a stack of stream layers, with this being the lowest layer.
+
+        @return A reference to the lowest layer (*this).
+        Ownership is not transferred to the caller.
+    */
+    const stream&
+    lowest_layer() const
+    {
+        return *this;
     }
 
     /** Close the stream.


### PR DESCRIPTION
This allows the stream to be used as the next layer type in a stack of network stream layers.

Signed-off-by: Damian Jarek <damian.jarek93@gmail.com>