### PR TITLE
Version 112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ API Changes:
 
 * WebSocket writes return the bytes transferred
 
+* HTTP reads and writes return bytes transferred
+
 Actions Required:
 
 * Modify websocket write completion handlers to receive
   the extra std::size_t bytes_transferred parameter.
+
+* Modify HTTP read and/or write completion handlers to
+  receive the extra std::size_t bytes_transferred parameter.
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Version 112:
 
+* Update websocket notes
+
 API Changes:
 
 * WebSocket writes return the bytes transferred

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+Version 112:
+
+API Changes:
+
+* WebSocket writes return the bytes transferred
+
+Actions Required:
+
+* Modify websocket write completion handlers to receive
+  the extra std::size_t bytes_transferred parameter.
+
+--------------------------------------------------------------------------------
+
 Version 111:
 
 WebSocket:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.5.2)
 
-project (Beast VERSION 111)
+project (Beast VERSION 112)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/doc/qbk/00_main.qbk
+++ b/doc/qbk/00_main.qbk
@@ -52,8 +52,10 @@
 [def __ConstBufferSequence__    [@http://www.boost.org/doc/html/boost_asio/reference/ConstBufferSequence.html [*ConstBufferSequence]]]
 [def __Handler__                [@http://www.boost.org/doc/html/boost_asio/reference/Handler.html [*Handler]]]
 [def __MutableBufferSequence__  [@http://www.boost.org/doc/html/boost_asio/reference/MutableBufferSequence.html [*MutableBufferSequence]]]
+[def __ReadHandler__            [@http://www.boost.org/doc/html/boost_asio/reference/ReadHandler.html [*ReadHandler]]]
 [def __SyncReadStream__         [@http://www.boost.org/doc/html/boost_asio/reference/SyncReadStream.html [*SyncReadStream]]]
 [def __SyncWriteStream__        [@http://www.boost.org/doc/html/boost_asio/reference/SyncWriteStream.html [*SyncWriteStream]]]
+[def __WriteHandler__           [@http://www.boost.org/doc/html/boost_asio/reference/WriteHandler.html [*WriteHandler]]]
 
 [def __async_initfn__           [@http://www.boost.org/doc/html/boost_asio/reference/asynchronous_operations.html initiating function]]
 

--- a/doc/qbk/04_http/03_streams.qbk
+++ b/doc/qbk/04_http/03_streams.qbk
@@ -72,8 +72,11 @@ Messages may also be read asynchronously. When performing asynchronous
 stream read operations the stream, buffer, and message variables must
 remain valid until the operation has completed. Beast asynchronous
 initiation functions use Asio's completion handler model. This call
-reads a message asynchronously and report the error code upon
-completion:
+reads a message asynchronously and reports the error code upon
+completion. The handler is called with the error, set to any that
+occurs, and the number of bytes parsed. This number may be used to
+measure the relative amount of work performed, or it may be ignored
+as this example shows.
 
 [http_snippet_5]
 
@@ -105,5 +108,10 @@ the number of octets received prior to the server closing the connection:
 The asynchronous version could be used instead:
 
 [http_snippet_8]
+
+The completion handler is called with the number of bytes written to the
+stream, which includes protocol specific data such as the delimiters in
+the header and line endings. The number may be used to measure the amount
+of data transferred, or it may be ignored as in the example.
 
 [endsect]

--- a/doc/qbk/06_websocket/8_notes.qbk
+++ b/doc/qbk/06_websocket/8_notes.qbk
@@ -45,13 +45,28 @@ Like a regular __Asio__ socket, a
 [link beast.ref.boost__beast__websocket__stream `stream`]
 is not thread safe. Callers are responsible for synchronizing operations on
 the socket using an implicit or explicit strand, as per the Asio documentation.
-The asynchronous interface supports one active read and one active write
-simultaneously. Undefined behavior results if two or more reads or two or
-more writes are attempted concurrently. Caller initiated WebSocket ping, pong,
-and close operations each count as an active write.
+The asynchronous interface supports one of each of the following operations
+to be active at the same time:
 
-The implementation uses composed asynchronous operations internally; a high
-level read can cause both reads and writes to take place on the underlying
-stream. This behavior is transparent to callers.
+* [link beast.ref.boost__beast__websocket__stream.async_read `async_read`] or [link beast.ref.boost__beast__websocket__stream.async_read_some `async_read_some`]
+* [link beast.ref.boost__beast__websocket__stream.async_write `async_write`] or [link beast.ref.boost__beast__websocket__stream.async_write_some `async_write_some`]
+* [link beast.ref.boost__beast__websocket__stream.async_ping `async_ping`] or [link beast.ref.boost__beast__websocket__stream.async_pong `async_pong`]
+* [link beast.ref.boost__beast__websocket__stream.async_close `async_close`]
+
+For example, the following code is malformed, because the program is
+attempting to perform two simultaneous reads:
+
+[ws_snippet_24]
+
+However, this code is well-formed:
+
+[ws_snippet_25]
+
+The implementation uses composed asynchronous operations internally;
+although some individiual operations can perform both reads and writes,
+this behavior is coordinated internally to make sure the underlying stream
+is operated in a safe fashion. This allows an asynchronous read operation
+to respond to a received ping frame even while a user-initiated call to
+asynchronous write is active.
 
 [endsect]

--- a/doc/xsl/class_detail.xsl
+++ b/doc/xsl/class_detail.xsl
@@ -36,6 +36,9 @@
     <xsl:when test="declname = 'MutableBufferSequence' or type = 'class MutableBufferSequence'">
       <xsl:text>class __MutableBufferSequence__</xsl:text>
     </xsl:when>
+    <xsl:when test="declname = 'ReadHandler' or type = 'class ReadHandler'">
+      <xsl:text>class __ReadHandler__</xsl:text>
+    </xsl:when>
     <xsl:when test="declname = 'Stream' or type = 'class Stream'">
       <xsl:text>class ``[link beast.concepts.streams.Stream [*Stream]]``</xsl:text>
     </xsl:when>
@@ -47,5 +50,8 @@
     </xsl:when>
     <xsl:when test="declname = 'SyncWriteStream' or type = 'class SyncWriteStream'">
       <xsl:text>class __SyncWriteStream__</xsl:text>
+    </xsl:when>
+    <xsl:when test="declname = 'WriteHandler' or type = 'class WriteHandler'">
+      <xsl:text>class __WriteHandler__</xsl:text>
     </xsl:when>
 <!-- CLASS_DETAIL_TEMPLATE END -->

--- a/example/advanced/server-flex/advanced_server_flex.cpp
+++ b/example/advanced/server-flex/advanced_server_flex.cpp
@@ -310,12 +310,17 @@ public:
             strand_.wrap(std::bind(
                 &websocket_session::on_read,
                 derived().shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1,
+                std::placeholders::_2)));
     }
 
     void
-    on_read(boost::system::error_code ec)
+    on_read(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         // Happens when the timer closes the socket
         if(ec == boost::asio::error::operation_aborted)
             return;
@@ -334,12 +339,17 @@ public:
             strand_.wrap(std::bind(
                 &websocket_session::on_write,
                 derived().shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1,
+                std::placeholders::_2)));
     }
 
     void
-    on_write(boost::system::error_code ec)
+    on_write(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         // Happens when the timer closes the socket
         if(ec == boost::asio::error::operation_aborted)
             return;

--- a/example/advanced/server/advanced_server.cpp
+++ b/example/advanced/server/advanced_server.cpp
@@ -301,12 +301,17 @@ public:
             strand_.wrap(std::bind(
                 &websocket_session::on_read,
                 shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1,
+                std::placeholders::_2)));
     }
 
     void
-    on_read(boost::system::error_code ec)
+    on_read(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         // Happens when the timer closes the socket
         if(ec == boost::asio::error::operation_aborted)
             return;
@@ -325,12 +330,17 @@ public:
             strand_.wrap(std::bind(
                 &websocket_session::on_write,
                 shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1,
+                std::placeholders::_2)));
     }
 
     void
-    on_write(boost::system::error_code ec)
+    on_write(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         // Happens when the timer closes the socket
         if(ec == boost::asio::error::operation_aborted)
             return;

--- a/example/http/client/async-ssl/http_client_async_ssl.cpp
+++ b/example/http/client/async-ssl/http_client_async_ssl.cpp
@@ -125,12 +125,17 @@ public:
             std::bind(
                 &session::on_write,
                 shared_from_this(),
-                std::placeholders::_1));
+                std::placeholders::_1,
+                std::placeholders::_2));
     }
 
     void
-    on_write(boost::system::error_code ec)
+    on_write(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec)
             return fail(ec, "write");
         
@@ -139,12 +144,17 @@ public:
             std::bind(
                 &session::on_read,
                 shared_from_this(),
-                std::placeholders::_1));
+                std::placeholders::_1,
+                std::placeholders::_2));
     }
 
     void
-    on_read(boost::system::error_code ec)
+    on_read(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec)
             return fail(ec, "read");
 

--- a/example/http/client/async/http_client_async.cpp
+++ b/example/http/client/async/http_client_async.cpp
@@ -104,12 +104,17 @@ public:
             std::bind(
                 &session::on_write,
                 shared_from_this(),
-                std::placeholders::_1));
+                std::placeholders::_1,
+                std::placeholders::_2));
     }
 
     void
