### PR TITLE
Support for noncopyable completion handlers (HTTP Read/Write)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ matrix:
         - TOOLSET=gcc
         - COMPILER=g++-6
         - CXXSTD=c++11
+      before_install:
+        - pip install --user https://github.com/codecov/codecov-python/archive/master.zip
       addons:
         apt:
           packages:
@@ -117,9 +119,6 @@ matrix:
         - CXXSTD=c++14
 
     # OSX
-
-before_install: &base_before_install
-  - pip install --user https://github.com/codecov/codecov-python/archive/master.zip
 
 install:
   - export BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 148:
 * Handle invalid deflate frames
 * Fix CMakeLists.txt variable
 * Protect calls from macros
+* Install codecov on codecov CI targets only
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 148:
+
+* built-in r-value return values can't be assigned
+
+--------------------------------------------------------------------------------
+
 Version 147:
 
 * Don't use boost::string_ref

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 148:
 * Tidy up ssl_stream special members
 * Update reports for hybrid assessment
 * Handle invalid deflate frames
+* Fix CMakeLists.txt variable
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 148:
 
 * built-in r-value return values can't be assigned
+* Tidy up ssl_stream special members
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Version 148:
 * Fix CMakeLists.txt variable
 * Protect calls from macros
 * Install codecov on codecov CI targets only
+* pausation always allocates
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 148:
 
 * built-in r-value return values can't be assigned
 * Tidy up ssl_stream special members
+* Update reports for hybrid assessment
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 148:
 * built-in r-value return values can't be assigned
 * Tidy up ssl_stream special members
 * Update reports for hybrid assessment
+* Handle invalid deflate frames
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 148:
 * Update reports for hybrid assessment
 * Handle invalid deflate frames
 * Fix CMakeLists.txt variable
+* Protect calls from macros
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.5.1)
 
-project (Beast VERSION 147)
+project (Beast VERSION 148)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/doc/qbk/01_intro.qbk
+++ b/doc/qbk/01_intro.qbk
@@ -101,7 +101,32 @@ for tirelessly answering questions on
 [section Reports]
 [block'''<?dbhtml stop-chunking?>''']
 
