### PR TITLE
Version 126

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,16 @@ addons:
 
 matrix:
   include:
+    # Default g++
+    - os: linux
+      compiler: g++
+      script: b2 -j3 libs/beast/test toolset=gcc cxxstd=11
+
+    # Default clang++
+    - os: linux
+      compiler: clang++
+      script: b2 -j3 libs/beast/test toolset=clang cxxstd=11
+
     # GCC 6.0, Debug + Coverage
     - os: linux
       compiler: g++-6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 126:
+
+* Add CppCon2017 presentation link
+
+--------------------------------------------------------------------------------
+
 Version 125:
 
 API Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Version 126:
 * Fix doc typo
 * Fix shadowing in session_alloc
 * Fix executor type compilation
+* Add Travis tests with the default compilers
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 126:
 * Add CppCon2017 presentation link
 * Update README.md
 * Update stream write documentation for end of stream changes
+* Tidy up unused variable warnings
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 126:
 * Update stream write documentation for end of stream changes
 * Tidy up unused variable warnings
 * Don't return end_of_stream on win32 file body writes
+* Fix doc typo
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 126:
 
 * Add CppCon2017 presentation link
 * Update README.md
+* Update stream write documentation for end of stream changes
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version 126:
 * Fix executor type compilation
 * Add Travis tests with the default compilers
 * Update Boost.WinAPI usage to the new location and namespace.
+* Fix buffered_read_stream async_read_some signature
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 126:
 * Tidy up unused variable warnings
 * Don't return end_of_stream on win32 file body writes
 * Fix doc typo
+* Fix shadowing in session_alloc
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 126:
 * Update README.md
 * Update stream write documentation for end of stream changes
 * Tidy up unused variable warnings
+* Don't return end_of_stream on win32 file body writes
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version 126:
 * Fix shadowing in session_alloc
 * Fix executor type compilation
 * Add Travis tests with the default compilers
+* Update Boost.WinAPI usage to the new location and namespace.
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Version 126:
 * Don't return end_of_stream on win32 file body writes
 * Fix doc typo
 * Fix shadowing in session_alloc
+* Fix executor type compilation
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 126:
 
 * Add CppCon2017 presentation link
+* Update README.md
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.5.1)
 
-project (Beast VERSION 125)
+project (Beast VERSION 126)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ This library is designed for:
 
 ## Appearances
 
-| <a href="http://cppcast.com/2017/01/vinnie-falco/">CppCast 2017</a> | <a href="https://raw.githubusercontent.com/vinniefalco/BeastAssets/master/CppCon2016.pdf">CppCon 2016</a> |
-| ------------ | ----------- |
-| <a href="http://cppcast.com/2017/01/vinnie-falco/"><img width="180" height="180" alt="Vinnie Falco" src="https://avatars1.githubusercontent.com/u/1503976?v=3&u=76c56d989ef4c09625256662eca2775df78a16ad&s=180"></a> | <a href="https://www.youtube.com/watch?v=uJZgRcvPFwI"><img width="320" height = "180" alt="Beast" src="https://raw.githubusercontent.com/vinniefalco/BeastAssets/master/CppCon2016.png"></a> |
+| <a href="https://raw.githubusercontent.com/vinniefalco/CppCon2017/master/Make%20Classes%20Great%20Again%20-%20Vinnie%20Falco%20-%20CppCon%202017.pdf">CppCon 2017</a> | <a href="http://cppcast.com/2017/01/vinnie-falco/">CppCast 2017</a> | <a href="https://raw.githubusercontent.com/vinniefalco/BeastAssets/master/CppCon2016.pdf">CppCon 2016</a> |
+| ------------ | ------------ | ----------- |
+| <a href="https://www.youtube.com/watch?v=WsUnnYEKPnI"><img width="320" height = "180" alt="Beast" src="https://raw.githubusercontent.com/vinniefalco/CppCon2017/master/CppCon2017.png"></a> | <a href="http://cppcast.com/2017/01/vinnie-falco/"><img width="180" height="180" alt="Vinnie Falco" src="https://avatars1.githubusercontent.com/u/1503976?v=3&u=76c56d989ef4c09625256662eca2775df78a16ad&s=180"></a> | <a href="https://www.youtube.com/watch?v=uJZgRcvPFwI"><img width="320" height = "180" alt="Beast" src="https://raw.githubusercontent.com/vinniefalco/BeastAssets/master/CppCon2016.png"></a> |
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,9 @@ This library is designed for:
 
 ## Description
 