-    on_write(boost::system::error_code ec)
+    on_write(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec)
             return fail(ec, "write");
         
@@ -118,12 +123,17 @@ public:
             std::bind(
                 &session::on_read,
                 shared_from_this(),
-                std::placeholders::_1));
+                std::placeholders::_1,
+                std::placeholders::_2));
     }
 
     void
-    on_read(boost::system::error_code ec)
+    on_read(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec)
             return fail(ec, "read");
 

--- a/example/http/client/crawl/http_crawl.cpp
+++ b/example/http/client/crawl/http_crawl.cpp
@@ -297,12 +297,17 @@ public:
             strand_.wrap(std::bind(
                 &worker::on_write,
                 shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1,
+                std::placeholders::_2)));
     }
 
     void
-    on_write(boost::system::error_code ec)
+    on_write(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec)
         {
             report_.aggregate(
@@ -324,12 +329,17 @@ public:
             strand_.wrap(std::bind(
                 &worker::on_read,
                 shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1,
+                std::placeholders::_2)));
     }
 
     void
-    on_read(boost::system::error_code ec)
+    on_read(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec)
         {
             report_.aggregate(

--- a/example/http/server/async-ssl/http_server_async_ssl.cpp
+++ b/example/http/server/async-ssl/http_server_async_ssl.cpp
@@ -247,7 +247,8 @@ class session : public std::enable_shared_from_this<session>
                 self_.strand_.wrap(std::bind(
                     &session::on_write,
                     self_.shared_from_this(),
-                    std::placeholders::_1)));
+                    std::placeholders::_1,
+                    std::placeholders::_2)));
         }
     };
 
@@ -305,12 +306,17 @@ public:
             strand_.wrap(std::bind(
                 &session::on_read,
                 shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1,
+                std::placeholders::_2)));
     }
 
     void
-    on_read(boost::system::error_code ec)
+    on_read(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         // This means they closed the connection
         if(ec == http::error::end_of_stream)
             return do_close();
@@ -323,8 +329,12 @@ public:
     }
 
     void
-    on_write(boost::system::error_code ec)
+    on_write(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec == http::error::end_of_stream)
         {
             // This means we should close the connection, usually because

--- a/example/http/server/async/http_server_async.cpp
+++ b/example/http/server/async/http_server_async.cpp
@@ -243,7 +243,8 @@ class session : public std::enable_shared_from_this<session>
                 self_.strand_.wrap(std::bind(
                     &session::on_write,
                     self_.shared_from_this(),
-                    std::placeholders::_1)));
+                    std::placeholders::_1,
+                    std::placeholders::_2)));
         }
     };
 
@@ -283,12 +284,17 @@ public:
             strand_.wrap(std::bind(
                 &session::on_read,
                 shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1,
+                std::placeholders::_2)));
     }
 
     void
-    on_read(boost::system::error_code ec)
+    on_read(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         // This means they closed the connection
         if(ec == http::error::end_of_stream)
             return do_close();
@@ -301,8 +307,12 @@ public:
     }
 
     void
-    on_write(boost::system::error_code ec)
+    on_write(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec == http::error::end_of_stream)
         {
             // This means we should close the connection, usually because

--- a/example/http/server/fast/http_server_fast.cpp
+++ b/example/http/server/fast/http_server_fast.cpp
@@ -172,7 +172,7 @@ private:
             socket_,
             buffer_,
             *parser_,
-            [this](boost::beast::error_code ec)
+            [this](boost::beast::error_code ec, std::size_t)
             {
                 if (ec)
                     accept();
@@ -220,7 +220,7 @@ private:
         http::async_write(
             socket_,
             *string_serializer_,
-            [this](boost::beast::error_code ec)
+            [this](boost::beast::error_code ec, std::size_t)
             {
                 socket_.shutdown(tcp::socket::shutdown_send, ec);
                 string_serializer_.reset();
@@ -276,7 +276,7 @@ private:
         http::async_write(
             socket_,
             *file_serializer_,
-            [this](boost::beast::error_code ec)
+            [this](boost::beast::error_code ec, std::size_t)
             {
                 socket_.shutdown(tcp::socket::shutdown_send, ec);
                 file_serializer_.reset();

--- a/example/http/server/flex/http_server_flex.cpp
+++ b/example/http/server/flex/http_server_flex.cpp
@@ -258,7 +258,8 @@ class session
                 self_.strand_.wrap(std::bind(
                     &session::on_write,
                     self_.derived().shared_from_this(),
-                    std::placeholders::_1)));
+                    std::placeholders::_1,
+                    std::placeholders::_2)));
         }
     };
 
