### PR TITLE
Remove field_range copy constructor

### DIFF
--- a/include/boost/beast/http/impl/fields.ipp
+++ b/include/boost/beast/http/impl/fields.ipp
@@ -123,8 +123,6 @@ public:
         using value_type =
             typename const_iterator::value_type;
 
-        field_range(field_range const&) = default;
-
         field_range(iter_type first, iter_type last)
             : first_(first)
             , last_(last)


### PR DESCRIPTION
*  This presence of the user-declared copy constructor makes
   the compiler-provided copy assignment operator deprecated.
   This change allows the compiler to provide both copy members
   without deprecated behavior.