-[section WebSocket]
+[section Security Review (Bishop Fox)]
+
+Since 2005, [@https://www.bishopfox.com/ Bishop Fox] has provided
+security consulting services to the Fortune 1000, high-tech startups,
+and financial institutions worldwide.
+Beast engaged Bishop Fox to assess the security of the Boost C++ Beast HTTP/S
+networking library. The following report details the findings identified during
+the course of the engagement, which started on September 11, 2017.
+
+The assessment team conducted a hybrid application assessment of the Beast
+library. Bishop Fox’s hybrid application assessment methodology leverages
+the real-world attack techniques of application penetration testing in
+combination with targeted source code review to thoroughly identify
+application security vulnerabilities. These fullknowledge assessments
+begin with automated scans of the deployed application and source code.
+Next, analyses of the scan results are combined with manual review to
+thoroughly identify potential application security vulnerabilities. In
+addition, the team performs a review of the application architecture and
+business logic to locate any design-level issues. Finally, the team performs
+manual exploitation and review of these issues to validate the findings.
+
+[@https://vinniefalco.github.io/BeastAssets/Beast%20-%20Hybrid%20Application%20Assessment%202017%20-%20Assessment%20Report%20-%2020171114.pdf [*Beast - Hybrid Application Assessment 2017 - Assessment Report - 20171114]]
+
+[endsect]
+
+[section WebSocket (Autobahn|Testsuite)]
 
 The
 [@https://github.com/crossbario/autobahn-testsuite Autobahn WebSockets Testsuite]
@@ -114,7 +139,7 @@ verification and performance and limits testing.
 Autobahn|Testsuite is used across the industry and
 contains over 500 test cases.
 
-[@https://vinniefalco.github.io/boost/beast/reports/autobahn/index.html [*Autobahn|Testsuite WebSocket Results]]
+[@https://vinniefalco.github.io/BeastAssets/reports/autobahn/index.html [*Autobahn|Testsuite WebSocket Results]]
 
 [warning
     Version 0.7.6 of Autobahn|Testsuite contains a

--- a/example/common/detect_ssl.hpp
+++ b/example/common/detect_ssl.hpp
@@ -353,7 +353,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(handler_);
+        return (boost::asio::get_associated_allocator)(handler_);
     }
 
     // Executor hook. This is Asio's system for customizing the
@@ -367,7 +367,7 @@ public:
 
     executor_type get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(handler_, stream_.get_executor());
+        return (boost::asio::get_associated_executor)(handler_, stream_.get_executor());
     }
 
     // Determines if the next asynchronous operation represents a

--- a/example/echo-op/echo_op.cpp
+++ b/example/echo-op/echo_op.cpp
@@ -154,7 +154,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(p_.handler());
+        return (boost::asio::get_associated_allocator)(p_.handler());
     }
 
     // Executor hook. This is Asio's system for customizing the
@@ -168,7 +168,7 @@ public:
 
     executor_type get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             p_.handler(), p_->stream.get_executor());
     }
 

--- a/include/boost/beast/core/detail/bind_handler.hpp
+++ b/include/boost/beast/core/detail/bind_handler.hpp
@@ -123,7 +123,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     friend

--- a/include/boost/beast/core/impl/buffered_read_stream.ipp
+++ b/include/boost/beast/core/impl/buffered_read_stream.ipp
@@ -55,7 +55,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type =
@@ -65,7 +65,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 

--- a/include/boost/beast/core/impl/buffered_read_stream.ipp
+++ b/include/boost/beast/core/impl/buffered_read_stream.ipp
@@ -37,7 +37,7 @@ class buffered_read_stream<
 
 public:
     read_some_op(read_some_op&&) = default;
-    read_some_op(read_some_op const&) = default;
+    read_some_op(read_some_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     read_some_op(DeducedHandler&& h,
@@ -237,7 +237,7 @@ async_read_some(
         void(error_code, std::size_t)> init{handler};
     read_some_op<MutableBufferSequence, BOOST_ASIO_HANDLER_TYPE(
         ReadHandler, void(error_code, std::size_t))>{
-            init.completion_handler, *this, buffers}(
+            std::move(init.completion_handler), *this, buffers}(
                 error_code{}, 0);
     return init.result.get();
 }

--- a/include/boost/beast/core/type_traits.hpp
+++ b/include/boost/beast/core/type_traits.hpp
@@ -52,7 +52,7 @@ template<class T, class Signature>
 using is_completion_handler = std::integral_constant<bool, ...>;
 #else
 using is_completion_handler = std::integral_constant<bool,
-    std::is_copy_constructible<typename std::decay<T>::type>::value &&
+    std::is_move_constructible<typename std::decay<T>::type>::value &&
     detail::is_invocable<T, Signature>::value>;
 #endif
 

--- a/include/boost/beast/http/fields.hpp
+++ b/include/boost/beast/http/fields.hpp
@@ -102,7 +102,7 @@ public:
         value_type& operator=(value_type const&) = delete;
 
         /// Returns the field enum, which can be @ref field::unknown
-        field const
+        field
         name() const;
 
         /// Returns the field name as a string

--- a/include/boost/beast/http/impl/fields.ipp
+++ b/include/boost/beast/http/impl/fields.ipp
@@ -291,7 +291,7 @@ value_type(field name,
 
 template<class Allocator>
 inline
-field const
+field
 basic_fields<Allocator>::
 value_type::
 name() const

--- a/include/boost/beast/http/impl/file_body_win32.ipp
+++ b/include/boost/beast/http/impl/file_body_win32.ipp
@@ -344,7 +344,8 @@ class write_some_win32_op
 
 public:
     write_some_win32_op(write_some_win32_op&&) = default;
-    write_some_win32_op(write_some_win32_op const&) = default;
+    write_some_win32_op(write_some_win32_op const&) = delete;
+    write_some_win32_op& operator=(write_some_win32_op const&) = delete;
 
     template<class DeducedHandler>
     write_some_win32_op(
@@ -569,7 +570,7 @@ async_write_some(
         BOOST_ASIO_HANDLER_TYPE(WriteHandler,
             void(error_code, std::size_t)),
         isRequest, Fields>{
-            init.completion_handler, sock, sr}();
+            std::move(init.completion_handler), sock, sr}();
     return init.result.get();
 }
 

--- a/include/boost/beast/http/impl/file_body_win32.ipp
+++ b/include/boost/beast/http/impl/file_body_win32.ipp
@@ -364,7 +364,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type =
@@ -374,7 +374,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, sock_.get_executor());
     }
 

--- a/include/boost/beast/http/impl/read.ipp
+++ b/include/boost/beast/http/impl/read.ipp
@@ -50,7 +50,7 @@ class read_some_op
 
 public:
     read_some_op(read_some_op&&) = default;
-    read_some_op(read_some_op const&) = default;
+    read_some_op(read_some_op const&) = delete;
 
     template<class DeducedHandler>
     read_some_op(DeducedHandler&& h, Stream& s,
@@ -208,7 +208,7 @@ class read_op
 
 public:
     read_op(read_op&&) = default;
-    read_op(read_op const&) = default;
+    read_op(read_op const&) = delete;
 
     template<class DeducedHandler>
     read_op(DeducedHandler&& h, Stream& s,
@@ -331,7 +331,7 @@ class read_msg_op
 
 public:
     read_msg_op(read_msg_op&&) = default;
-    read_msg_op(read_msg_op const&) = default;
+    read_msg_op(read_msg_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     read_msg_op(DeducedHandler&& h, Stream& s, Args&&... args)
@@ -531,7 +531,7 @@ async_read_some(
     detail::read_some_op<AsyncReadStream,
         DynamicBuffer, isRequest, Derived, BOOST_ASIO_HANDLER_TYPE(
             ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler, stream, buffer, parser}(
+                std::move(init.completion_handler), stream, buffer, parser}(
                     {}, 0, false);
     return init.result.get();
 }
@@ -619,8 +619,8 @@ async_read_header(
     detail::read_op<AsyncReadStream, DynamicBuffer,
         isRequest, Derived, detail::parser_is_header_done,
             BOOST_ASIO_HANDLER_TYPE(ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler, stream, buffer, parser}(
-                    {}, 0, false);
+                std::move(init.completion_handler), stream,
+                buffer, parser}({}, 0, false);
     return init.result.get();
 }
 
@@ -708,7 +708,7 @@ async_read(
     detail::read_op<AsyncReadStream, DynamicBuffer,
         isRequest, Derived, detail::parser_is_done,
             BOOST_ASIO_HANDLER_TYPE(ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler, stream, buffer, parser}(
+                std::move(init.completion_handler), stream, buffer, parser}(
                     {}, 0, false);
     return init.result.get();
 }
@@ -803,7 +803,7 @@ async_read(
         isRequest, Body, Allocator,
         BOOST_ASIO_HANDLER_TYPE(
             ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler, stream, buffer, msg}(
+                std::move(init.completion_handler), stream, buffer, msg}(
                     {}, 0, false);
     return init.result.get();
 }

--- a/include/boost/beast/http/impl/read.ipp
+++ b/include/boost/beast/http/impl/read.ipp
@@ -68,7 +68,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -77,7 +77,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 
@@ -227,7 +227,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -236,7 +236,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 
@@ -346,7 +346,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -355,7 +355,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->s.get_executor());
     }
 

--- a/include/boost/beast/http/impl/write.ipp
+++ b/include/boost/beast/http/impl/write.ipp
@@ -67,7 +67,7 @@ class write_some_op
 
 public:
     write_some_op(write_some_op&&) = default;
-    write_some_op(write_some_op const&) = default;
+    write_some_op(write_some_op const&) = delete;
 
     template<class DeducedHandler>
     write_some_op(DeducedHandler&& h, Stream& s,
@@ -203,7 +203,7 @@ class write_op
 
 public:
     write_op(write_op&&) = default;
-    write_op(write_op const&) = default;
+    write_op(write_op const&) = delete;
 
     template<class DeducedHandler>
     write_op(DeducedHandler&& h, Stream& s,
@@ -318,7 +318,7 @@ class write_msg_op
 
 public:
     write_msg_op(write_msg_op&&) = default;
-    write_msg_op(write_msg_op const&) = default;
+    write_msg_op(write_msg_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     write_msg_op(DeducedHandler&& h, Stream& s, Args&&... args)
@@ -479,7 +479,7 @@ async_write_some_impl(
         BOOST_ASIO_HANDLER_TYPE(WriteHandler,
             void(error_code, std::size_t)),
         isRequest, Body, Fields>{
-            init.completion_handler, stream, sr}();
+            std::move(init.completion_handler), stream, sr}();
     return init.result.get();
 }
 
@@ -638,7 +638,7 @@ async_write_header(
             void(error_code, std::size_t)),
         detail::serializer_is_header_done,
         isRequest, Body, Fields>{
-        init.completion_handler, stream, sr}();
+        std::move(init.completion_handler), stream, sr}();
     return init.result.get();
 }
 
@@ -715,7 +715,7 @@ async_write(
             void(error_code, std::size_t)),
         detail::serializer_is_done,
         isRequest, Body, Fields>{
-            init.completion_handler, stream, sr}();
+            std::move(init.completion_handler), stream, sr}();
     return init.result.get();
 }
 
