### PR TITLE
Revisit boost library min/max guidance

### DIFF
--- a/include/boost/beast/core/flat_static_buffer.hpp
+++ b/include/boost/beast/core/flat_static_buffer.hpp
@@ -124,7 +124,7 @@ public:
     void
     commit(std::size_t n)
     {
-        out_ += std::min<std::size_t>(n, last_ - out_);
+        out_ += (std::min<std::size_t>)(n, last_ - out_);
     }
 
     /// Remove bytes from the input sequence.

--- a/include/boost/beast/core/impl/flat_buffer.ipp
+++ b/include/boost/beast/core/impl/flat_buffer.ipp
@@ -263,9 +263,9 @@ prepare(std::size_t n) ->
         BOOST_THROW_EXCEPTION(std::length_error{
             "basic_flat_buffer overflow"});
     // allocate a new buffer
-    auto const new_size = std::min<std::size_t>(
+    auto const new_size = (std::min<std::size_t>)(
         max_,
-        std::max<std::size_t>(2 * len, len + n));
+        (std::max<std::size_t>)(2 * len, len + n));
     auto const p = alloc_traits::allocate(
         this->member(), new_size);
     if(begin_)

--- a/include/boost/beast/core/impl/multi_buffer.ipp
+++ b/include/boost/beast/core/impl/multi_buffer.ipp
@@ -700,9 +700,9 @@ prepare(size_type n) ->
         {
             static auto const growth_factor = 2.0f;
             auto const size =
-                std::min<std::size_t>(
+                (std::min<std::size_t>)(
                     max_ - total,
-                    std::max<std::size_t>({
+                    (std::max<std::size_t>)({
                         static_cast<std::size_t>(
                             in_size_ * growth_factor - in_size_),
                         512,

--- a/include/boost/beast/core/impl/read_size.ipp
+++ b/include/boost/beast/core/impl/read_size.ipp
@@ -45,9 +45,9 @@ read_size(DynamicBuffer& buffer,
     auto const size = buffer.size();
     auto const limit = buffer.max_size() - size;
     BOOST_ASSERT(size <= buffer.max_size());
-    return std::min<std::size_t>(
-        std::max<std::size_t>(512, buffer.capacity() - size),
-        std::min<std::size_t>(max_size, limit));
+    return (std::min<std::size_t>)(
+        (std::max<std::size_t>)(512, buffer.capacity() - size),
+        (std::min<std::size_t>)(max_size, limit));
 }
 
 } // detail

--- a/include/boost/beast/http/impl/basic_parser.ipp
+++ b/include/boost/beast/http/impl/basic_parser.ipp
@@ -167,7 +167,7 @@ loop:
         maybe_need_more(p, n, ec);
         if(ec)
             goto done;
-        parse_start_line(p, p + std::min<std::size_t>(
+        parse_start_line(p, p + (std::min<std::size_t>)(
             header_limit_, n), ec, is_request{});
         if(ec)
         {
@@ -198,7 +198,7 @@ loop:
         maybe_need_more(p, n, ec);
         if(ec)
             goto done;
-        parse_fields(p, p + std::min<std::size_t>(
+        parse_fields(p, p + (std::min<std::size_t>)(
             header_limit_, n), ec);
         if(ec)
         {

--- a/include/boost/beast/http/impl/file_body_win32.ipp
+++ b/include/boost/beast/http/impl/file_body_win32.ipp
@@ -417,8 +417,8 @@ operator()()
     }
     auto& r = sr_.reader_impl();
     boost::winapi::DWORD_ const nNumberOfBytesToWrite =
-        std::min<boost::winapi::DWORD_>(
-            beast::detail::clamp(std::min<std::uint64_t>(
+        (std::min<boost::winapi::DWORD_>)(
+            beast::detail::clamp((std::min<std::uint64_t>)(
                 r.body_.last_ - r.pos_, sr_.limit())),
             2147483646);
     boost::asio::windows::overlapped_ptr overlapped{
@@ -514,8 +514,8 @@ write_some(
     if(ec)
         return 0;
     boost::winapi::DWORD_ const nNumberOfBytesToWrite =
-        std::min<boost::winapi::DWORD_>(
-            beast::detail::clamp(std::min<std::uint64_t>(
+        (std::min<boost::winapi::DWORD_>)(
+            beast::detail::clamp((std::min<std::uint64_t>)(
                 r.body_.last_ - r.pos_, sr.limit())),
             2147483646);
     auto const bSuccess = ::TransmitFile(

--- a/include/boost/beast/websocket/detail/pmd_extension.hpp
+++ b/include/boost/beast/websocket/detail/pmd_extension.hpp
@@ -277,7 +277,7 @@ pmd_negotiate(
         s += "; client_no_context_takeover";
 
     if(offer.server_max_window_bits != 0)
-        config.server_max_window_bits = std::min(
+        config.server_max_window_bits = (std::min)(
             offer.server_max_window_bits,
                 o.server_max_window_bits);
     else
@@ -326,7 +326,7 @@ pmd_negotiate(
 
     default:
         // extension parameter has value in [8..15]
-        config.client_max_window_bits = std::min(
+        config.client_max_window_bits = (std::min)(
             o.client_max_window_bits,
                 offer.client_max_window_bits);
         s += "; client_max_window_bits=";


### PR DESCRIPTION
Currently, builds on Windows may fail if `Windows.h` is included before `beast` headers due to infamous `min` and `max` macros clashes with their `std` counterparts. To reproduce, just include `Windows.h` before `beast` headers in `beast\example\websocket\server\async\websocket_server_async.cpp` example. Compilation will fail with:
```
1>c:\dev\boost\boost\beast\websocket\detail\pmd_extension.hpp(280): error C2062: type 'unknown-type' unexpected
1>c:\dev\boost\boost\beast\websocket\detail\pmd_extension.hpp(280): error C2059: syntax error: ')'
1>c:\dev\boost\boost\beast\websocket\detail\pmd_extension.hpp(329): error C2589: '(': illegal token on right side of '::'
1>c:\dev\boost\boost\beast\websocket\detail\pmd_extension.hpp(329): error C2062: type 'unknown-type' unexpected
1>c:\dev\boost\boost\beast\websocket\detail\pmd_extension.hpp(329): error C2059: syntax error: ')'
```
Looks like not all occurrences of `std::min`/`std::max` has been fixed in #170 or maybe it's just a new code. This PR revisits and fixes the rest of them.