### PR TITLE
Fix enum and non-enum in conditional exp. gcc warning

### DIFF
--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -1075,7 +1075,8 @@ loop:
                 // _Start the WebSocket Closing Handshake_
                 do_fail(
                     cr.code == close_code::none ?
-                        close_code::normal : cr.code,
+                        close_code::normal : 
+                        static_cast<close_code>(cr.code),
                     error::closed, ec);
                 return bytes_written;
             }


### PR DESCRIPTION
Fix "enumeral and non-enumeral type in conditional expression” GCC warning. 
Identical to line 364.

