### PR TITLE
Size checking of example programs

### DIFF
--- a/tools/build-and-test.sh
+++ b/tools/build-and-test.sh
@@ -111,12 +111,14 @@ function build_bjam ()
       -j${JOBS}
   else
     b2 \
-      cxxflags=-std=c++11 \
+      cxxflags="-std=c++11 -flto" \
       libs/beast/test//fat-tests \
       libs/beast/example \
       toolset=$TOOLSET \
       variant=$VARIANT \
+      linkflags=-flto \
       -j${JOBS}
+    ./libs/beast/tools/check-sizes.sh
   fi
 }
 

--- a/tools/check-sizes.sh
+++ b/tools/check-sizes.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+
+(git clone https://github.com/google/bloaty.git \
+    && cd bloaty \
+    && mkdir build \
+    && cd build \
+    && cmake .. \
+    && make -j${JOBS}) || exit $?
+
+BLOATY=bloaty/build/bloaty
+
+find $BOOST_ROOT/bin.v2/libs/beast/example -executable -type f | while read file; do
+    printf "\n----------------------------------------------------------\n"
+    echo "Top 30 largest symbols in example '$file'"
+    $BLOATY $file -d cppsymbols -s vm -n 30
+    echo "File stats:"
+    size $file
+    stripped_file=$file'-stripped'
+    cp $file $stripped_file
+    strip $stripped_file
+    echo "Total binary size(with symbols)"
+    stat --printf="%s\n" $file
+    echo "Total binary size(stripped)"
+    stat --printf="%s\n" $stripped_file
+    rm $stripped_file
+done


### PR DESCRIPTION
Added a script which checks the example programs binary size (both with symbols and stripped) and outputs the statistics of symbols which contribute the most to the size of the stripped binary.

Resolves: #850 