@@ -296,12 +297,17 @@ public:
             strand_.wrap(std::bind(
                 &session::on_read,
                 derived().shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1,
+                std::placeholders::_2)));
     }
 
     void
-    on_read(boost::system::error_code ec)
+    on_read(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         // This means they closed the connection
         if(ec == http::error::end_of_stream)
             return derived().do_eof();
@@ -314,8 +320,12 @@ public:
     }
 
     void
-    on_write(boost::system::error_code ec)
+    on_write(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec == http::error::end_of_stream)
         {
             // This means we should close the connection, usually because

--- a/example/http/server/small/http_server_small.cpp
+++ b/example/http/server/small/http_server_small.cpp
@@ -87,8 +87,10 @@ private:
             socket_,
             buffer_,
             request_,
-            [self](boost::beast::error_code ec)
+            [self](boost::beast::error_code ec,
+                std::size_t bytes_transferred)
             {
+                boost::ignore_unused(bytes_transferred);
                 if(!ec)
                     self->process_request();
             });
@@ -175,7 +177,7 @@ private:
         http::async_write(
             socket_,
             response_,
-            [self](boost::beast::error_code ec)
+            [self](boost::beast::error_code ec, std::size_t)
             {
                 self->socket_.shutdown(tcp::socket::shutdown_send, ec);
                 self->deadline_.cancel();

--- a/example/http/server/stackless-ssl/http_server_stackless_ssl.cpp
+++ b/example/http/server/stackless-ssl/http_server_stackless_ssl.cpp
@@ -250,7 +250,8 @@ class session
                 self_.strand_.wrap(std::bind(
                     &session::loop,
                     self_.shared_from_this(),
-                    std::placeholders::_1)));
+                    std::placeholders::_1,
+                    std::placeholders::_2)));
         }
     };
 
@@ -282,13 +283,16 @@ public:
     void
     run()
     {
-        loop();
+        loop({}, 0);
     }
 
 #include <boost/asio/yield.hpp>
     void
-    loop(boost::system::error_code ec = {})
+    loop(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
         reenter(*this)
         {
             // Perform the SSL handshake
@@ -297,7 +301,8 @@ public:
                 strand_.wrap(std::bind(
                     &session::loop,
                     shared_from_this(),
-                    std::placeholders::_1)));
+                    std::placeholders::_1,
+                    0)));
             if(ec)
                 return fail(ec, "handshake");
 
@@ -308,7 +313,8 @@ public:
                     strand_.wrap(std::bind(
                         &session::loop,
                         shared_from_this(),
-                        std::placeholders::_1)));
+                        std::placeholders::_1,
+                        std::placeholders::_2)));
                 if(ec == http::error::end_of_stream)
                 {
                     // The remote host closed the connection
@@ -337,7 +343,8 @@ public:
                 strand_.wrap(std::bind(
                     &session::loop,
                     shared_from_this(),
-                    std::placeholders::_1)));
+                    std::placeholders::_1,
+                    0)));
             if(ec)
                 return fail(ec, "shutdown");
 

--- a/example/http/server/stackless/http_server_stackless.cpp
+++ b/example/http/server/stackless/http_server_stackless.cpp
@@ -247,7 +247,8 @@ class session
                 self_.strand_.wrap(std::bind(
                     &session::loop,
                     self_.shared_from_this(),
-                    std::placeholders::_1)));
+                    std::placeholders::_1,
+                    std::placeholders::_2)));
         }
     };
 
@@ -276,13 +277,16 @@ public:
     void
     run()
     {
-        loop();
+        loop({}, 0);
     }
 
 #include <boost/asio/yield.hpp>
     void
-    loop(boost::system::error_code ec = {})
+    loop(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
         reenter(*this)
         {
             for(;;)
@@ -292,7 +296,8 @@ public:
                     strand_.wrap(std::bind(
                         &session::loop,
                         shared_from_this(),
-                        std::placeholders::_1)));
+                        std::placeholders::_1,
+                        std::placeholders::_2)));
                 if(ec == http::error::end_of_stream)
                 {
                     // The remote host closed the connection

--- a/example/websocket/client/async-ssl/websocket_client_async_ssl.cpp
+++ b/example/websocket/client/async-ssl/websocket_client_async_ssl.cpp
@@ -137,12 +137,17 @@ public:
             std::bind(
                 &session::on_write,
                 shared_from_this(),
-                std::placeholders::_1));
+                std::placeholders::_1,
+                std::placeholders::_2));
     }
 
     void
-    on_write(boost::system::error_code ec)
+    on_write(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec)
             return fail(ec, "write");
         
@@ -152,12 +157,17 @@ public:
             std::bind(
                 &session::on_read,
                 shared_from_this(),
-                std::placeholders::_1));
+                std::placeholders::_1,
+                std::placeholders::_2));
     }
 
     void
-    on_read(boost::system::error_code ec)
+    on_read(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec)
             return fail(ec, "read");
 

--- a/example/websocket/client/async/websocket_client_async.cpp
+++ b/example/websocket/client/async/websocket_client_async.cpp
@@ -117,12 +117,17 @@ public:
             std::bind(
                 &session::on_write,
                 shared_from_this(),
-                std::placeholders::_1));
+                std::placeholders::_1,
+                std::placeholders::_2));
     }
 
     void
-    on_write(boost::system::error_code ec)
+    on_write(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec)
             return fail(ec, "write");
         
@@ -132,12 +137,17 @@ public:
             std::bind(
                 &session::on_read,
                 shared_from_this(),
-                std::placeholders::_1));
+                std::placeholders::_1,
+                std::placeholders::_2));
     }
 
     void
-    on_read(boost::system::error_code ec)
+    on_read(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec)
             return fail(ec, "read");
 

--- a/example/websocket/server/async-ssl/websocket_server_async_ssl.cpp
+++ b/example/websocket/server/async-ssl/websocket_server_async_ssl.cpp
@@ -106,12 +106,17 @@ public:
             strand_.wrap(std::bind(
                 &session::on_read,
                 shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1,
+                std::placeholders::_2)));
     }
 
     void
-    on_read(boost::system::error_code ec)
+    on_read(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         // This indicates that the session was closed
         if(ec == websocket::error::closed)
             return;
@@ -126,12 +131,17 @@ public:
             strand_.wrap(std::bind(
                 &session::on_write,
                 shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1,
+                std::placeholders::_2)));
     }
 
     void
