### PR TITLE
fix async_read_some() completion signature for yield_context

### DIFF
--- a/include/boost/beast/http/impl/read.ipp
+++ b/include/boost/beast/http/impl/read.ipp
@@ -536,7 +536,8 @@ async_read_some(
         boost::asio::is_dynamic_buffer<DynamicBuffer>::value,
         "DynamicBuffer requirements not met");
     BOOST_ASSERT(! parser.is_done());
-    boost::asio::async_completion<ReadHandler, void(error_code)> init{handler};
+    boost::asio::async_completion<ReadHandler,
+        void(error_code, std::size_t)> init{handler};
     detail::read_some_op<AsyncReadStream,
         DynamicBuffer, isRequest, Derived, BOOST_ASIO_HANDLER_TYPE(
             ReadHandler, void(error_code, std::size_t))>{

--- a/test/beast/http/read.cpp
+++ b/test/beast/http/read.cpp
@@ -311,6 +311,25 @@ public:
                 break;
         }
         BEAST_EXPECT(n < limit);
+
+        for(n = 0; n < limit; ++n)
+        {
+            test::fail_counter fc{n};
+            test::stream c{ioc_, fc,
+                "GET / HTTP/1.1\r\n"
+                "Host: localhost\r\n"
+                "User-Agent: test\r\n"
+                "Content-Length: 0\r\n"
+                "\r\n"
+            };
+            request_parser<dynamic_body> m;
+            error_code ec = test::error::fail_error;
+            multi_buffer b;
+            async_read_some(c, b, m, do_yield[ec]);
+            if(! ec)
+                break;
+        }
+        BEAST_EXPECT(n < limit);
     }
 
     void


### PR DESCRIPTION
this adds a test case that calls async_read_some() with a yield_context. the test fails to compile on the return statement of async_read_some():
```
 libs/beast/test/beast/http/read.cpp:328:50:   required from here
./boost/beast/http/impl/read.ipp:544:28: error: void value not ignored as it ought to be
     return init.result.get();
```
full error message here: https://pastebin.com/raw/Xfqx8kKR

the async_completion in async_read_some() is just missing ReadHandler's size_t argument in its signature