@@ -788,7 +788,7 @@ async_write(
         BOOST_ASIO_HANDLER_TYPE(WriteHandler,
             void(error_code, std::size_t)),
         isRequest, Body, Fields>{
-            init.completion_handler, stream, msg}();
+            std::move(init.completion_handler), stream, msg}();
     return init.result.get();
 }
 

--- a/include/boost/beast/http/impl/write.ipp
+++ b/include/boost/beast/http/impl/write.ipp
@@ -84,7 +84,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -93,7 +93,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 
@@ -220,7 +220,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -229,7 +229,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 
@@ -333,7 +333,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -342,7 +342,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->s.get_executor());
     }
 

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 147
+#define BOOST_BEAST_VERSION 148
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/detail/pausation.hpp
+++ b/include/boost/beast/websocket/detail/pausation.hpp
@@ -10,13 +10,10 @@
 #ifndef BOOST_BEAST_WEBSOCKET_DETAIL_PAUSATION_HPP
 #define BOOST_BEAST_WEBSOCKET_DETAIL_PAUSATION_HPP
 
-#include <boost/beast/core/handler_ptr.hpp>
+#include <boost/beast/core/detail/allocator.hpp>
 #include <boost/asio/associated_allocator.hpp>
-#include <boost/asio/coroutine.hpp>
 #include <boost/assert.hpp>