-    on_write(boost::system::error_code ec)
+    on_write(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec)
             return fail(ec, "write");
 

--- a/example/websocket/server/async/websocket_server_async.cpp
+++ b/example/websocket/server/async/websocket_server_async.cpp
@@ -85,12 +85,17 @@ public:
             strand_.wrap(std::bind(
                 &session::on_read,
                 shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1,
+                std::placeholders::_2)));
     }
 
     void
-    on_read(boost::system::error_code ec)
+    on_read(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         // This indicates that the session was closed
         if(ec == websocket::error::closed)
             return;
@@ -105,12 +110,17 @@ public:
             strand_.wrap(std::bind(
                 &session::on_write,
                 shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1,
+                std::placeholders::_2)));
     }
 
     void
-    on_write(boost::system::error_code ec)
+    on_write(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec)
             return fail(ec, "write");
 

--- a/example/websocket/server/fast/websocket_server_fast.cpp
+++ b/example/websocket/server/fast/websocket_server_fast.cpp
@@ -187,12 +187,17 @@ public:
             strand_.wrap(std::bind(
                 &async_session::on_read,
                 shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1,
+                std::placeholders::_2)));
     }
 
     void
-    on_read(boost::system::error_code ec)
+    on_read(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         // This indicates that the async_session was closed
         if(ec == websocket::error::closed)
             return;
@@ -207,12 +212,17 @@ public:
             strand_.wrap(std::bind(
                 &async_session::on_write,
                 shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1,
+                std::placeholders::_2)));
     }
 
     void
-    on_write(boost::system::error_code ec)
+    on_write(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         if(ec)
             return fail(ec, "write");
 

--- a/example/websocket/server/stackless-ssl/websocket_server_stackless_ssl.cpp
+++ b/example/websocket/server/stackless-ssl/websocket_server_stackless_ssl.cpp
@@ -67,13 +67,17 @@ public:
     void
     run()
     {
-        loop();
+        loop({}, 0);
     }
 
 #include <boost/asio/yield.hpp>
     void
-    loop(boost::system::error_code ec = {})
+    loop(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
+
         reenter(*this)
         {
             // Perform the SSL handshake
@@ -82,7 +86,8 @@ public:
                 strand_.wrap(std::bind(
                     &session::loop,
                     shared_from_this(),
-                    std::placeholders::_1)));
+                    std::placeholders::_1,
+                    0)));
             if(ec)
                 return fail(ec, "handshake");
 
@@ -91,7 +96,8 @@ public:
                 strand_.wrap(std::bind(
                     &session::loop,
                     shared_from_this(),
-                    std::placeholders::_1)));
+                    std::placeholders::_1,
+                    0)));
             if(ec)
                 return fail(ec, "accept");
 
@@ -103,7 +109,8 @@ public:
                     strand_.wrap(std::bind(
                         &session::loop,
                         shared_from_this(),
-                        std::placeholders::_1)));
+                        std::placeholders::_1,
+                        std::placeholders::_2)));
                 if(ec == websocket::error::closed)
                 {
                     // This indicates that the session was closed
@@ -119,7 +126,8 @@ public:
                     strand_.wrap(std::bind(
                         &session::loop,
                         shared_from_this(),
-                        std::placeholders::_1)));
+                        std::placeholders::_1,
+                        std::placeholders::_2)));
                 if(ec)
                     return fail(ec, "write");
 

--- a/example/websocket/server/stackless/websocket_server_stackless.cpp
+++ b/example/websocket/server/stackless/websocket_server_stackless.cpp
@@ -61,13 +61,16 @@ public:
     void
     run()
     {
-        loop();
+        loop({}, 0);
     }
 
 #include <boost/asio/yield.hpp>
     void
-    loop(boost::system::error_code ec = {})
+    loop(
+        boost::system::error_code ec,
+        std::size_t bytes_transferred)
     {
+        boost::ignore_unused(bytes_transferred);
         reenter(*this)
         {
             // Accept the websocket handshake
@@ -75,7 +78,8 @@ public:
                 strand_.wrap(std::bind(
                     &session::loop,
                     shared_from_this(),
-                    std::placeholders::_1)));
+                    std::placeholders::_1,
+                    0)));
             if(ec)
                 return fail(ec, "accept");
 
@@ -87,7 +91,8 @@ public:
                     strand_.wrap(std::bind(
                         &session::loop,
                         shared_from_this(),
-                        std::placeholders::_1)));
+                        std::placeholders::_1,
+                        std::placeholders::_2)));
                 if(ec == websocket::error::closed)
                 {
                     // This indicates that the session was closed
@@ -103,7 +108,8 @@ public:
                     strand_.wrap(std::bind(
                         &session::loop,
                         shared_from_this(),
-                        std::placeholders::_1)));
+                        std::placeholders::_1,
+                        std::placeholders::_2)));
                 if(ec)
                     return fail(ec, "write");
 

