### PR TITLE
Version 118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 118:
 
 * file_win32 opens for read-only in shared mode
+* Remove unused strands in server examples
 
 HTTP:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 118:
 
 * file_win32 opens for read-only in shared mode
 * Remove unused strands in server examples
+* Update build instructions
 
 HTTP:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Version 118:
+
+HTTP:
+
+* Fix writing header into std::ostream
+
+--------------------------------------------------------------------------------
+
 Version 117:
 
 * Add buffers_to_string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 118:
 * file_win32 opens for read-only in shared mode
 * Remove unused strands in server examples
 * Update build instructions
+* Doc root is at index.html
 
 HTTP:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Version 118:
 
+* file_win32 opens for read-only in shared mode
+
 HTTP:
 
 * Fix writing header into std::ostream

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.5.2)
 
-project (Beast VERSION 117)
+project (Beast VERSION 118)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/README.md
+++ b/README.md
@@ -88,22 +88,31 @@ library to link with. If you use coroutines you'll also need to link
 with the Boost.Coroutine library. Please visit the Boost documentation
 for instructions on how to do this for your particular build system.
 
-For the examples and tests, Beast provides build scripts for Boost.Build
-(bjam) and CMake (Windows). It is possible to generate Microsoft Visual
-Studio project files using CMake by executing these commands from
-the root of the repository:
+To build the documentation, examples, tests, and benchmarks it is
+necessary to first obtain the boost "superproject" along with all
+of the boost libraries. Instructions for doing so may be found on
+the [Boost Wiki](https://github.com/boostorg/boost/wiki/Getting-Started).
+These commamnds will build the programs and documentation that come
+with Beast (omit the cxxflags parameter when building using MSVC):
 
 ```
+cd boost   # The directory containing the boost superproject and libraries
+b2 libs/beast/test cxxflags="-std=c++11"    # bjam must be in your $PATH
+b2 libs/beast/example cxxflags="-std=c++11"
+b2 libs/beast/doc
+```
+
+On Windows platforms only, CMake may be used to generate a Visual Studio
+solution and a set of Visual Studio project files using these commands:
+
+```
+cd boost   # The directory containing the boost superproject and libraries
+cd libs/beast
 mkdir bin
 cd bin
-cmake ..                                    # for 32-bit Windows builds
-
-cd ..
-mkdir bin64
-cd bin64
-cmake -G"Visual Studio 14 2015 Win64" ..    # for 64-bit Windows builds (VS2015)
+cmake ..                                    # for 32-bit Windows builds, or
+cmake -G"Visual Studio 14 2015 Win64" ..    # for 64-bit Windows builds (VS2015), or
 cmake -G"Visual Studio 15 2017 Win64" ..    # for 64-bit Windows builds (VS2017)
-
 ```
 
 The files in the repository are laid out thusly:

--- a/doc/Jamfile
+++ b/doc/Jamfile
@@ -178,7 +178,6 @@ boostbook beast
         beast_doc
     :
         <xsl:param>boost.root=../../../..
-        <xsl:param>root.filename=beast
         <xsl:param>chapter.autolabel=1
         <xsl:param>chunk.section.depth=8                # Depth to which sections should be chunked
         <xsl:param>chunk.first.sections=1               # Chunk the first top-level section?

--- a/example/advanced/server-flex/advanced_server_flex.cpp
+++ b/example/advanced/server-flex/advanced_server_flex.cpp
@@ -1023,7 +1023,6 @@ public:
 class listener : public std::enable_shared_from_this<listener>
 {
     ssl::context& ctx_;
-    boost::asio::io_service::strand strand_;
     tcp::acceptor acceptor_;
     tcp::socket socket_;
     std::string const& doc_root_;

--- a/example/advanced/server/advanced_server.cpp
+++ b/example/advanced/server/advanced_server.cpp
@@ -593,7 +593,6 @@ public:
 // Accepts incoming connections and launches the sessions
 class listener : public std::enable_shared_from_this<listener>
 {
-    boost::asio::io_service::strand strand_;
     tcp::acceptor acceptor_;
     tcp::socket socket_;
     std::string const& doc_root_;
@@ -603,8 +602,7 @@ public:
         boost::asio::io_service& ios,
         tcp::endpoint endpoint,
         std::string const& doc_root)
-        : strand_(ios)
-        , acceptor_(ios)
+        : acceptor_(ios)
         , socket_(ios)
         , doc_root_(doc_root)
     {

--- a/example/http/server/async-ssl/http_server_async_ssl.cpp
+++ b/example/http/server/async-ssl/http_server_async_ssl.cpp
@@ -379,7 +379,6 @@ public:
 class listener : public std::enable_shared_from_this<listener>
 {
     ssl::context& ctx_;
-    boost::asio::io_service::strand strand_;
     tcp::acceptor acceptor_;
     tcp::socket socket_;
     std::string const& doc_root_;
@@ -391,7 +390,6 @@ public:
         tcp::endpoint endpoint,
         std::string const& doc_root)
         : ctx_(ctx)
-        , strand_(ios)
         , acceptor_(ios)
         , socket_(ios)
         , doc_root_(doc_root)

--- a/example/http/server/async/http_server_async.cpp
+++ b/example/http/server/async/http_server_async.cpp
@@ -346,7 +346,6 @@ public:
 // Accepts incoming connections and launches the sessions
 class listener : public std::enable_shared_from_this<listener>
 {
-    boost::asio::io_service::strand strand_;
     tcp::acceptor acceptor_;
     tcp::socket socket_;
     std::string const& doc_root_;
@@ -356,8 +355,7 @@ public:
         boost::asio::io_service& ios,
         tcp::endpoint endpoint,
         std::string const& doc_root)
-        : strand_(ios)
-        , acceptor_(ios)
+        : acceptor_(ios)
         , socket_(ios)
         , doc_root_(doc_root)
     {

--- a/example/http/server/stackless-ssl/http_server_stackless_ssl.cpp
+++ b/example/http/server/stackless-ssl/http_server_stackless_ssl.cpp
@@ -362,7 +362,6 @@ class listener
     , public std::enable_shared_from_this<listener>
 {
     ssl::context& ctx_;
-    boost::asio::io_service::strand strand_;
     tcp::acceptor acceptor_;
     tcp::socket socket_;
     std::string const& doc_root_;
@@ -374,7 +373,6 @@ public:
         tcp::endpoint endpoint,
         std::string const& doc_root)
         : ctx_(ctx)
-        , strand_(ios)
         , acceptor_(ios)
         , socket_(ios)
         , doc_root_(doc_root)

--- a/example/http/server/stackless/http_server_stackless.cpp
+++ b/example/http/server/stackless/http_server_stackless.cpp
@@ -337,7 +337,6 @@ class listener
     : public boost::asio::coroutine
     , public std::enable_shared_from_this<listener>
 {
-    boost::asio::io_service::strand strand_;
     tcp::acceptor acceptor_;
     tcp::socket socket_;
     std::string const& doc_root_;
@@ -347,8 +346,7 @@ public:
         boost::asio::io_service& ios,
         tcp::endpoint endpoint,
         std::string const& doc_root)
-        : strand_(ios)
-        , acceptor_(ios)
+        : acceptor_(ios)
         , socket_(ios)
         , doc_root_(doc_root)
     {

--- a/example/websocket/server/async-ssl/websocket_server_async_ssl.cpp
+++ b/example/websocket/server/async-ssl/websocket_server_async_ssl.cpp
@@ -159,7 +159,6 @@ public:
 class listener : public std::enable_shared_from_this<listener>
 {
     ssl::context& ctx_;
-    boost::asio::io_service::strand strand_;
     tcp::acceptor acceptor_;
     tcp::socket socket_;
 
@@ -169,7 +168,6 @@ public:
         ssl::context& ctx,
         tcp::endpoint endpoint)
         : ctx_(ctx)
-        , strand_(ios)
         , acceptor_(ios)
         , socket_(ios)
     {

--- a/example/websocket/server/async/websocket_server_async.cpp
+++ b/example/websocket/server/async/websocket_server_async.cpp
@@ -137,7 +137,6 @@ public:
 // Accepts incoming connections and launches the sessions
 class listener : public std::enable_shared_from_this<listener>
 {
-    boost::asio::io_service::strand strand_;
     tcp::acceptor acceptor_;
     tcp::socket socket_;
 
@@ -145,8 +144,7 @@ public:
     listener(
         boost::asio::io_service& ios,
         tcp::endpoint endpoint)
-        : strand_(ios)
-        , acceptor_(ios)
+        : acceptor_(ios)
         , socket_(ios)
     {
         boost::system::error_code ec;
@@ -191,10 +189,10 @@ public:
     {
         acceptor_.async_accept(
             socket_,
-            strand_.wrap(std::bind(
+            std::bind(
                 &listener::on_accept,
                 shared_from_this(),
-                std::placeholders::_1)));
+                std::placeholders::_1));
     }
 
     void

--- a/example/websocket/server/stackless-ssl/websocket_server_stackless_ssl.cpp
+++ b/example/websocket/server/stackless-ssl/websocket_server_stackless_ssl.cpp
@@ -147,7 +147,6 @@ class listener
     , public std::enable_shared_from_this<listener>
 {
     ssl::context& ctx_;
-    boost::asio::io_service::strand strand_;
     tcp::acceptor acceptor_;
     tcp::socket socket_;
 
@@ -157,7 +156,6 @@ public:
         ssl::context& ctx,
         tcp::endpoint endpoint)
         : ctx_(ctx)
-        , strand_(ios)
         , acceptor_(ios)
         , socket_(ios)
     {

--- a/example/websocket/server/stackless/websocket_server_stackless.cpp
+++ b/example/websocket/server/stackless/websocket_server_stackless.cpp
@@ -128,7 +128,6 @@ class listener
     : public boost::asio::coroutine
     , public std::enable_shared_from_this<listener>
 {
-    boost::asio::io_service::strand strand_;
     tcp::acceptor acceptor_;
     tcp::socket socket_;
 
@@ -136,8 +135,7 @@ public:
     listener(
         boost::asio::io_service& ios,
         tcp::endpoint endpoint)
-        : strand_(ios)
-        , acceptor_(ios)
+        : acceptor_(ios)
         , socket_(ios)
     {
         boost::system::error_code ec;

--- a/include/boost/beast/core/impl/file_win32.ipp
+++ b/include/boost/beast/core/impl/file_win32.ipp
@@ -120,9 +120,10 @@ open(char const* path, file_mode mode, error_code& ec)
         boost::detail::winapi::CloseHandle(h_);
         h_ = boost::detail::winapi::INVALID_HANDLE_VALUE_;
     }
-    boost::detail::winapi::DWORD_ dw1 = 0;
-    boost::detail::winapi::DWORD_ dw2 = 0;
-    boost::detail::winapi::DWORD_ dw3 = 0;
+    boost::detail::winapi::DWORD_ share_mode = 0;
+    boost::detail::winapi::DWORD_ desired_access = 0;
+    boost::detail::winapi::DWORD_ creation_disposition = 0;
+    boost::detail::winapi::DWORD_ flags_and_attributes = 0;
 /*
                              |                    When the file...
     This argument:           |             Exists            Does not exist
@@ -137,66 +138,69 @@ open(char const* path, file_mode mode, error_code& ec)
     {
     default:
     case file_mode::read:
-        dw1 = boost::detail::winapi::GENERIC_READ_;
-        dw2 = boost::detail::winapi::OPEN_EXISTING_;
-        dw3 = 0x10000000; // FILE_FLAG_RANDOM_ACCESS
+        desired_access = boost::detail::winapi::GENERIC_READ_;
+        share_mode = boost::detail::winapi::FILE_SHARE_READ_;
+        creation_disposition = boost::detail::winapi::OPEN_EXISTING_;
+        flags_and_attributes = 0x10000000; // FILE_FLAG_RANDOM_ACCESS
         break;
 
     case file_mode::scan:           
-        dw1 = boost::detail::winapi::GENERIC_READ_;
-        dw2 = boost::detail::winapi::OPEN_EXISTING_;
-        dw3 = 0x08000000; // FILE_FLAG_SEQUENTIAL_SCAN
+        desired_access = boost::detail::winapi::GENERIC_READ_;
+        share_mode = boost::detail::winapi::FILE_SHARE_READ_;
+        creation_disposition = boost::detail::winapi::OPEN_EXISTING_;
+        flags_and_attributes = 0x08000000; // FILE_FLAG_SEQUENTIAL_SCAN
         break;
 
     case file_mode::write:          
-        dw1 = boost::detail::winapi::GENERIC_READ_ |
-              boost::detail::winapi::GENERIC_WRITE_;
-        dw2 = boost::detail::winapi::CREATE_ALWAYS_;
-        dw3 = 0x10000000; // FILE_FLAG_RANDOM_ACCESS
+        desired_access = boost::detail::winapi::GENERIC_READ_ |
+                         boost::detail::winapi::GENERIC_WRITE_;
+        creation_disposition = boost::detail::winapi::CREATE_ALWAYS_;
+        flags_and_attributes = 0x10000000; // FILE_FLAG_RANDOM_ACCESS
         break;
 
     case file_mode::write_new:      
-        dw1 = boost::detail::winapi::GENERIC_READ_ |
-              boost::detail::winapi::GENERIC_WRITE_;
-        dw2 = boost::detail::winapi::CREATE_NEW_;
-        dw3 = 0x10000000; // FILE_FLAG_RANDOM_ACCESS
+        desired_access = boost::detail::winapi::GENERIC_READ_ |
+                         boost::detail::winapi::GENERIC_WRITE_;
+        creation_disposition = boost::detail::winapi::CREATE_NEW_;
+        flags_and_attributes = 0x10000000; // FILE_FLAG_RANDOM_ACCESS
         break;
 
     case file_mode::write_existing: 
-        dw1 = boost::detail::winapi::GENERIC_READ_ |
-              boost::detail::winapi::GENERIC_WRITE_;
-        dw2 = boost::detail::winapi::OPEN_EXISTING_;
-        dw3 = 0x10000000; // FILE_FLAG_RANDOM_ACCESS
+        desired_access = boost::detail::winapi::GENERIC_READ_ |
+                         boost::detail::winapi::GENERIC_WRITE_;
+        creation_disposition = boost::detail::winapi::OPEN_EXISTING_;
+        flags_and_attributes = 0x10000000; // FILE_FLAG_RANDOM_ACCESS
         break;
 
     case file_mode::append:         
-        dw1 = boost::detail::winapi::GENERIC_READ_ |
-              boost::detail::winapi::GENERIC_WRITE_;
-        dw2 = boost::detail::winapi::CREATE_ALWAYS_;
-        dw3 = 0x08000000; // FILE_FLAG_SEQUENTIAL_SCAN
+        desired_access = boost::detail::winapi::GENERIC_READ_ |
+                         boost::detail::winapi::GENERIC_WRITE_;
+
+        creation_disposition = boost::detail::winapi::CREATE_ALWAYS_;
+        flags_and_attributes = 0x08000000; // FILE_FLAG_SEQUENTIAL_SCAN
         break;
 
     case file_mode::append_new:     
-        dw1 = boost::detail::winapi::GENERIC_READ_ |
-              boost::detail::winapi::GENERIC_WRITE_;
-        dw2 = boost::detail::winapi::CREATE_NEW_;
-        dw3 = 0x08000000; // FILE_FLAG_SEQUENTIAL_SCAN
+        desired_access = boost::detail::winapi::GENERIC_READ_ |
+                         boost::detail::winapi::GENERIC_WRITE_;
+        creation_disposition = boost::detail::winapi::CREATE_NEW_;
+        flags_and_attributes = 0x08000000; // FILE_FLAG_SEQUENTIAL_SCAN
         break;
 
     case file_mode::append_existing:
-        dw1 = boost::detail::winapi::GENERIC_READ_ |
-              boost::detail::winapi::GENERIC_WRITE_;
-        dw2 = boost::detail::winapi::OPEN_EXISTING_;
-        dw3 = 0x08000000; // FILE_FLAG_SEQUENTIAL_SCAN
+        desired_access = boost::detail::winapi::GENERIC_READ_ |
+                         boost::detail::winapi::GENERIC_WRITE_;
+        creation_disposition = boost::detail::winapi::OPEN_EXISTING_;
+        flags_and_attributes = 0x08000000; // FILE_FLAG_SEQUENTIAL_SCAN
         break;
     }
     h_ = ::CreateFileA(
         path,
-        dw1,
-        0,
+        desired_access,
+        share_mode,
         NULL,
-        dw2,
-        dw3,
+        creation_disposition,
+        flags_and_attributes,
         NULL);
     if(h_ == boost::detail::winapi::INVALID_HANDLE_VALUE_)
         ec.assign(boost::detail::winapi::GetLastError(),

--- a/include/boost/beast/http/impl/write.ipp
+++ b/include/boost/beast/http/impl/write.ipp
@@ -878,7 +878,7 @@ operator<<(std::ostream& os,
     header<true, Fields> const& h)
 {
     typename Fields::reader fr{
-        h, h.version, h.method()};
+        h, h.version(), h.method()};
     return os << buffers(fr.get());
 }
 
@@ -888,7 +888,7 @@ operator<<(std::ostream& os,
     header<false, Fields> const& h)
 {
     typename Fields::reader fr{
-        h, h.version, h.result_int()};
+        h, h.version(), h.result_int()};
     return os << buffers(fr.get());
 }
 

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 117
+#define BOOST_BEAST_VERSION 118
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
 <html>
     <head>
         <title>Boost.Beast</title>
-        <meta http-equiv="refresh" content="0; URL=./doc/html/beast.html">
+        <meta http-equiv="refresh" content="0; URL=./doc/html/index.html">
     </head>
     <body>
         Automatic redirection failed, please go to
-        <a href="./doc/html/beast.html">./doc/html/beast.html</a>
+        <a href="./doc/html/beast.html">./doc/html/index.html</a>
         <hr>
         <tt>
         Boost.Beast<br>

--- a/test/beast/http/write.cpp
+++ b/test/beast/http/write.cpp
@@ -596,14 +596,36 @@ public:
     void test_std_ostream()
     {
         // Conversion to std::string via operator<<
-        request<string_body> m;
-        m.method(verb::get);
-        m.target("/");
-        m.version(11);
-        m.set(field::user_agent, "test");
-        m.body() = "*";
-        BEAST_EXPECT(to_string(m) ==
-            "GET / HTTP/1.1\r\nUser-Agent: test\r\n\r\n*");
+        {
+            request<string_body> m;
+            m.method(verb::get);
+            m.target("/");
+            m.version(11);
+            m.set(field::user_agent, "test");
+            m.body() = "*";
+            BEAST_EXPECT(to_string(m) ==
+                "GET / HTTP/1.1\r\nUser-Agent: test\r\n\r\n*");
+        }
+
+        // Output to std::ostream
+        {
+            request<string_body> m{verb::get, "/", 11};
+            std::stringstream ss;
+            ss << m;
+            BEAST_EXPECT(ss.str() ==
+                "GET / HTTP/1.1\r\n"
+                "\r\n");
+        }
+
+        // Output header to std::ostream
+        {
+            request<string_body> m{verb::get, "/", 11};
+            std::stringstream ss;
+            ss << m.base();
+            BEAST_EXPECT(ss.str() ==
+                "GET / HTTP/1.1\r\n"
+                "\r\n");
+        }
     }
 
     // Ensure completion handlers are not leaked


### PR DESCRIPTION
* file_win32 opens for read-only in shared mode
* Remove unused strands in server examples
* Update build instructions
* Doc root is at index.html

HTTP:

* Fix writing header into std::ostream