-#include <array>
 #include <memory>
-#include <new>
 #include <utility>
 
 namespace boost {
@@ -30,124 +27,59 @@ namespace detail {
 //
 class pausation
 {
-    struct base
+    struct handler
     {
-        base() = default;
-        base(base &&) = delete;
-        base(base const&) = delete;
-        virtual ~base() = default;
-        virtual void operator()() = 0;
+        handler() = default;
+        handler(handler &&) = delete;
+        handler(handler const&) = delete;
+        virtual ~handler() = default;
+        virtual void destroy() = 0;
+        virtual void invoke() = 0;
     };
 
-    template<class F>
-    struct holder : base
+    template<class Handler>
+    class impl : public handler
     {
-        F f;
-
-        holder(holder&&) = default;
-
-        template<class U>
-        explicit
-        holder(U&& u)
-            : f(std::forward<U>(u))
-        {
-        }
-
-        void
-        operator()() override
-        {
-            F f_(std::move(f));
-            this->~holder();
-            // invocation of f_() can
-            // assign a new object to *this.
-            f_();
-        }
-    };
-
-    struct exemplar : boost::asio::coroutine
-    {
-        struct H
-        {
-            void operator()();
-        };
-
-        struct T
-        {
-            using handler_type = H;
-        };
-
-        handler_ptr<T, H> hp;
-
-        void operator()();
-    };
-
-    template<class Op>
-    class saved_op
-    {
-        Op* op_ = nullptr;
+        Handler h_;
 
     public:
-        ~saved_op()
+        template<class DeducedHandler>
+        impl(DeducedHandler&& h)
+            : h_(std::forward<DeducedHandler>(h))
         {
-            if(op_)
-            {
-                Op op(std::move(*op_));
-                op_->~Op();
-                typename std::allocator_traits<
-                    boost::asio::associated_allocator_t<Op>>::
-                        template rebind_alloc<Op> alloc{
-                            boost::asio::get_associated_allocator(op)};
-                std::allocator_traits<
-                    decltype(alloc)>::deallocate(alloc, op_, 1);
-            }
-        }
-
-        saved_op(saved_op&& other)
-            : op_(other.op_)
-        {
-            other.op_ = nullptr;
-        }
-
-        saved_op& operator=(saved_op&& other)
-        {
-            BOOST_ASSERT(! op_);
-            op_ = other.op_;
-            other.op_ = 0;
-            return *this;
-        }
-
-        explicit
-        saved_op(Op&& op)
-        {
-            typename std::allocator_traits<
-                boost::asio::associated_allocator_t<Op>>::
-                    template rebind_alloc<Op> alloc{
-                        boost::asio::get_associated_allocator(op)};
-            auto const p = std::allocator_traits<
-                decltype(alloc)>::allocate(alloc, 1);
-            op_ = new(p) Op{std::move(op)};
         }
 
         void
-        operator()()
+        destroy() override
         {
-            BOOST_ASSERT(op_);
-            Op op{std::move(*op_)};
-            typename std::allocator_traits<
-                boost::asio::associated_allocator_t<Op>>::
-                    template rebind_alloc<Op> alloc{
-                        boost::asio::get_associated_allocator(op)};
-            std::allocator_traits<
-                decltype(alloc)>::deallocate(alloc, op_, 1);
-            op_ = nullptr;
-            op();
+            Handler h(std::move(h_));
+            typename beast::detail::allocator_traits<
+                boost::asio::associated_allocator_t<
+                    Handler>>::template rebind_alloc<impl> alloc{
+                        boost::asio::get_associated_allocator(h)};
+            beast::detail::allocator_traits<
+                decltype(alloc)>::destroy(alloc, this);
+            beast::detail::allocator_traits<
+                decltype(alloc)>::deallocate(alloc, this, 1);
+        }
+
+        void
+        invoke() override
+        {
+            Handler h(std::move(h_));
+            typename beast::detail::allocator_traits<
+                boost::asio::associated_allocator_t<
+                    Handler>>::template rebind_alloc<impl> alloc{
+                        boost::asio::get_associated_allocator(h)};
+            beast::detail::allocator_traits<
+                decltype(alloc)>::destroy(alloc, this);
+            beast::detail::allocator_traits<
+                decltype(alloc)>::deallocate(alloc, this, 1);
+            h();
         }
     };
 
-    using buf_type = char[sizeof(holder<exemplar>)];
-
-    base* base_ = nullptr;
-    alignas(holder<exemplar>) buf_type buf_;
+    handler* h_ = nullptr;
 
 public:
     pausation() = default;
@@ -156,69 +88,73 @@ public:
 
     ~pausation()
     {
-        if(base_)
-            base_->~base();
+        if(h_)
+            h_->destroy();
     }
 
     pausation(pausation&& other)
     {
         boost::ignore_unused(other);
-        BOOST_ASSERT(! other.base_);
+        BOOST_ASSERT(! other.h_);
     }
 
     pausation&
     operator=(pausation&& other)
     {
         boost::ignore_unused(other);
-        BOOST_ASSERT(! base_);
-        BOOST_ASSERT(! other.base_);
+        BOOST_ASSERT(! h_);
+        BOOST_ASSERT(! other.h_);
         return *this;
     }
 
-    template<class F>
+    template<class CompletionHandler>
     void
-    emplace(F&& f);
-
-    template<class F>
-    void
-    save(F&& f);
+    emplace(CompletionHandler&& handler);
 
     explicit
     operator bool() const
     {
-        return base_ != nullptr;
+        return h_ != nullptr;
     }
 
     bool
     maybe_invoke()
     {
-        if(base_)
+        if(h_)
         {
-            auto const basep = base_;
-            base_ = nullptr;
-            (*basep)();
+            auto const h = h_;
+            h_ = nullptr;
+            h->invoke();
             return true;
         }
         return false;
     }
 };
 
-template<class F>
+template<class CompletionHandler>
 void
-pausation::emplace(F&& f)
+pausation::emplace(CompletionHandler&& handler)
 {
-    using type = holder<typename std::decay<F>::type>;
-    static_assert(sizeof(buf_type) >= sizeof(type),
-        "buffer too small");
-    BOOST_ASSERT(! base_);
-    base_ = ::new(buf_) type{std::forward<F>(f)};
-}
-
-template<class F>
-void
-pausation::save(F&& f)
-{
-    emplace(saved_op<F>{std::move(f)});
+    BOOST_ASSERT(! h_);
+    typename beast::detail::allocator_traits<
+        boost::asio::associated_allocator_t<
+            CompletionHandler>>::template rebind_alloc<
+                impl<CompletionHandler>> alloc{
+                    boost::asio::get_associated_allocator(handler)};
+    auto const h = beast::detail::allocator_traits<
+        decltype(alloc)>::allocate(alloc, 1);
+    try
+    {
+        beast::detail::allocator_traits<
+            decltype(alloc)>::construct(alloc, h,
+                std::forward<CompletionHandler>(handler));
+        h_ = h;
+    }
+    catch(...)
+    {
+        beast::detail::allocator_traits<
+            decltype(alloc)>::deallocate(alloc, h, 1);
+    }
 }
 
 } // detail

--- a/include/boost/beast/websocket/impl/accept.ipp
+++ b/include/boost/beast/websocket/impl/accept.ipp
@@ -74,7 +74,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -83,7 +83,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->ws.get_executor());
     }
 