-This software is currently in beta: interfaces may change.
-For recent changes see the [CHANGELOG](CHANGELOG.md).
-As of July 20th, this library has been ACCEPTED into Boost
-without conditions. The first official release of Beast will
-appear in Boost 1.66.0, due in December.
+This software is in its first official release. Interfaces
+may change in response to user feedback. For recent changes
+see the [CHANGELOG](CHANGELOG.md).
 
 * [Official Site](https://github.com/boostorg/beast)
 * [Documentation](http://www.boost.org/doc/libs/develop/libs/beast/)

--- a/doc/qbk/04_http/03_streams.qbk
+++ b/doc/qbk/04_http/03_streams.qbk
@@ -94,14 +94,7 @@ overflow attacks. The following code will print the error message:
 [heading Writing]
 
 A set of free functions allow serialization of an entire HTTP message to
-a stream. If a response has no declared content length and no chunked
-transfer encoding, then the end of the message is indicated by the server
-closing the connection. When sending such a response, Beast will return the
-[link beast.ref.boost__beast__http__error `error::end_of_stream`]
-from the write algorithm to indicate
-to the caller that the connection should be closed. This example
-constructs and sends a response whose body length is determined by
-the number of octets received prior to the server closing the connection:
+a stream. This example constructs and sends an HTTP response:
 
 [http_snippet_7]
 

--- a/example/common/detect_ssl.hpp
+++ b/example/common/detect_ssl.hpp
@@ -363,7 +363,7 @@ public:
     // final handler.
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(stream_.get_executor())>;
+        Handler, decltype(std::declval<AsyncReadStream&>().get_executor())>;
 
     executor_type get_executor() const noexcept
     {

--- a/example/common/session_alloc.hpp
+++ b/example/common/session_alloc.hpp
@@ -202,6 +202,7 @@ session_alloc_base<Context>::
 pool_t::
 dealloc(void* pv, std::size_t n)
 {
+    boost::ignore_unused(n);
     auto& e = *(reinterpret_cast<element*>(pv) - 1);
     BOOST_ASSERT(e.size() == n);
     if( (e.end() > buf_ + size_) ||

--- a/example/common/session_alloc.hpp
+++ b/example/common/session_alloc.hpp
@@ -14,6 +14,7 @@
 #include <boost/asio/associated_executor.hpp>
 #include <boost/asio/handler_continuation_hook.hpp>
 #include <boost/assert.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/intrusive/list.hpp>
 #include <algorithm>
 #include <cstddef>
@@ -233,7 +234,7 @@ class session_alloc
     {
         // Can't friend partial specializations,
         // so we just friend the whole thing.
-        template<class T, class Executor>
+        template<class U, class Executor>
         friend struct boost::asio::associated_executor;
 
         Handler h_;

--- a/example/common/ssl_stream.hpp
+++ b/example/common/ssl_stream.hpp
@@ -58,6 +58,9 @@ public:
     /// The type of the lowest layer.
     using lowest_layer_type = typename stream_type::lowest_layer_type;
 
+    /// The type of the executor associated with the object.
+    using executor_type = typename stream_type::executor_type;
+
     ssl_stream(
         boost::asio::ip::tcp::socket socket,
         boost::asio::ssl::context& ctx)
@@ -88,7 +91,7 @@ public:
         return *this;
     }
 
-    decltype(p_->get_executor())
+    executor_type
     get_executor() noexcept
     {
         return p_->get_executor();

--- a/example/echo-op/echo_op.cpp
+++ b/example/echo-op/echo_op.cpp
@@ -164,7 +164,7 @@ public:
     // final handler.
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(p_->stream.get_executor())>;
+        Handler, decltype(std::declval<AsyncStream&>().get_executor())>;
 
     executor_type get_executor() const noexcept
     {

--- a/include/boost/beast/core/buffered_read_stream.hpp
+++ b/include/boost/beast/core/buffered_read_stream.hpp
@@ -288,7 +288,7 @@ public:
     */
     template<class MutableBufferSequence, class ReadHandler>
     BOOST_ASIO_INITFN_RESULT_TYPE(
-        ReadHandler, void(error_code))
+        ReadHandler, void(error_code, std::size_t))
     async_read_some(MutableBufferSequence const& buffers,
         ReadHandler&& handler);
 
@@ -360,7 +360,7 @@ public:
     */
     template<class ConstBufferSequence, class WriteHandler>
     BOOST_ASIO_INITFN_RESULT_TYPE(
-        WriteHandler, void(error_code))
+        WriteHandler, void(error_code, std::size_t))
     async_write_some(ConstBufferSequence const& buffers,
         WriteHandler&& handler);
 };

--- a/include/boost/beast/core/file_win32.hpp
+++ b/include/boost/beast/core/file_win32.hpp
@@ -24,8 +24,8 @@
 
 #include <boost/beast/core/error.hpp>
 #include <boost/beast/core/file_base.hpp>
-#include <boost/detail/winapi/basic_types.hpp>
-#include <boost/detail/winapi/handles.hpp>
+#include <boost/winapi/basic_types.hpp>
+#include <boost/winapi/handles.hpp>
 #include <cstdio>
 #include <cstdint>
 
@@ -38,8 +38,8 @@ namespace beast {
 */
 class file_win32
 {
-    boost::detail::winapi::HANDLE_ h_ =
-        boost::detail::winapi::INVALID_HANDLE_VALUE_;
+    boost::winapi::HANDLE_ h_ =
+        boost::winapi::INVALID_HANDLE_VALUE_;
 
 public:
     /** The type of the underlying file handle.
@@ -49,7 +49,7 @@ public:
 #if BOOST_BEAST_DOXYGEN
     using native_handle_type = HANDLE;
 #else
-    using native_handle_type = boost::detail::winapi::HANDLE_;
+    using native_handle_type = boost::winapi::HANDLE_;
 #endif
 
     /** Destructor
@@ -96,7 +96,7 @@ public:
     bool
     is_open() const
     {
-        return h_ != boost::detail::winapi::INVALID_HANDLE_VALUE_;
+        return h_ != boost::winapi::INVALID_HANDLE_VALUE_;
     }
 
     /** Close the file if open

--- a/include/boost/beast/core/impl/buffered_read_stream.ipp
+++ b/include/boost/beast/core/impl/buffered_read_stream.ipp
@@ -144,11 +144,12 @@ buffered_read_stream(Args&&... args)
 
 template<class Stream, class DynamicBuffer>
 template<class ConstBufferSequence, class WriteHandler>
-auto
+BOOST_ASIO_INITFN_RESULT_TYPE(
+    WriteHandler, void(error_code, std::size_t))
 buffered_read_stream<Stream, DynamicBuffer>::
-async_write_some(ConstBufferSequence const& buffers,
-        WriteHandler&& handler) ->
-    BOOST_ASIO_INITFN_RESULT_TYPE(WriteHandler, void(error_code))
+async_write_some(
+    ConstBufferSequence const& buffers,
+    WriteHandler&& handler)
 {
     static_assert(is_async_write_stream<next_layer_type>::value,
         "AsyncWriteStream requirements not met");
@@ -217,11 +218,12 @@ read_some(MutableBufferSequence const& buffers,
 
 template<class Stream, class DynamicBuffer>
 template<class MutableBufferSequence, class ReadHandler>
-auto
+BOOST_ASIO_INITFN_RESULT_TYPE(
+    ReadHandler, void(error_code, std::size_t))
 buffered_read_stream<Stream, DynamicBuffer>::
-async_read_some(MutableBufferSequence const& buffers,
-        ReadHandler&& handler) ->
-    BOOST_ASIO_INITFN_RESULT_TYPE(ReadHandler, void(error_code))
+async_read_some(
+    MutableBufferSequence const& buffers,
+    ReadHandler&& handler)
 {
     static_assert(is_async_read_stream<next_layer_type>::value,
         "AsyncReadStream requirements not met");

--- a/include/boost/beast/core/impl/buffered_read_stream.ipp
+++ b/include/boost/beast/core/impl/buffered_read_stream.ipp
@@ -58,10 +58,12 @@ public:
         return boost::asio::get_associated_allocator(h_);
     }
 
-    using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(s_.get_executor())>;
+    using executor_type =
+        boost::asio::associated_executor_t<Handler, decltype(
+            std::declval<buffered_read_stream&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             h_, s_.get_executor());

--- a/include/boost/beast/core/impl/file_win32.ipp
+++ b/include/boost/beast/core/impl/file_win32.ipp
@@ -10,10 +10,10 @@
 #ifndef BOOST_BEAST_CORE_IMPL_FILE_WIN32_IPP
 #define BOOST_BEAST_CORE_IMPL_FILE_WIN32_IPP
 
-#include <boost/detail/winapi/access_rights.hpp>
-#include <boost/detail/winapi/error_codes.hpp>
-#include <boost/detail/winapi/file_management.hpp>
-#include <boost/detail/winapi/get_last_error.hpp>
+#include <boost/winapi/access_rights.hpp>
+#include <boost/winapi/error_codes.hpp>
+#include <boost/winapi/file_management.hpp>
+#include <boost/winapi/get_last_error.hpp>
 #include <limits>
 #include <utility>
 
@@ -25,20 +25,20 @@ namespace detail {
 // VFALCO Can't seem to get boost/detail/winapi to work with
 //        this so use the non-Ex version for now.
 inline
-boost::detail::winapi::BOOL_
+boost::winapi::BOOL_
 set_file_pointer_ex(
-    boost::detail::winapi::HANDLE_ hFile,
-    boost::detail::winapi::LARGE_INTEGER_ lpDistanceToMove,
-    boost::detail::winapi::PLARGE_INTEGER_ lpNewFilePointer,
-    boost::detail::winapi::DWORD_ dwMoveMethod)
+    boost::winapi::HANDLE_ hFile,
+    boost::winapi::LARGE_INTEGER_ lpDistanceToMove,
+    boost::winapi::PLARGE_INTEGER_ lpNewFilePointer,
+    boost::winapi::DWORD_ dwMoveMethod)
 {
     auto dwHighPart = lpDistanceToMove.u.HighPart;
-    auto dwLowPart = boost::detail::winapi::SetFilePointer(
+    auto dwLowPart = boost::winapi::SetFilePointer(
         hFile,
         lpDistanceToMove.u.LowPart,
         &dwHighPart,
         dwMoveMethod);
-    if(dwLowPart == boost::detail::winapi::INVALID_SET_FILE_POINTER_)
+    if(dwLowPart == boost::winapi::INVALID_SET_FILE_POINTER_)
         return 0;
     if(lpNewFilePointer)
     {
@@ -54,8 +54,8 @@ inline
 file_win32::
 ~file_win32()
 {
-    if(h_ != boost::detail::winapi::INVALID_HANDLE_VALUE_)
-        boost::detail::winapi::CloseHandle(h_);
+    if(h_ != boost::winapi::INVALID_HANDLE_VALUE_)
+        boost::winapi::CloseHandle(h_);
 }
 
 inline
@@ -63,7 +63,7 @@ file_win32::
 file_win32(file_win32&& other)
     : h_(other.h_)
 {
-    other.h_ = boost::detail::winapi::INVALID_HANDLE_VALUE_;
+    other.h_ = boost::winapi::INVALID_HANDLE_VALUE_;
 }
 
 inline
@@ -74,9 +74,9 @@ operator=(file_win32&& other)
     if(&other == this)
         return *this;
     if(h_)
-        boost::detail::winapi::CloseHandle(h_);
+        boost::winapi::CloseHandle(h_);
     h_ = other.h_;
-    other.h_ = boost::detail::winapi::INVALID_HANDLE_VALUE_;
+    other.h_ = boost::winapi::INVALID_HANDLE_VALUE_;
     return *this;
 }
 
@@ -85,8 +85,8 @@ void
 file_win32::
 native_handle(native_handle_type h)
 {
-     if(h_ != boost::detail::winapi::INVALID_HANDLE_VALUE_)
-        boost::detail::winapi::CloseHandle(h_);
+     if(h_ != boost::winapi::INVALID_HANDLE_VALUE_)
+        boost::winapi::CloseHandle(h_);
     h_ = h;
 }
 
@@ -95,14 +95,14 @@ void
 file_win32::
 close(error_code& ec)
 {
-    if(h_ != boost::detail::winapi::INVALID_HANDLE_VALUE_)
+    if(h_ != boost::winapi::INVALID_HANDLE_VALUE_)
     {
-        if(! boost::detail::winapi::CloseHandle(h_))
-            ec.assign(boost::detail::winapi::GetLastError(),
+        if(! boost::winapi::CloseHandle(h_))
+            ec.assign(boost::winapi::GetLastError(),
                 system_category());
         else
             ec.assign(0, ec.category());
-        h_ = boost::detail::winapi::INVALID_HANDLE_VALUE_;
+        h_ = boost::winapi::INVALID_HANDLE_VALUE_;
     }
     else
     {
@@ -115,15 +115,15 @@ void
 file_win32::
 open(char const* path, file_mode mode, error_code& ec)
 {
-    if(h_ != boost::detail::winapi::INVALID_HANDLE_VALUE_)
+    if(h_ != boost::winapi::INVALID_HANDLE_VALUE_)
     {
-        boost::detail::winapi::CloseHandle(h_);
-        h_ = boost::detail::winapi::INVALID_HANDLE_VALUE_;
+        boost::winapi::CloseHandle(h_);
+        h_ = boost::winapi::INVALID_HANDLE_VALUE_;
     }
-    boost::detail::winapi::DWORD_ share_mode = 0;
-    boost::detail::winapi::DWORD_ desired_access = 0;
-    boost::detail::winapi::DWORD_ creation_disposition = 0;
-    boost::detail::winapi::DWORD_ flags_and_attributes = 0;
+    boost::winapi::DWORD_ share_mode = 0;
+    boost::winapi::DWORD_ desired_access = 0;
+    boost::winapi::DWORD_ creation_disposition = 0;
+    boost::winapi::DWORD_ flags_and_attributes = 0;
 /*
                              |                    When the file...
     This argument:           |             Exists            Does not exist
@@ -138,59 +138,59 @@ open(char const* path, file_mode mode, error_code& ec)
     {
     default:
     case file_mode::read:
-        desired_access = boost::detail::winapi::GENERIC_READ_;
-        share_mode = boost::detail::winapi::FILE_SHARE_READ_;
-        creation_disposition = boost::detail::winapi::OPEN_EXISTING_;
+        desired_access = boost::winapi::GENERIC_READ_;
+        share_mode = boost::winapi::FILE_SHARE_READ_;
+        creation_disposition = boost::winapi::OPEN_EXISTING_;
         flags_and_attributes = 0x10000000; // FILE_FLAG_RANDOM_ACCESS
         break;
 
     case file_mode::scan:           
-        desired_access = boost::detail::winapi::GENERIC_READ_;
-        share_mode = boost::detail::winapi::FILE_SHARE_READ_;
-        creation_disposition = boost::detail::winapi::OPEN_EXISTING_;
+        desired_access = boost::winapi::GENERIC_READ_;
+        share_mode = boost::winapi::FILE_SHARE_READ_;
+        creation_disposition = boost::winapi::OPEN_EXISTING_;
         flags_and_attributes = 0x08000000; // FILE_FLAG_SEQUENTIAL_SCAN
         break;
 
     case file_mode::write:          
-        desired_access = boost::detail::winapi::GENERIC_READ_ |
-                         boost::detail::winapi::GENERIC_WRITE_;
-        creation_disposition = boost::detail::winapi::CREATE_ALWAYS_;
+        desired_access = boost::winapi::GENERIC_READ_ |
+                         boost::winapi::GENERIC_WRITE_;
+        creation_disposition = boost::winapi::CREATE_ALWAYS_;
         flags_and_attributes = 0x10000000; // FILE_FLAG_RANDOM_ACCESS
         break;
 
     case file_mode::write_new:      
-        desired_access = boost::detail::winapi::GENERIC_READ_ |
-                         boost::detail::winapi::GENERIC_WRITE_;
-        creation_disposition = boost::detail::winapi::CREATE_NEW_;
+        desired_access = boost::winapi::GENERIC_READ_ |
+                         boost::winapi::GENERIC_WRITE_;
+        creation_disposition = boost::winapi::CREATE_NEW_;
         flags_and_attributes = 0x10000000; // FILE_FLAG_RANDOM_ACCESS
         break;
 
     case file_mode::write_existing: 
-        desired_access = boost::detail::winapi::GENERIC_READ_ |
-                         boost::detail::winapi::GENERIC_WRITE_;
-        creation_disposition = boost::detail::winapi::OPEN_EXISTING_;
+        desired_access = boost::winapi::GENERIC_READ_ |
+                         boost::winapi::GENERIC_WRITE_;
+        creation_disposition = boost::winapi::OPEN_EXISTING_;
         flags_and_attributes = 0x10000000; // FILE_FLAG_RANDOM_ACCESS
         break;
 
     case file_mode::append:         
-        desired_access = boost::detail::winapi::GENERIC_READ_ |
-                         boost::detail::winapi::GENERIC_WRITE_;
+        desired_access = boost::winapi::GENERIC_READ_ |
+                         boost::winapi::GENERIC_WRITE_;
 
-        creation_disposition = boost::detail::winapi::CREATE_ALWAYS_;
+        creation_disposition = boost::winapi::CREATE_ALWAYS_;
         flags_and_attributes = 0x08000000; // FILE_FLAG_SEQUENTIAL_SCAN
         break;
 
     case file_mode::append_new:     
-        desired_access = boost::detail::winapi::GENERIC_READ_ |
-                         boost::detail::winapi::GENERIC_WRITE_;
-        creation_disposition = boost::detail::winapi::CREATE_NEW_;
+        desired_access = boost::winapi::GENERIC_READ_ |
+                         boost::winapi::GENERIC_WRITE_;
+        creation_disposition = boost::winapi::CREATE_NEW_;
         flags_and_attributes = 0x08000000; // FILE_FLAG_SEQUENTIAL_SCAN
         break;
 
     case file_mode::append_existing:
-        desired_access = boost::detail::winapi::GENERIC_READ_ |
-                         boost::detail::winapi::GENERIC_WRITE_;
-        creation_disposition = boost::detail::winapi::OPEN_EXISTING_;
+        desired_access = boost::winapi::GENERIC_READ_ |
+                         boost::winapi::GENERIC_WRITE_;
+        creation_disposition = boost::winapi::OPEN_EXISTING_;
         flags_and_attributes = 0x08000000; // FILE_FLAG_SEQUENTIAL_SCAN
         break;
     }
@@ -202,8 +202,8 @@ open(char const* path, file_mode mode, error_code& ec)
         creation_disposition,
         flags_and_attributes,
         NULL);
-    if(h_ == boost::detail::winapi::INVALID_HANDLE_VALUE_)
-        ec.assign(boost::detail::winapi::GetLastError(),
+    if(h_ == boost::winapi::INVALID_HANDLE_VALUE_)
+        ec.assign(boost::winapi::GetLastError(),
             system_category());
     else
         ec.assign(0, ec.category());
@@ -214,15 +214,15 @@ std::uint64_t
 file_win32::
 size(error_code& ec) const
 {
-    if(h_ == boost::detail::winapi::INVALID_HANDLE_VALUE_)
+    if(h_ == boost::winapi::INVALID_HANDLE_VALUE_)
     {
         ec.assign(errc::invalid_argument, generic_category());
         return 0;
     }
-    boost::detail::winapi::LARGE_INTEGER_ fileSize;
-    if(! boost::detail::winapi::GetFileSizeEx(h_, &fileSize))
+    boost::winapi::LARGE_INTEGER_ fileSize;
+    if(! boost::winapi::GetFileSizeEx(h_, &fileSize))
     {
-        ec.assign(boost::detail::winapi::GetLastError(),
+        ec.assign(boost::winapi::GetLastError(),
             system_category());
         return 0;
     }
@@ -235,18 +235,18 @@ std::uint64_t
 file_win32::
 pos(error_code& ec)
 {
-    if(h_ == boost::detail::winapi::INVALID_HANDLE_VALUE_)
+    if(h_ == boost::winapi::INVALID_HANDLE_VALUE_)
     {
         ec.assign(errc::invalid_argument, generic_category());
         return 0;
     }
-    boost::detail::winapi::LARGE_INTEGER_ in;
-    boost::detail::winapi::LARGE_INTEGER_ out;
+    boost::winapi::LARGE_INTEGER_ in;
+    boost::winapi::LARGE_INTEGER_ out;
     in.QuadPart = 0;
     if(! detail::set_file_pointer_ex(h_, in, &out,
-        boost::detail::winapi::FILE_CURRENT_))
+        boost::winapi::FILE_CURRENT_))
     {
-        ec.assign(boost::detail::winapi::GetLastError(),
+        ec.assign(boost::winapi::GetLastError(),
             system_category());
         return 0;
     }
@@ -259,17 +259,17 @@ void
 file_win32::
 seek(std::uint64_t offset, error_code& ec)
 {
-    if(h_ == boost::detail::winapi::INVALID_HANDLE_VALUE_)
+    if(h_ == boost::winapi::INVALID_HANDLE_VALUE_)
     {
         ec.assign(errc::invalid_argument, generic_category());
         return;
     }
-    boost::detail::winapi::LARGE_INTEGER_ in;
+    boost::winapi::LARGE_INTEGER_ in;
     in.QuadPart = offset;
     if(! detail::set_file_pointer_ex(h_, in, 0,
-        boost::detail::winapi::FILE_BEGIN_))
+        boost::winapi::FILE_BEGIN_))
     {
-        ec.assign(boost::detail::winapi::GetLastError(),
+        ec.assign(boost::winapi::GetLastError(),
             system_category());
         return;
     }
@@ -281,7 +281,7 @@ std::size_t
 file_win32::
 read(void* buffer, std::size_t n, error_code& ec)
 {
-    if(h_ == boost::detail::winapi::INVALID_HANDLE_VALUE_)
+    if(h_ == boost::winapi::INVALID_HANDLE_VALUE_)
     {
         ec.assign(errc::invalid_argument, generic_category());
         return 0;
@@ -289,19 +289,19 @@ read(void* buffer, std::size_t n, error_code& ec)
     std::size_t nread = 0;
     while(n > 0)
     {
-        boost::detail::winapi::DWORD_ amount;
+        boost::winapi::DWORD_ amount;
         if(n > (std::numeric_limits<
-                boost::detail::winapi::DWORD_>::max)())
+                boost::winapi::DWORD_>::max)())
             amount = (std::numeric_limits<
-                boost::detail::winapi::DWORD_>::max)();
+                boost::winapi::DWORD_>::max)();
         else
             amount = static_cast<
-                boost::detail::winapi::DWORD_>(n);
-        boost::detail::winapi::DWORD_ bytesRead;
+                boost::winapi::DWORD_>(n);
+        boost::winapi::DWORD_ bytesRead;
         if(! ::ReadFile(h_, buffer, amount, &bytesRead, 0))
         {
             auto const dwError = ::GetLastError();
-            if(dwError != boost::detail::winapi::ERROR_HANDLE_EOF_)
+            if(dwError != boost::winapi::ERROR_HANDLE_EOF_)
                 ec.assign(::GetLastError(), system_category());
             else
                 ec.assign(0, ec.category());
@@ -322,7 +322,7 @@ std::size_t
 file_win32::
 write(void const* buffer, std::size_t n, error_code& ec)
 {
-    if(h_ == boost::detail::winapi::INVALID_HANDLE_VALUE_)
+    if(h_ == boost::winapi::INVALID_HANDLE_VALUE_)
     {
         ec.assign(errc::invalid_argument, generic_category());
         return 0;
@@ -330,19 +330,19 @@ write(void const* buffer, std::size_t n, error_code& ec)
     std::size_t nwritten = 0;
     while(n > 0)
     {
-        boost::detail::winapi::DWORD_ amount;
+        boost::winapi::DWORD_ amount;
         if(n > (std::numeric_limits<
-                boost::detail::winapi::DWORD_>::max)())
+                boost::winapi::DWORD_>::max)())
             amount = (std::numeric_limits<
-                boost::detail::winapi::DWORD_>::max)();
+                boost::winapi::DWORD_>::max)();
         else
             amount = static_cast<
-                boost::detail::winapi::DWORD_>(n);
-        boost::detail::winapi::DWORD_ bytesWritten;
+                boost::winapi::DWORD_>(n);
+        boost::winapi::DWORD_ bytesWritten;
         if(! ::WriteFile(h_, buffer, amount, &bytesWritten, 0))
         {
             auto const dwError = ::GetLastError();
-            if(dwError != boost::detail::winapi::ERROR_HANDLE_EOF_)
+            if(dwError != boost::winapi::ERROR_HANDLE_EOF_)
                 ec.assign(::GetLastError(), system_category());
             else
                 ec.assign(0, ec.category());

--- a/include/boost/beast/http/impl/file_body_win32.ipp
+++ b/include/boost/beast/http/impl/file_body_win32.ipp
@@ -24,7 +24,7 @@
 #include <boost/asio/windows/overlapped_ptr.hpp>
 #include <boost/make_unique.hpp>
 #include <boost/smart_ptr/make_shared_array.hpp>
-#include <boost/detail/winapi/basic_types.hpp>
+#include <boost/winapi/basic_types.hpp>
 #include <algorithm>
 #include <cstring>
 
@@ -279,27 +279,27 @@ namespace detail {
 
 template<class Unsigned>
 inline
-boost::detail::winapi::DWORD_
+boost::winapi::DWORD_
 lowPart(Unsigned n)
 {
     return static_cast<
-        boost::detail::winapi::DWORD_>(
+        boost::winapi::DWORD_>(
             n & 0xffffffff);
 }
 
 template<class Unsigned>
 inline
-boost::detail::winapi::DWORD_
+boost::winapi::DWORD_
 highPart(Unsigned n, std::true_type)
 {
     return static_cast<
-        boost::detail::winapi::DWORD_>(
+        boost::winapi::DWORD_>(
             (n>>32)&0xffffffff);
 }
 
 template<class Unsigned>
 inline
-boost::detail::winapi::DWORD_
+boost::winapi::DWORD_
 highPart(Unsigned, std::false_type)
 {
     return 0;
@@ -307,7 +307,7 @@ highPart(Unsigned, std::false_type)
 
 template<class Unsigned>
 inline
-boost::detail::winapi::DWORD_
+boost::winapi::DWORD_
 highPart(Unsigned n)
 {
     return highPart(n, std::integral_constant<
@@ -416,8 +416,8 @@ operator()()
             sock_, sr_, std::move(*this));
     }
     auto& r = sr_.reader_impl();
-    boost::detail::winapi::DWORD_ const nNumberOfBytesToWrite =
-        std::min<boost::detail::winapi::DWORD_>(
+    boost::winapi::DWORD_ const nNumberOfBytesToWrite =
+        std::min<boost::winapi::DWORD_>(
             beast::detail::clamp(std::min<std::uint64_t>(
                 r.body_.last_ - r.pos_, sr_.limit())),
             2147483646);
@@ -436,12 +436,12 @@ operator()()
         0);
     auto const dwError = ::GetLastError();
     if(! bSuccess && dwError !=
-        boost::detail::winapi::ERROR_IO_PENDING_)
+        boost::winapi::ERROR_IO_PENDING_)
     {
         // VFALCO This needs review, is 0 the right number?
         // completed immediately (with error?)
         overlapped.complete(error_code{static_cast<int>(
-            boost::detail::winapi::GetLastError()),
+            boost::winapi::GetLastError()),
                 system_category()}, 0);
         return;
     }
@@ -513,8 +513,8 @@ write_some(
     r.body_.file_.seek(r.pos_, ec);
     if(ec)
         return 0;
-    boost::detail::winapi::DWORD_ const nNumberOfBytesToWrite =
-        std::min<boost::detail::winapi::DWORD_>(
+    boost::winapi::DWORD_ const nNumberOfBytesToWrite =
+        std::min<boost::winapi::DWORD_>(
             beast::detail::clamp(std::min<std::uint64_t>(
                 r.body_.last_ - r.pos_, sr.limit())),
             2147483646);
@@ -529,7 +529,7 @@ write_some(
     if(! bSuccess)
     {
         ec.assign(static_cast<int>(
-            boost::detail::winapi::GetLastError()),
+            boost::winapi::GetLastError()),
                 system_category());
         return 0;
     }

--- a/include/boost/beast/http/impl/file_body_win32.ipp
+++ b/include/boost/beast/http/impl/file_body_win32.ipp
@@ -367,10 +367,12 @@ public:
         return boost::asio::get_associated_allocator(h_);
     }
 
-    using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(sock_.get_executor())>;
+    using executor_type =
+        boost::asio::associated_executor_t<Handler, decltype(std::declval<
+            boost::asio::basic_stream_socket<Protocol>&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             h_, sock_.get_executor());

--- a/include/boost/beast/http/impl/file_body_win32.ipp
+++ b/include/boost/beast/http/impl/file_body_win32.ipp
@@ -471,8 +471,6 @@ operator()(
             sr_.next(ec, null_lambda{});
             BOOST_ASSERT(! ec);
             BOOST_ASSERT(sr_.is_done());
-            if(! sr_.keep_alive())
-                ec = error::end_of_stream;
         }
     }
     h_(ec, bytes_transferred_);
@@ -544,8 +542,6 @@ write_some(
         sr.next(ec, detail::null_lambda{});
         BOOST_ASSERT(! ec);
         BOOST_ASSERT(sr.is_done());
-        if(! sr.keep_alive())
-            ec = error::end_of_stream;
     }
     return nNumberOfBytesToWrite;
 }

--- a/include/boost/beast/http/impl/read.ipp
+++ b/include/boost/beast/http/impl/read.ipp
@@ -72,9 +72,10 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(s_.get_executor())>;
+        Handler, decltype(std::declval<Stream&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             h_, s_.get_executor());
@@ -234,9 +235,10 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(s_.get_executor())>;
+        Handler, decltype(std::declval<Stream&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             h_, s_.get_executor());
@@ -356,9 +358,10 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(d_->s.get_executor())>;
+        Handler, decltype(std::declval<Stream&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             d_.handler(), d_->s.get_executor());

--- a/include/boost/beast/http/impl/write.ipp
+++ b/include/boost/beast/http/impl/write.ipp
@@ -88,9 +88,10 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(s_.get_executor())>;
+        Handler, decltype(std::declval<Stream&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             h_, s_.get_executor());
@@ -223,9 +224,10 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(s_.get_executor())>;
+        Handler, decltype(std::declval<Stream&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             h_, s_.get_executor());
@@ -335,9 +337,10 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(d_->s.get_executor())>;
+        Handler, decltype(std::declval<Stream&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             d_.handler(), d_->s.get_executor());

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 125
+#define BOOST_BEAST_VERSION 126
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/detail/pausation.hpp
+++ b/include/boost/beast/websocket/detail/pausation.hpp
@@ -162,12 +162,14 @@ public:
 
     pausation(pausation&& other)
     {
+        boost::ignore_unused(other);
         BOOST_ASSERT(! other.base_);
     }
 
     pausation&
     operator=(pausation&& other)
     {
+        boost::ignore_unused(other);
         BOOST_ASSERT(! base_);
         BOOST_ASSERT(! other.base_);
         return *this;

--- a/include/boost/beast/websocket/impl/accept.ipp
+++ b/include/boost/beast/websocket/impl/accept.ipp
@@ -78,9 +78,10 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(d_->ws.get_executor())>;
+        Handler, decltype(std::declval<stream<NextLayer>&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             d_.handler(), d_->ws.get_executor());
@@ -173,9 +174,10 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(d_->ws.get_executor())>;
+        Handler, decltype(std::declval<stream<NextLayer>&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             d_.handler(), d_->ws.get_executor());

--- a/include/boost/beast/websocket/impl/close.ipp
+++ b/include/boost/beast/websocket/impl/close.ipp
@@ -85,9 +85,10 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(d_->ws.get_executor())>;
+        Handler, decltype(std::declval<stream<NextLayer>&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             d_.handler(), d_->ws.get_executor());

--- a/include/boost/beast/websocket/impl/handshake.ipp
+++ b/include/boost/beast/websocket/impl/handshake.ipp
@@ -85,9 +85,10 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(d_->ws.get_executor())>;
+        Handler, decltype(std::declval<stream<NextLayer>&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             d_.handler(), d_->ws.get_executor());

--- a/include/boost/beast/websocket/impl/ping.ipp
+++ b/include/boost/beast/websocket/impl/ping.ipp
@@ -85,9 +85,10 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(d_->ws.get_executor())>;
+        Handler, decltype(std::declval<stream<NextLayer>&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             d_.handler(), d_->ws.get_executor());

--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -85,9 +85,10 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(ws_.get_executor())>;
+        Handler, decltype(std::declval<stream<NextLayer>&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             h_, ws_.get_executor());
@@ -707,9 +708,10 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(ws_.get_executor())>;
+        Handler, decltype(std::declval<stream<NextLayer>&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             h_, ws_.get_executor());

--- a/include/boost/beast/websocket/impl/teardown.ipp
+++ b/include/boost/beast/websocket/impl/teardown.ipp
@@ -60,9 +60,10 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(s_.get_executor())>;
+        Handler, decltype(std::declval<socket_type&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             h_, s_.get_executor());

--- a/include/boost/beast/websocket/impl/write.ipp
+++ b/include/boost/beast/websocket/impl/write.ipp
@@ -81,9 +81,10 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(ws_.get_executor())>;
+        Handler, decltype(std::declval<stream<NextLayer>&>().get_executor())>;
 
-    executor_type get_executor() const noexcept
+    executor_type
+    get_executor() const noexcept
     {
         return boost::asio::get_associated_executor(
             h_, ws_.get_executor());

--- a/include/boost/beast/websocket/stream.hpp
+++ b/include/boost/beast/websocket/stream.hpp
@@ -245,6 +245,9 @@ public:
     using lowest_layer_type =
         typename get_lowest_layer<next_layer_type>::type;
 
+    /// The type of the executor associated with the object.
+    using executor_type = typename next_layer_type::executor_type;
+
     /** Destructor
 
         Destroys the stream and all associated resources.
@@ -293,25 +296,13 @@ public:
 
     /** Get the executor associated with the object.
     
-        This function may be used to obtain the executor object that the stream
-        uses to dispatch handlers for asynchronous operations.
+        This function may be used to obtain the executor object that the
+        stream uses to dispatch handlers for asynchronous operations.
 
         @return A copy of the executor that stream will use to dispatch handlers.
-
-        @note This function participates in overload resolution only if
-        `NextLayer` has a member function named `get_executor`.
     */
-#if BOOST_BEAST_DOXYGEN
-    implementation_defined
-#else
-    template<
-        class T = next_layer_type,
-        class = typename std::enable_if<
-            has_get_executor<next_layer_type>::value>::type>
-    auto
-#endif
-    get_executor() noexcept ->
-        decltype(std::declval<T&>().get_executor())
+    executor_type
+    get_executor() noexcept
     {
         return stream_.get_executor();
     }

--- a/subtree/unit_test/include/boost/beast/unit_test/dstream.hpp
+++ b/subtree/unit_test/include/boost/beast/unit_test/dstream.hpp
@@ -18,8 +18,8 @@
 #include <string>
 
 #ifdef BOOST_WINDOWS
-#include <boost/detail/winapi/basic_types.hpp>
-#include <boost/detail/winapi/debugapi.hpp>
+#include <boost/winapi/basic_types.hpp>
+#include <boost/winapi/debugapi.hpp>
 #endif
 
 namespace boost {
@@ -45,14 +45,14 @@ class dstream_buf
     void write(char const* s)
     {
         if(dbg_)
-            boost::detail::winapi::OutputDebugStringA(s);
+            boost::winapi::OutputDebugStringA(s);
         os_ << s;
     }
 
     void write(wchar_t const* s)
     {
         if(dbg_)
-            boost::detail::winapi::OutputDebugStringW(s);
+            boost::winapi::OutputDebugStringW(s);
         os_ << s;
     }
 
@@ -60,7 +60,7 @@ public:
     explicit
     dstream_buf(ostream& os)
         : os_(os)
-        , dbg_(boost::detail::winapi::IsDebuggerPresent() != 0)
+        , dbg_(boost::winapi::IsDebuggerPresent() != 0)
     {
     }
 

--- a/test/bench/wsload/wsload.cpp
+++ b/test/bench/wsload/wsload.cpp
@@ -299,7 +299,7 @@ main(int argc, char** argv)
         auto const messages= static_cast<std::size_t>(std::atoi(argv[4]));
         auto const workers = static_cast<std::size_t>(std::atoi(argv[5]));
         auto const threads = static_cast<std::size_t>(std::atoi(argv[6]));
-        auto const deflate = static_cast<bool>(std::atoi(argv[7]));
+        auto const deflate = std::atoi(argv[7]) != 0;
         auto const work = (messages + workers - 1) / workers;
         test_buffer tb;
         for(auto i = trials; i != 0; --i)

--- a/test/doc/http_snippets.cpp
+++ b/test/doc/http_snippets.cpp
@@ -116,11 +116,10 @@ void fxx() {
     res.result(status::ok);
     res.set(field::server, "Beast");
     res.body() = "Hello, world!";
+    res.prepare_payload();
 
     error_code ec;
     write(sock, res, ec);
-    if(ec == error::end_of_stream)
-        sock.close();
 //]
 
 //[http_snippet_8


### PR DESCRIPTION
* Add CppCon2017 presentation link
* Update README.md
* Update stream write documentation for end of stream changes
* Tidy up unused variable warnings
* Don't return end_of_stream on win32 file body writes
* Fix doc typo
* Fix shadowing in session_alloc
* Fix executor type compilation
* Add Travis tests with the default compilers
* Update Boost.WinAPI usage to the new location and namespace.
* Fix buffered_read_stream async_read_some signature
