### PR TITLE
Fix UB in buffers_cat_view

### DIFF
--- a/include/boost/beast/core/detail/type_traits.hpp
+++ b/include/boost/beast/core/detail/type_traits.hpp
@@ -346,6 +346,12 @@ buffers_range(Buffers const& buffers)
     return buffers_range_adapter<Buffers>{buffers};
 }
 
+template<typename... Ts>
+using aligned_union_t = typename std::aligned_storage<
+        max_sizeof<Ts...>(),
+        max_alignof<Ts...>()
+    >::type;
+
 } // detail
 } // beast
 } // boost

--- a/include/boost/beast/core/detail/variant.hpp
+++ b/include/boost/beast/core/detail/variant.hpp
@@ -31,10 +31,7 @@ namespace detail {
 template<class... TN>
 class variant
 {
-    typename std::aligned_storage<
-        max_sizeof<TN...>(),
-        max_alignof<TN...>()
-    >::type buf_;
+    detail::aligned_union_t<TN...> buf_;
     unsigned char i_ = 0;
 
     template<std::size_t I>

--- a/include/boost/beast/core/impl/buffers_cat.ipp
+++ b/include/boost/beast/core/impl/buffers_cat.ipp
@@ -30,8 +30,8 @@ class buffers_cat_view<Bn...>::const_iterator
     static_assert(sizeof...(Bn) > 0,  "Must have at least 1 buffer sequence.");
     std::size_t n_;
     std::tuple<Bn...> const* bn_;
-    typename std::aligned_union<1, typename detail::buffer_sequence_iterator<
-        Bn>::type...>::type buf_;
+    detail::aligned_union_t<typename detail::buffer_sequence_iterator<
+        Bn>::type...> buf_;
 
     friend class buffers_cat_view<Bn...>;
 


### PR DESCRIPTION
- `std::array<char, N>` is not a valid type for in-place polymorphic storage, due to the fact that it might not have the required alignment.
- Removed unnecessary casts to `void*` in `iter()`.