--- a/include/boost/beast/http/read.hpp
+++ b/include/boost/beast/http/read.hpp
@@ -59,7 +59,7 @@ namespace http {
 
     @param parser The parser to use.
 
-    @return The number of bytes consumed by the parser.
+    @return The number of bytes transferred to the parser.
 
     @throws system_error Thrown on failure.
 */
@@ -118,7 +118,7 @@ read_some(
 
     @param ec Set to the error, if any occurred.
 
-    @return The number of bytes consumed by the parser.
+    @return The number of bytes transferred to the parser.
 */
 template<
     class SyncReadStream,
@@ -179,8 +179,8 @@ read_some(
     completes. Copies will be made of the handler as required.
     The equivalent function signature of the handler must be:
     @code void handler(
-        error_code const& error,    // result of operation
-        std::size_t bytes_used      // the number of bytes consumed by the parser
+        error_code const& error,        // result of operation
+        std::size_t bytes_transferred   // the number of bytes transferred to the parser
     ); @endcode
     Regardless of whether the asynchronous operation completes
     immediately or not, the handler will not be invoked from within
@@ -249,6 +249,8 @@ async_read_some(
 
     @param parser The parser to use.
 
+    @return The number of bytes transferred to the parser.
+
     @throws system_error Thrown on failure.
 
     @note The implementation will call @ref basic_parser::eager
@@ -258,7 +260,7 @@ template<
     class SyncReadStream,
     class DynamicBuffer,
     bool isRequest, class Derived>
-void
+std::size_t
 read_header(
     SyncReadStream& stream,
     DynamicBuffer& buffer,
@@ -304,6 +306,8 @@ read_header(
 
     @param ec Set to the error, if any occurred.
 
+    @return The number of bytes transferred to the parser.
+
     @note The implementation will call @ref basic_parser::eager
     with the value `false` on the parser passed in.
 */
@@ -311,7 +315,7 @@ template<
     class SyncReadStream,
     class DynamicBuffer,
     bool isRequest, class Derived>
-void
+std::size_t
 read_header(
     SyncReadStream& stream,
     DynamicBuffer& buffer,
@@ -365,7 +369,8 @@ read_header(
     completes. Copies will be made of the handler as required.
     The equivalent function signature of the handler must be:
     @code void handler(
-        error_code const& error // result of operation
+        error_code const& error,        // result of operation,
+        std::size_t bytes_transferred   // the number of bytes transferred to the parser
     ); @endcode
     Regardless of whether the asynchronous operation completes
     immediately or not, the handler will not be invoked from within
@@ -384,7 +389,7 @@ template<
     void_or_deduced
 #else
 async_return_type<
-    ReadHandler, void(error_code)>
+    ReadHandler, void(error_code, std::size_t)>
 #endif
 async_read_header(
     AsyncReadStream& stream,
@@ -432,6 +437,8 @@ async_read_header(
 
     @param parser The parser to use.
 
+    @return The number of bytes transferred to the parser.
+
     @throws system_error Thrown on failure.
 
     @note The implementation will call @ref basic_parser::eager
@@ -441,7 +448,7 @@ template<
     class SyncReadStream,
     class DynamicBuffer,
     bool isRequest, class Derived>
-void
+std::size_t
 read(
     SyncReadStream& stream,
     DynamicBuffer& buffer,
@@ -487,6 +494,8 @@ read(
 
     @param ec Set to the error, if any occurred.
 
+    @return The number of bytes transferred to the parser.
+
     @note The implementation will call @ref basic_parser::eager
     with the value `true` on the parser passed in.
 */
@@ -494,7 +503,7 @@ template<
     class SyncReadStream,
     class DynamicBuffer,
     bool isRequest, class Derived>
-void
+std::size_t
 read(
     SyncReadStream& stream,
     DynamicBuffer& buffer,
@@ -548,7 +557,8 @@ read(
     completes. Copies will be made of the handler as required.
     The equivalent function signature of the handler must be:
     @code void handler(
-        error_code const& error // result of operation
+        error_code const& error,        // result of operation,
+        std::size_t bytes_transferred   // the number of bytes transferred to the parser
     ); @endcode
     Regardless of whether the asynchronous operation completes
     immediately or not, the handler will not be invoked from within
@@ -567,7 +577,8 @@ template<
     void_or_deduced
 #else
 async_return_type<
-    ReadHandler, void(error_code)>
+    ReadHandler,
+    void(error_code, std::size_t)>
 #endif
 async_read(
     AsyncReadStream& stream,
@@ -617,13 +628,15 @@ async_read(
     the behavior is undefined.
     The type must be @b MoveAssignable and @b MoveConstructible.
 
+    @return The number of bytes transferred to the parser.
+
     @throws system_error Thrown on failure.
 */
 template<
     class SyncReadStream,
     class DynamicBuffer,
     bool isRequest, class Body, class Allocator>
-void
+std::size_t
 read(
     SyncReadStream& stream,
     DynamicBuffer& buffer,
@@ -670,12 +683,14 @@ read(
     The type must be @b MoveAssignable and @b MoveConstructible.
 
     @param ec Set to the error, if any occurred.
+
+    @return The number of bytes transferred to the parser.
 */
 template<
     class SyncReadStream,
     class DynamicBuffer,
     bool isRequest, class Body, class Allocator>
-void
+std::size_t
 read(
     SyncReadStream& stream,
     DynamicBuffer& buffer,
@@ -733,7 +748,8 @@ read(
     completes. Copies will be made of the handler as required.
     The equivalent function signature of the handler must be:
     @code void handler(
-        error_code const& error // result of operation
+        error_code const& error,        // result of operation,
+        std::size_t bytes_transferred   // the number of bytes transferred to the parser
     ); @endcode
     Regardless of whether the asynchronous operation completes
     immediately or not, the handler will not be invoked from within
@@ -749,7 +765,8 @@ template<
     void_or_deduced
 #else
 async_return_type<
-    ReadHandler, void(error_code)>
+    ReadHandler,
+    void(error_code, std::size_t)>
 #endif
 async_read(
     AsyncReadStream& stream,

--- a/include/boost/beast/http/write.hpp
+++ b/include/boost/beast/http/write.hpp
@@ -58,6 +58,8 @@ namespace http {
 
     @param sr The serializer to use.
 
+    @return The number of bytes written to the stream.
+
     @throws system_error Thrown on failure.
 
     @see serializer
@@ -65,7 +67,7 @@ namespace http {
 template<
     class SyncWriteStream,
     bool isRequest, class Body, class Fields>
-void
+std::size_t
 write_some(
     SyncWriteStream& stream,
     serializer<isRequest, Body, Fields>& sr);
@@ -100,12 +102,14 @@ write_some(
 
     @param ec Set to indicate what error occurred, if any.
 
+    @return The number of bytes written to the stream.
+
     @see @ref async_write_some, @ref serializer
 */
 template<
     class SyncWriteStream,
     bool isRequest, class Body, class Fields>
-void
+std::size_t
 write_some(
     SyncWriteStream& stream,
     serializer<isRequest, Body, Fields>& sr,
@@ -148,7 +152,8 @@ write_some(
     completes. Copies will be made of the handler as required.
     The equivalent function signature of the handler must be:
     @code void handler(
-        error_code const& error // result of operation
+        error_code const& error,        // result of operation
+        std::size_t bytes_transferred   // the number of bytes written to the stream
     ); @endcode
     Regardless of whether the asynchronous operation completes
     immediately or not, the handler will not be invoked from within
@@ -164,7 +169,9 @@ template<
 #if BOOST_BEAST_DOXYGEN
     void_or_deduced
 #else
-async_return_type<WriteHandler, void(error_code)>
+async_return_type<
+    WriteHandler,
+    void(error_code, std::size_t)>
 #endif
 async_write_some(
     AsyncWriteStream& stream,
@@ -191,6 +198,8 @@ async_write_some(
 
     @param sr The serializer to use.
 
+    @return The number of bytes written to the stream.
+
     @throws system_error Thrown on failure.
 
     @note The implementation will call @ref serializer::split with
@@ -201,7 +210,7 @@ async_write_some(
 template<
     class SyncWriteStream,
     bool isRequest, class Body, class Fields>
-void
+std::size_t
 write_header(
     SyncWriteStream& stream,
     serializer<isRequest, Body, Fields>& sr);
@@ -226,6 +235,8 @@ write_header(
 
     @param ec Set to indicate what error occurred, if any.
 
+    @return The number of bytes written to the stream.
+
     @note The implementation will call @ref serializer::split with
     the value `true` on the serializer passed in.
 
@@ -234,7 +245,7 @@ write_header(
 template<
     class SyncWriteStream,
     bool isRequest, class Body, class Fields>
-void
+std::size_t
 write_header(
     SyncWriteStream& stream,
     serializer<isRequest, Body, Fields>& sr,
@@ -267,7 +278,8 @@ write_header(
     completes. Copies will be made of the handler as required.
     The equivalent function signature of the handler must be:
     @code void handler(
-        error_code const& error // result of operation
+        error_code const& error,        // result of operation
+        std::size_t bytes_transferred   // the number of bytes written to the stream
     ); @endcode
     Regardless of whether the asynchronous operation completes
     immediately or not, the handler will not be invoked from within
@@ -286,7 +298,9 @@ template<
 #if BOOST_BEAST_DOXYGEN
     void_or_deduced
 #else
-async_return_type<WriteHandler, void(error_code)>
+async_return_type<
+    WriteHandler,
+    void(error_code, std::size_t)>
 #endif
 async_write_header(
     AsyncWriteStream& stream,
@@ -313,6 +327,8 @@ async_write_header(
 
     @param sr The serializer to use.
 
+    @return The number of bytes written to the stream.
+
     @throws system_error Thrown on failure.
 
     @see @ref serializer
@@ -320,7 +336,7 @@ async_write_header(
 template<
     class SyncWriteStream,
     bool isRequest, class Body, class Fields>
-void
+std::size_t
 write(
     SyncWriteStream& stream,
     serializer<isRequest, Body, Fields>& sr);
@@ -345,12 +361,14 @@ write(
 
     @param ec Set to the error, if any occurred.
 
+    @return The number of bytes written to the stream.
+
     @see @ref serializer
 */
 template<
     class SyncWriteStream,
     bool isRequest, class Body, class Fields>
-void
+std::size_t
 write(
     SyncWriteStream& stream,
     serializer<isRequest, Body, Fields>& sr,
@@ -383,7 +401,8 @@ write(
     completes. Copies will be made of the handler as required.
     The equivalent function signature of the handler must be:
     @code void handler(
-        error_code const& error // result of operation
+        error_code const& error,        // result of operation
+        std::size_t bytes_transferred   // the number of bytes written to the stream
     ); @endcode
     Regardless of whether the asynchronous operation completes
     immediately or not, the handler will not be invoked from within
@@ -399,7 +418,9 @@ template<
 #if BOOST_BEAST_DOXYGEN
     void_or_deduced
 #else
-async_return_type<WriteHandler, void(error_code)>
+async_return_type<
+    WriteHandler,
+    void(error_code, std::size_t)>
 #endif
 async_write(
     AsyncWriteStream& stream,
@@ -428,6 +449,8 @@ async_write(
 
     @param msg The message to write.
 
+    @return The number of bytes written to the stream.
+
     @throws system_error Thrown on failure.
 
     @see @ref message
@@ -435,7 +458,7 @@ async_write(
 template<
     class SyncWriteStream,
     bool isRequest, class Body, class Fields>
-void
+std::size_t
 write(
     SyncWriteStream& stream,
     message<isRequest, Body, Fields> const& msg);
@@ -462,12 +485,14 @@ write(
 
     @param ec Set to the error, if any occurred.
 
+    @return The number of bytes written to the stream.
+
     @see @ref message
 */
 template<
     class SyncWriteStream,
     bool isRequest, class Body, class Fields>
-void
+std::size_t
 write(
     SyncWriteStream& stream,
     message<isRequest, Body, Fields> const& msg,
@@ -503,7 +528,8 @@ write(
     completes. Copies will be made of the handler as required.
     The equivalent function signature of the handler must be:
     @code void handler(
-        error_code const& error // result of operation
+        error_code const& error,        // result of operation
+        std::size_t bytes_transferred   // the number of bytes written to the stream
     ); @endcode
     Regardless of whether the asynchronous operation completes
     immediately or not, the handler will not be invoked from within
@@ -516,7 +542,9 @@ template<
     class AsyncWriteStream,
     bool isRequest, class Body, class Fields,
     class WriteHandler>
-async_return_type<WriteHandler, void(error_code)>
+async_return_type<
+    WriteHandler,
+    void(error_code, std::size_t)>
 async_write(
     AsyncWriteStream& stream,
     message<isRequest, Body, Fields>& msg,

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 111
+#define BOOST_BEAST_VERSION 112
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/detail/pmd_extension.hpp
+++ b/include/boost/beast/websocket/detail/pmd_extension.hpp
@@ -367,6 +367,7 @@ deflate(
     boost::asio::mutable_buffer& out,
     consuming_buffers<ConstBufferSequence>& cb,
     bool fin,
+    std::size_t& total_in,
     error_code& ec)
 {
     using boost::asio::buffer;
@@ -401,6 +402,7 @@ deflate(
         }
         BOOST_ASSERT(zs.avail_in == 0);
     }
+    total_in = zs.total_in;
     cb.consume(zs.total_in);
     if(zs.avail_out > 0 && fin)
     {

--- a/include/boost/beast/websocket/impl/accept.ipp
+++ b/include/boost/beast/websocket/impl/accept.ipp
@@ -67,7 +67,9 @@ public:
     {
     }
 
-    void operator()(error_code ec = {});
+    void operator()(
+        error_code ec = {},
+        std::size_t bytes_transferred = 0);
 
     friend
     void* asio_handler_allocate(
@@ -110,7 +112,9 @@ template<class Handler>
 void
 stream<NextLayer>::
 response_op<Handler>::
-operator()(error_code ec)
+operator()(
+    error_code ec,
+    std::size_t)
 {
     auto& d = *d_;
     BOOST_ASIO_CORO_REENTER(*this)
@@ -170,7 +174,9 @@ public:
     template<class Buffers>
     void run(Buffers const& buffers);
 
-    void operator()(error_code ec = {});
+    void operator()(
+        error_code ec = {},
+        std::size_t bytes_used = 0);
 
     friend
     void* asio_handler_allocate(
@@ -242,7 +248,7 @@ template<class Decorator, class Handler>
 void
 stream<NextLayer>::
 accept_op<Decorator, Handler>::
-operator()(error_code ec)
+operator()(error_code ec, std::size_t)
 {
     auto& d = *d_;
     BOOST_ASIO_CORO_REENTER(*this)

--- a/include/boost/beast/websocket/impl/handshake.ipp
+++ b/include/boost/beast/websocket/impl/handshake.ipp
@@ -76,7 +76,9 @@ public:
     }
 
     void
-    operator()(error_code ec = {});
+    operator()(
+        error_code ec = {},
+        std::size_t bytes_used = 0);
 
     friend
     void* asio_handler_allocate(
@@ -118,7 +120,7 @@ template<class NextLayer>
 template<class Handler>
 void
 stream<NextLayer>::handshake_op<Handler>::
-operator()(error_code ec)
+operator()(error_code ec, std::size_t)
 {
     auto& d = *d_;
     BOOST_ASIO_CORO_REENTER(*this)

--- a/test/beast/http/read.cpp
+++ b/test/beast/http/read.cpp
@@ -329,7 +329,7 @@ public:
         handler() { ++count(); }
         ~handler() { --count(); }
         handler(handler const&) { ++count(); }
-        void operator()(error_code const&) const {}
+        void operator()(error_code const&, std::size_t) const {}
     };
 
     void

--- a/test/beast/http/write.cpp
+++ b/test/beast/http/write.cpp
@@ -614,7 +614,7 @@ public:
         handler() { ++count(); }
         ~handler() { --count(); }
         handler(handler const&) { ++count(); }
-        void operator()(error_code const&) const {}
+        void operator()(error_code const&, std::size_t) const {}
     };
 
     void
@@ -830,7 +830,7 @@ public:
         res.chunked(true);
         response_serializer<empty_body> sr{res};
         async_write_header(ts, sr,
-            [&](const error_code&)
+            [&](error_code const&, std::size_t)
             {
             });
         ios.run();

--- a/test/beast/websocket/close.cpp
+++ b/test/beast/websocket/close.cpp
@@ -212,12 +212,13 @@ public:
             ws.handshake("localhost", "/");
             std::size_t count = 0;
             ws.async_write(sbuf("*"),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t n)
                 {
                     ++count;
                     if(ec)
                         BOOST_THROW_EXCEPTION(
                             system_error{ec});
+                    BEAST_EXPECT(n == 1);
                 });
             BEAST_EXPECT(ws.wr_block_);
             BEAST_EXPECT(count == 0);
@@ -371,11 +372,12 @@ public:
             std::size_t count = 0;
             std::string const s = "Hello, world!";
             ws.async_write(buffer(s),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t n)
                 {
                     if(ec)
                         BOOST_THROW_EXCEPTION(
                             system_error{ec});
+                    BEAST_EXPECT(n == s.size());
                     BEAST_EXPECT(++count == 1);
                 });
             multi_buffer b;
@@ -415,11 +417,12 @@ public:
             multi_buffer b;
             std::string const s = "Hello, world!";
             ws.async_write(buffer(s),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t n)
                 {
                     if(ec)
                         BOOST_THROW_EXCEPTION(
                             system_error{ec});
+                    BEAST_EXPECT(n == s.size());
                     BEAST_EXPECT(++count == 1);
                 });
             ws.async_read(b,
@@ -474,7 +477,7 @@ public:
                     ++count;
                 });
             ws.async_write(buffer(s),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t)
                 {
                     if(ec != boost::asio::error::operation_aborted)
                         BOOST_THROW_EXCEPTION(
@@ -519,11 +522,12 @@ public:
                     ++count;
                 });
             ws.async_write(buffer(s),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t n)
                 {
                     if(ec)
                         BOOST_THROW_EXCEPTION(
                             system_error{ec});
+                    BEAST_EXPECT(n == s.size());
                     BEAST_EXPECT(++count == 1);
                 });
             ws.async_ping({},
@@ -578,7 +582,7 @@ public:
                     ++count;
                 });
             ws.async_write(buffer(s),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t)
                 {
                     if(ec != boost::asio::error::operation_aborted)
                         BOOST_THROW_EXCEPTION(

--- a/test/beast/websocket/ping.cpp
+++ b/test/beast/websocket/ping.cpp
@@ -104,12 +104,13 @@ public:
             ws.handshake("localhost", "/");
             std::size_t count = 0;
             ws.async_write(sbuf("Hello, world"),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t n)
                 {
                     ++count;
                     if(ec)
                         BOOST_THROW_EXCEPTION(
                             system_error{ec});
+                    BEAST_EXPECT(n == 12);
                 });
             BEAST_EXPECT(ws.wr_block_);
             BEAST_EXPECT(count == 0);
@@ -333,12 +334,13 @@ public:
             ws.handshake("localhost", "/");
             std::size_t count = 0;
             ws.async_write(sbuf("*"),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t n)
                 {
                     ++count;
                     if(ec)
                         BOOST_THROW_EXCEPTION(
                             system_error{ec});
+                    BEAST_EXPECT(n == 1);
                 });
             BEAST_EXPECT(ws.wr_block_);
             ws.async_ping("",

--- a/test/beast/websocket/read.cpp
+++ b/test/beast/websocket/read.cpp
@@ -744,11 +744,12 @@ public:
                 });
             BEAST_EXPECT(ws.rd_block_);
             ws.async_write(buffer(s),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t n)
                 {
                     if(ec)
                         BOOST_THROW_EXCEPTION(
                             system_error{ec});
+                    BEAST_EXPECT(n == s.size());
                     ++count;
                 });
             BEAST_EXPECT(ws.wr_block_);

--- a/test/beast/websocket/test.hpp
+++ b/test/beast/websocket/test.hpp
@@ -636,29 +636,29 @@ public:
 
         template<
             class NextLayer, class ConstBufferSequence>
-        void
+        std::size_t
         write(stream<NextLayer>& ws,
             ConstBufferSequence const& buffers) const
         {
-            ws.write(buffers);
+            return ws.write(buffers);
         }
 
         template<
             class NextLayer, class ConstBufferSequence>
-        void
+        std::size_t
         write_some(stream<NextLayer>& ws, bool fin,
             ConstBufferSequence const& buffers) const
         {
-            ws.write_some(fin, buffers);
+            return ws.write_some(fin, buffers);
         }
 
         template<
             class NextLayer, class ConstBufferSequence>
-        void
+        std::size_t
         write_raw(stream<NextLayer>& ws,
             ConstBufferSequence const& buffers) const
         {
-            boost::asio::write(
+            return boost::asio::write(
                 ws.next_layer(), buffers);
         }
     };
@@ -896,39 +896,45 @@ public:
 
         template<
             class NextLayer, class ConstBufferSequence>
-        void
+        std::size_t
         write(stream<NextLayer>& ws,
             ConstBufferSequence const& buffers) const
         {
             error_code ec;
-            ws.async_write(buffers, yield_[ec]);
+            auto const bytes_transferred =
+                ws.async_write(buffers, yield_[ec]);
             if(ec)
                 throw system_error{ec};
+            return bytes_transferred;
         }
 
         template<
             class NextLayer, class ConstBufferSequence>
-        void
+        std::size_t
         write_some(stream<NextLayer>& ws, bool fin,
             ConstBufferSequence const& buffers) const
         {
             error_code ec;
-            ws.async_write_some(fin, buffers, yield_[ec]);
+            auto const bytes_transferred =
+                ws.async_write_some(fin, buffers, yield_[ec]);
             if(ec)
                 throw system_error{ec};
+            return bytes_transferred;
         }
 
         template<
             class NextLayer, class ConstBufferSequence>
-        void
+        std::size_t
         write_raw(stream<NextLayer>& ws,
             ConstBufferSequence const& buffers) const
         {
             error_code ec;
-            boost::asio::async_write(
-                ws.next_layer(), buffers, yield_[ec]);
+            auto const bytes_transferred =
+                boost::asio::async_write(
+                    ws.next_layer(), buffers, yield_[ec]);
             if(ec)
                 throw system_error{ec};
+            return bytes_transferred;
         }
     };
 };

--- a/test/beast/websocket/write.cpp
+++ b/test/beast/websocket/write.cpp
@@ -271,12 +271,13 @@ public:
             BEAST_EXPECT(ws.wr_block_);
             BEAST_EXPECT(count == 0);
             ws.async_write(sbuf("*"),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t n)
                 {
                     ++count;
                     if(ec)
                         BOOST_THROW_EXCEPTION(
                             system_error{ec});
+                    BEAST_EXPECT(n == 1);
                 });
             BEAST_EXPECT(count == 0);
             ios.run();
@@ -303,7 +304,7 @@ public:
             BEAST_EXPECT(ws.wr_block_);
             BEAST_EXPECT(count == 0);
             ws.async_write(sbuf("*"),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t)
                 {
                     ++count;
                     if(ec != boost::asio::error::operation_aborted)
@@ -344,12 +345,13 @@ public:
             }
             BEAST_EXPECT(count == 0);
             ws.async_write(sbuf("*"),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t n)
                 {
                     ++count;
                     if(ec)
                         BOOST_THROW_EXCEPTION(
                             system_error{ec});
+                    BEAST_EXPECT(n == 1);
                 });
             BEAST_EXPECT(count == 0);
             ios.run();
@@ -369,12 +371,13 @@ public:
             std::string const s(16384, '*');
             ws.auto_fragment(false);
             ws.async_write(buffer(s),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t n)
                 {
                     ++count;
                     if(ec)
                         BOOST_THROW_EXCEPTION(
                             system_error{ec});
+                    BEAST_EXPECT(n == 16384);
                 });
             BEAST_EXPECT(ws.wr_block_);
             ws.async_ping("",
@@ -402,12 +405,13 @@ public:
             std::string const s(16384, '*');
             ws.auto_fragment(true);
             ws.async_write(buffer(s),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t n)
                 {
                     ++count;
                     if(ec)
                         BOOST_THROW_EXCEPTION(
                             system_error{ec});
+                    BEAST_EXPECT(n == 16384);
                 });
             BEAST_EXPECT(ws.wr_block_);
             ws.async_ping("",
@@ -435,12 +439,13 @@ public:
             std::string const s(16384, '*');
             ws.auto_fragment(false);
             ws.async_write(buffer(s),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t n)
                 {
                     ++count;
                     if(ec)
                         BOOST_THROW_EXCEPTION(
                             system_error{ec});
+                    BEAST_EXPECT(n == 16384);
                 });
             BEAST_EXPECT(ws.wr_block_);
             ws.async_ping("",
@@ -467,12 +472,13 @@ public:
             std::string const s(16384, '*');
             ws.auto_fragment(true);
             ws.async_write(buffer(s),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t n)
                 {
                     ++count;
                     if(ec)
                         BOOST_THROW_EXCEPTION(
                             system_error{ec});
+                    BEAST_EXPECT(n == 16384);
                 });
             BEAST_EXPECT(ws.wr_block_);
             ws.async_ping("",
@@ -504,12 +510,13 @@ public:
             auto const& s = random_string();
             ws.binary(true);
             ws.async_write(buffer(s),
-                [&](error_code ec)
+                [&](error_code ec, std::size_t n)
                 {
                     ++count;
                     if(ec)
                         BOOST_THROW_EXCEPTION(
                             system_error{ec});
+                    BEAST_EXPECT(n == s.size());
                 });
             BEAST_EXPECT(ws.wr_block_);
             ws.async_ping("",
@@ -543,7 +550,7 @@ public:
                     break;
                 ws.async_write_some(false,
                     boost::asio::null_buffers{},
-                    [&](error_code)
+                    [&](error_code, std::size_t)
                     {
                         fail();
                     });

--- a/test/doc/http_snippets.cpp
+++ b/test/doc/http_snippets.cpp
@@ -83,8 +83,9 @@ void fxx() {
     flat_buffer buffer;
     response<string_body> res;
     async_read(sock, buffer, res,
-        [&](error_code ec)
+        [&](error_code ec, std::size_t bytes_transferred)
         {
+            boost::ignore_unused(bytes_transferred);
             std::cerr << ec.message() << std::endl;
         });
 
@@ -124,8 +125,9 @@ void fxx() {
 
 //[http_snippet_8
     async_write(sock, res,
-        [&](error_code)
+        [&](error_code ec, std::size_t bytes_transferred)
         {
+            boost::ignore_unused(bytes_transferred);
             if(ec)
                 std::cerr << ec.message() << std::endl;
         });

--- a/test/doc/websocket_snippets.cpp
+++ b/test/doc/websocket_snippets.cpp
@@ -226,7 +226,7 @@ void echo(stream<boost::asio::ip::tcp::socket>& ws,
     multi_buffer& buffer, boost::asio::yield_context yield)
 {
     ws.async_read(buffer, yield);
-    std::future<void> fut =
+    std::future<std::size_t> fut =
         ws.async_write(buffer.data(), boost::asio::use_future);
 }
 //]

--- a/test/doc/websocket_snippets.cpp
+++ b/test/doc/websocket_snippets.cpp
@@ -215,6 +215,25 @@ boost::asio::ip::tcp::socket sock{ios};
             // Do something with the buffer
         });
 //]
+
+{
+    multi_buffer b;
+//[ws_snippet_24
+    ws.async_read(b, [](error_code, std::size_t){});
+    ws.async_read(b, [](error_code, std::size_t){});
+//]
+}
+
+{
+    multi_buffer b;
+//[ws_snippet_25
+    ws.async_read(b, [](error_code, std::size_t){});
+    ws.async_write(b.data(), [](error_code, std::size_t){});
+    ws.async_ping({}, [](error_code){});
+    ws.async_close({}, [](error_code){});
+//]
+}
+
 }
 
 } // fxx()


### PR DESCRIPTION
* Update websocket notes

API Changes:

* WebSocket writes return the bytes transferred
* HTTP reads and writes return bytes transferred

Actions Required:

* Modify websocket write completion handlers to receive
  the extra std::size_t bytes_transferred parameter.

* Modify HTTP read and/or write completion handlers to
  receive the extra std::size_t bytes_transferred parameter.