@@ -170,7 +170,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -179,7 +179,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->ws.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/accept.ipp
+++ b/include/boost/beast/websocket/impl/accept.ipp
@@ -58,7 +58,7 @@ class stream<NextLayer>::response_op
 
 public:
     response_op(response_op&&) = default;
-    response_op(response_op const&) = default;
+    response_op(response_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     response_op(DeducedHandler&& h,
@@ -154,7 +154,7 @@ class stream<NextLayer>::accept_op
 
 public:
     accept_op(accept_op&&) = default;
-    accept_op(accept_op const&) = default;
+    accept_op(accept_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     accept_op(DeducedHandler&& h,
@@ -545,7 +545,7 @@ async_accept(
         decltype(&default_decorate_res),
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 &default_decorate_res}({});
     return init.result.get();
@@ -574,7 +574,7 @@ async_accept_ex(
         ResponseDecorator,
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 decorator}({});
     return init.result.get();
@@ -605,7 +605,7 @@ async_accept(
         decltype(&default_decorate_res),
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 &default_decorate_res}.run(buffers);
     return init.result.get();
@@ -641,7 +641,7 @@ async_accept_ex(
         ResponseDecorator,
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 decorator}.run(buffers);
     return init.result.get();
@@ -667,7 +667,7 @@ async_accept(
     response_op<
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 req,
                 &default_decorate_res}();
@@ -699,7 +699,7 @@ async_accept_ex(
     response_op<
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 req,
                 decorator}();

--- a/include/boost/beast/websocket/impl/close.ipp
+++ b/include/boost/beast/websocket/impl/close.ipp
@@ -64,7 +64,7 @@ class stream<NextLayer>::close_op
 
 public:
     close_op(close_op&&) = default;
-    close_op(close_op const&) = default;
+    close_op(close_op const&) = delete;
 
     template<class DeducedHandler>
     close_op(
@@ -447,7 +447,7 @@ async_close(close_reason const& cr, CloseHandler&& handler)
         void(error_code)> init{handler};
     close_op<BOOST_ASIO_HANDLER_TYPE(
         CloseHandler, void(error_code))>{
-            init.completion_handler, *this, cr}(
+            std::move(init.completion_handler), *this, cr}(
                 {}, 0, false);
     return init.result.get();
 }

--- a/include/boost/beast/websocket/impl/close.ipp
+++ b/include/boost/beast/websocket/impl/close.ipp
@@ -81,7 +81,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -90,7 +90,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->ws.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/handshake.ipp
+++ b/include/boost/beast/websocket/impl/handshake.ipp
@@ -81,7 +81,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -90,7 +90,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->ws.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/handshake.ipp
+++ b/include/boost/beast/websocket/impl/handshake.ipp
@@ -65,7 +65,7 @@ class stream<NextLayer>::handshake_op
 
 public:
     handshake_op(handshake_op&&) = default;
-    handshake_op(handshake_op const&) = default;
+    handshake_op(handshake_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     handshake_op(DeducedHandler&& h,
@@ -161,7 +161,7 @@ async_handshake(string_view host,
         void(error_code)> init{handler};
     handshake_op<BOOST_ASIO_HANDLER_TYPE(
         HandshakeHandler, void(error_code))>{
-            init.completion_handler, *this, nullptr, host,
+            std::move(init.completion_handler), *this, nullptr, host,
                 target, &default_decorate_req}();
     return init.result.get();
 }
@@ -182,7 +182,7 @@ async_handshake(response_type& res,
         void(error_code)> init{handler};
     handshake_op<BOOST_ASIO_HANDLER_TYPE(
         HandshakeHandler, void(error_code))>{
-            init.completion_handler, *this, &res, host,
+            std::move(init.completion_handler), *this, &res, host,
                 target, &default_decorate_req}();
     return init.result.get();
 }
@@ -206,7 +206,7 @@ async_handshake_ex(string_view host,
         void(error_code)> init{handler};
     handshake_op<BOOST_ASIO_HANDLER_TYPE(
         HandshakeHandler, void(error_code))>{
-            init.completion_handler, *this, nullptr, host,
+            std::move(init.completion_handler), *this, nullptr, host,
                 target, decorator}();
     return init.result.get();
 }
@@ -231,7 +231,7 @@ async_handshake_ex(response_type& res,
         void(error_code)> init{handler};
     handshake_op<BOOST_ASIO_HANDLER_TYPE(
         HandshakeHandler, void(error_code))>{
-            init.completion_handler, *this, &res, host,
+            std::move(init.completion_handler), *this, &res, host,
                 target, decorator}();
     return init.result.get();
 }

--- a/include/boost/beast/websocket/impl/ping.ipp
+++ b/include/boost/beast/websocket/impl/ping.ipp
@@ -81,7 +81,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -90,7 +90,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->ws.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/ping.ipp
+++ b/include/boost/beast/websocket/impl/ping.ipp
@@ -62,7 +62,7 @@ class stream<NextLayer>::ping_op
 
 public:
     ping_op(ping_op&&) = default;
-    ping_op(ping_op const&) = default;
+    ping_op(ping_op const&) = delete;
 
     template<class DeducedHandler>
     ping_op(
@@ -241,7 +241,7 @@ async_ping(ping_data const& payload, WriteHandler&& handler)
         void(error_code)> init{handler};
     ping_op<BOOST_ASIO_HANDLER_TYPE(
         WriteHandler, void(error_code))>{
-            init.completion_handler, *this,
+            std::move(init.completion_handler), *this,
                 detail::opcode::ping, payload}();
     return init.result.get();
 }
@@ -259,7 +259,7 @@ async_pong(ping_data const& payload, WriteHandler&& handler)
         void(error_code)> init{handler};
     ping_op<BOOST_ASIO_HANDLER_TYPE(
         WriteHandler, void(error_code))>{
-            init.completion_handler, *this,
+            std::move(init.completion_handler), *this,
                 detail::opcode::pong, payload}();
     return init.result.get();
 }

--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -512,7 +512,8 @@ operator()(
                     zs.next_in = empty_block;
                     zs.avail_in = sizeof(empty_block);
                     ws_.pmd_->zi.write(zs, zlib::Flush::sync, ec);
-                    BOOST_ASSERT(! ec);
+                    if(! ws_.check_ok(ec))
+                        goto upcall;
                     // VFALCO See:
                     // https://github.com/madler/zlib/issues/280
                     BOOST_ASSERT(zs.total_out == 0);
@@ -1239,7 +1240,8 @@ loop:
                 zs.next_in = empty_block;
                 zs.avail_in = sizeof(empty_block);
                 pmd_->zi.write(zs, zlib::Flush::sync, ec);
-                BOOST_ASSERT(! ec);
+                if(! check_ok(ec))
+                    return bytes_written;
                 // VFALCO See:
                 // https://github.com/madler/zlib/issues/280
                 BOOST_ASSERT(zs.total_out == 0);

--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -81,7 +81,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -90,7 +90,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, ws_.get_executor());
     }
 
@@ -705,7 +705,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -714,7 +714,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, ws_.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -152,7 +152,7 @@ operator()(
             // Suspend
             BOOST_ASSERT(ws_.rd_block_ != tok_);
             BOOST_ASIO_CORO_YIELD
-            ws_.paused_r_rd_.save(std::move(*this));
+            ws_.paused_r_rd_.emplace(std::move(*this));
 
             // Acquire the read block
             BOOST_ASSERT(! ws_.rd_block_);
@@ -275,7 +275,7 @@ operator()(
                         // Suspend
                         BOOST_ASSERT(ws_.wr_block_ != tok_);
                         BOOST_ASIO_CORO_YIELD
-                        ws_.paused_rd_.save(std::move(*this));
+                        ws_.paused_rd_.emplace(std::move(*this));
 
                         // Acquire the write block
                         BOOST_ASSERT(! ws_.wr_block_);
@@ -581,7 +581,7 @@ operator()(
             // Suspend
             BOOST_ASSERT(ws_.wr_block_ != tok_);
             BOOST_ASIO_CORO_YIELD
-            ws_.paused_rd_.save(std::move(*this));
+            ws_.paused_rd_.emplace(std::move(*this));
 
             // Acquire the write block
             BOOST_ASSERT(! ws_.wr_block_);

--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -59,7 +59,7 @@ class stream<NextLayer>::read_some_op
 
 public:
     read_some_op(read_some_op&&) = default;
-    read_some_op(read_some_op const&) = default;
+    read_some_op(read_some_op const&) = delete;
 
     template<class DeducedHandler>
     read_some_op(
@@ -684,7 +684,7 @@ public:
         boost::asio::associated_allocator_t<Handler>;
 
     read_op(read_op&&) = default;
-    read_op(read_op const&) = default;
+    read_op(read_op const&) = delete;
 
     template<class DeducedHandler>
     read_op(
@@ -840,7 +840,7 @@ async_read(DynamicBuffer& buffer, ReadHandler&& handler)
         DynamicBuffer,
         BOOST_ASIO_HANDLER_TYPE(
             ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 buffer,
                 0,
@@ -928,7 +928,7 @@ async_read_some(
         DynamicBuffer,
         BOOST_ASIO_HANDLER_TYPE(
             ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 buffer,
                 limit,
@@ -1313,7 +1313,7 @@ async_read_some(
         void(error_code, std::size_t)> init{handler};
     read_some_op<MutableBufferSequence, BOOST_ASIO_HANDLER_TYPE(
         ReadHandler, void(error_code, std::size_t))>{
-            init.completion_handler,*this, buffers}(
+            std::move(init.completion_handler), *this, buffers}(
                 {}, 0, false);
     return init.result.get();
 }

--- a/include/boost/beast/websocket/impl/teardown.ipp
+++ b/include/boost/beast/websocket/impl/teardown.ipp
@@ -56,7 +56,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -65,7 +65,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/write.ipp
+++ b/include/boost/beast/websocket/impl/write.ipp
@@ -76,7 +76,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -85,7 +85,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, ws_.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/write.ipp
+++ b/include/boost/beast/websocket/impl/write.ipp
@@ -54,7 +54,7 @@ class stream<NextLayer>::write_some_op
 
 public:
     write_some_op(write_some_op&&) = default;
-    write_some_op(write_some_op const&) = default;
+    write_some_op(write_some_op const&) = delete;
 
     template<class DeducedHandler>
     write_some_op(
@@ -728,7 +728,7 @@ async_write_some(bool fin,
         void(error_code, std::size_t)> init{handler};
     write_some_op<ConstBufferSequence, BOOST_ASIO_HANDLER_TYPE(
         WriteHandler, void(error_code, std::size_t))>{
-            init.completion_handler, *this, fin, bs}(
+            std::move(init.completion_handler), *this, fin, bs}(
                 {}, 0, false);
     return init.result.get();
 }
@@ -784,7 +784,7 @@ async_write(
         void(error_code, std::size_t)> init{handler};
     write_some_op<ConstBufferSequence, BOOST_ASIO_HANDLER_TYPE(
         WriteHandler, void(error_code, std::size_t))>{
-            init.completion_handler, *this, true, bs}(
+            std::move(init.completion_handler), *this, true, bs}(
                 {}, 0, false);
     return init.result.get();
 }

--- a/include/boost/beast/websocket/impl/write.ipp
+++ b/include/boost/beast/websocket/impl/write.ipp
@@ -208,7 +208,7 @@ operator()(
             // Suspend
             BOOST_ASSERT(ws_.wr_block_ != tok_);
             BOOST_ASIO_CORO_YIELD
-            ws_.paused_wr_.save(std::move(*this));
+            ws_.paused_wr_.emplace(std::move(*this));
 
             // Acquire the write block
             BOOST_ASSERT(! ws_.wr_block_);

--- a/include/boost/beast/zlib/impl/error.ipp
+++ b/include/boost/beast/zlib/impl/error.ipp
@@ -69,7 +69,7 @@ public:
         switch(static_cast<error>(ev))
         {
         case error::need_buffers: return "need buffers";
-        case error::end_of_stream: return "end of stream";
+        case error::end_of_stream: return "unexpected end of deflate stream";
         case error::stream_error: return "stream error";
 
         case error::invalid_block_type: return "invalid block type";

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,7 @@ include_directories (./extern)
 include_directories (./extras/include)
 include_directories (../subtree/unit_test/include)
 
-file (GLOB_RECURSE EXTRAS_INCLUDES
+file (GLOB_RECURSE EXTRAS_FILES
     ${PROJECT_SOURCE_DIR}/test/extras/include/*.hpp
     ${PROJECT_SOURCE_DIR}/test/extras/include/*.ipp
     ${PROJECT_SOURCE_DIR}/subtree/unit_test/include/*.hpp

--- a/test/extras/include/boost/beast/test/stream.hpp
+++ b/test/extras/include/boost/beast/test/stream.hpp
@@ -488,7 +488,7 @@ async_read_some(
             return boost::asio::post(
                 in_->ioc.get_executor(),
                 bind_handler(
-                    init.completion_handler,
+                    std::move(init.completion_handler),
                     ec,
                     0));
     }
@@ -506,7 +506,7 @@ async_read_some(
             boost::asio::post(
                 in_->ioc.get_executor(),
                 bind_handler(
-                    init.completion_handler,
+                    std::move(init.completion_handler),
                     error_code{},
                     bytes_transferred));
         }
@@ -522,7 +522,7 @@ async_read_some(
             boost::asio::post(
                 in_->ioc.get_executor(),
                 bind_handler(
-                    init.completion_handler,
+                    std::move(init.completion_handler),
                     ec,
                     0));
         }
@@ -531,7 +531,7 @@ async_read_some(
             in_->op.reset(new read_op_impl<BOOST_ASIO_HANDLER_TYPE(
                 ReadHandler, void(error_code, std::size_t)),
                     MutableBufferSequence>{*in_, buffers,
-                        init.completion_handler});
+                        std::move(init.completion_handler)});
         }
     }
     return init.result.get();
@@ -605,7 +605,7 @@ async_write_some(ConstBufferSequence const& buffers,
         return boost::asio::post(
             in_->ioc.get_executor(),
             bind_handler(
-                init.completion_handler,
+                std::move(init.completion_handler),
                 boost::asio::error::connection_reset,
                 0));
     BOOST_ASSERT(out->code == status::ok);
@@ -616,7 +616,7 @@ async_write_some(ConstBufferSequence const& buffers,
             return boost::asio::post(
                 in_->ioc.get_executor(),
                 bind_handler(
-                    init.completion_handler,
+                    std::move(init.completion_handler),
                     ec,
                     0));
     }
@@ -632,7 +632,7 @@ async_write_some(ConstBufferSequence const& buffers,
     boost::asio::post(
         in_->ioc.get_executor(),
         bind_handler(
-            init.completion_handler,
+            std::move(init.completion_handler),
             error_code{},
             bytes_transferred));
     return init.result.get();
@@ -702,18 +702,11 @@ class stream::read_op_impl : public stream::read_op
         lambda(lambda&&) = default;
         lambda(lambda const&) = default;
 
-        lambda(state& s, Buffers const& b, Handler&& h)
+        template <class DeducedHandler>
+        lambda(state& s, Buffers const& b, DeducedHandler&& h)
             : s_(s)
             , b_(b)
-            , h_(std::move(h))
-            , work_(s_.ioc.get_executor())
-        {
-        }
-
-        lambda(state& s, Buffers const& b, Handler const& h)
-            : s_(s)
-            , b_(b)
-            , h_(h)
+            , h_(std::forward<DeducedHandler>(h))
             , work_(s_.ioc.get_executor())
         {
         }
@@ -772,13 +765,9 @@ class stream::read_op_impl : public stream::read_op
     lambda fn_;
 
 public:
-    read_op_impl(state& s, Buffers const& b, Handler&& h)
-        : fn_(s, b, std::move(h))
-    {
-    }
-
-    read_op_impl(state& s, Buffers const& b, Handler const& h)
-        : fn_(s, b, h)
+    template <typename DeducedHandler>
+    read_op_impl(state& s, Buffers const& b, DeducedHandler&& h)
+        : fn_(s, b, std::forward<DeducedHandler>(h))
     {
     }
 


### PR DESCRIPTION
HTTP async_read_* and async_write_* will now accept CompletionTokens which produce move-only CompletionHandlers.
