### PR TITLE
Move only handler ptr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ matrix:
         - TOOLSET=gcc
         - COMPILER=g++-6
         - CXXSTD=c++11
+      before_install:
+        - pip install --user https://github.com/codecov/codecov-python/archive/master.zip
       addons:
         apt:
           packages:
@@ -117,9 +119,6 @@ matrix:
         - CXXSTD=c++14
 
     # OSX
-
-before_install: &base_before_install
-  - pip install --user https://github.com/codecov/codecov-python/archive/master.zip
 
 install:
   - export BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 148:
 * Handle invalid deflate frames
 * Fix CMakeLists.txt variable
 * Protect calls from macros
+* Install codecov on codecov CI targets only
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 148:
+
+* built-in r-value return values can't be assigned
+
+--------------------------------------------------------------------------------
+
 Version 147:
 
 * Don't use boost::string_ref

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 148:
 * Tidy up ssl_stream special members
 * Update reports for hybrid assessment
 * Handle invalid deflate frames
+* Fix CMakeLists.txt variable
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 148:
 
 * built-in r-value return values can't be assigned
+* Tidy up ssl_stream special members
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Version 148:
 * Fix CMakeLists.txt variable
 * Protect calls from macros
 * Install codecov on codecov CI targets only
+* pausation always allocates
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 148:
 
 * built-in r-value return values can't be assigned
 * Tidy up ssl_stream special members
+* Update reports for hybrid assessment
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 148:
 * built-in r-value return values can't be assigned
 * Tidy up ssl_stream special members
 * Update reports for hybrid assessment
+* Handle invalid deflate frames
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Version 148:
 * Protect calls from macros
 * Install codecov on codecov CI targets only
 * pausation always allocates
+* Don't copy completion handlers
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 148:
 * Update reports for hybrid assessment
 * Handle invalid deflate frames
 * Fix CMakeLists.txt variable
+* Protect calls from macros
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.5.1)
 
-project (Beast VERSION 147)
+project (Beast VERSION 148)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/doc/qbk/01_intro.qbk
+++ b/doc/qbk/01_intro.qbk
@@ -101,7 +101,32 @@ for tirelessly answering questions on
 [section Reports]
 [block'''<?dbhtml stop-chunking?>''']
 
-[section WebSocket]
+[section Security Review (Bishop Fox)]
+
+Since 2005, [@https://www.bishopfox.com/ Bishop Fox] has provided
+security consulting services to the Fortune 1000, high-tech startups,
+and financial institutions worldwide.
+Beast engaged Bishop Fox to assess the security of the Boost C++ Beast HTTP/S
+networking library. The following report details the findings identified during
+the course of the engagement, which started on September 11, 2017.
+
+The assessment team conducted a hybrid application assessment of the Beast
+library. Bishop Fox’s hybrid application assessment methodology leverages
+the real-world attack techniques of application penetration testing in
+combination with targeted source code review to thoroughly identify
+application security vulnerabilities. These fullknowledge assessments
+begin with automated scans of the deployed application and source code.
+Next, analyses of the scan results are combined with manual review to
+thoroughly identify potential application security vulnerabilities. In
+addition, the team performs a review of the application architecture and
+business logic to locate any design-level issues. Finally, the team performs
+manual exploitation and review of these issues to validate the findings.
+
+[@https://vinniefalco.github.io/BeastAssets/Beast%20-%20Hybrid%20Application%20Assessment%202017%20-%20Assessment%20Report%20-%2020171114.pdf [*Beast - Hybrid Application Assessment 2017]]
+
+[endsect]
+
+[section WebSocket (Autobahn|Testsuite)]
 
 The
 [@https://github.com/crossbario/autobahn-testsuite Autobahn WebSockets Testsuite]
@@ -114,7 +139,7 @@ verification and performance and limits testing.
 Autobahn|Testsuite is used across the industry and
 contains over 500 test cases.
 
-[@https://vinniefalco.github.io/boost/beast/reports/autobahn/index.html [*Autobahn|Testsuite WebSocket Results]]
+[@https://vinniefalco.github.io/BeastAssets/reports/autobahn/index.html [*Autobahn|Testsuite WebSocket Results]]
 
 [warning
     Version 0.7.6 of Autobahn|Testsuite contains a

--- a/example/common/detect_ssl.hpp
+++ b/example/common/detect_ssl.hpp
@@ -353,7 +353,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(handler_);
+        return (boost::asio::get_associated_allocator)(handler_);
     }
 
     // Executor hook. This is Asio's system for customizing the
@@ -367,7 +367,7 @@ public:
 
     executor_type get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(handler_, stream_.get_executor());
+        return (boost::asio::get_associated_executor)(handler_, stream_.get_executor());
     }
 
     // Determines if the next asynchronous operation represents a

--- a/example/echo-op/echo_op.cpp
+++ b/example/echo-op/echo_op.cpp
@@ -154,7 +154,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(p_.handler());
+        return (boost::asio::get_associated_allocator)(p_.handler());
     }
 
     // Executor hook. This is Asio's system for customizing the
@@ -168,7 +168,7 @@ public:
 
     executor_type get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             p_.handler(), p_->stream.get_executor());
     }
 

--- a/include/boost/beast/core/detail/bind_handler.hpp
+++ b/include/boost/beast/core/detail/bind_handler.hpp
@@ -123,7 +123,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     friend

--- a/include/boost/beast/core/detail/bind_handler.hpp
+++ b/include/boost/beast/core/detail/bind_handler.hpp
@@ -109,7 +109,7 @@ public:
         boost::asio::associated_allocator_t<Handler>;
 
     bound_handler(bound_handler&&) = default;
-    bound_handler(bound_handler const&) = default;
+    bound_handler(bound_handler const&) = delete;
 
     template<class DeducedHandler>
     explicit

--- a/include/boost/beast/core/handler_ptr.hpp
+++ b/include/boost/beast/core/handler_ptr.hpp
@@ -10,10 +10,9 @@
 #ifndef BOOST_BEAST_HANDLER_PTR_HPP
 #define BOOST_BEAST_HANDLER_PTR_HPP
 
+#include <boost/beast/core/detail/allocator.hpp>
 #include <boost/beast/core/detail/config.hpp>
 #include <boost/beast/core/detail/type_traits.hpp>
-#include <atomic>
-#include <cstdint>
 #include <type_traits>
 #include <utility>
 
@@ -22,7 +21,7 @@ namespace beast {
 
 /** A smart pointer container with associated completion handler.
 
-    This is a smart pointer that retains shared ownership of an
+    This is a smart pointer that retains unique ownership of an
     object through a pointer. Memory is managed using the allocation
     and deallocation functions associated with a completion handler,
     which is also stored in the object. The managed object is
@@ -33,10 +32,10 @@ namespace beast {
 
     @li The function @ref release_handler is called.
 
-    @li The last remaining container owning the object is destroyed.
+    @li The owning the object is destroyed.
 
     Objects of this type are used in the implementation of
-    composed operations. Typically the composed operation's shared
+    composed operations. Typically the composed operation's
     state is managed by the @ref handler_ptr and an allocator
     associated with the final handler is used to create the managed
     object.
@@ -45,52 +44,42 @@ namespace beast {
     @e Distinct @e objects: Safe.@n
     @e Shared @e objects: Unsafe.
 
-    @note The reference count is stored using a 16 bit unsigned
-    integer. Making more than 2^16 copies of one object results
-    in undefined behavior.
-
-    @tparam T The type of the owned object.
+    @tparam T The type of the owned object. Must be noexcept destructible.
 
     @tparam Handler The type of the completion handler.
 */
 template<class T, class Handler>
 class handler_ptr
 {
-    struct P
-    {
-        T* t;
-        std::atomic<std::uint16_t> n;
+    T* t_ = nullptr;
+    Handler h_;
 
-        // There's no way to put the handler anywhere else
-        // without exposing ourselves to race conditions
-        // and all sorts of ugliness.
-        // See:
-        //  https://github.com/boostorg/beast/issues/215
-        Handler handler;
-
-        template<class DeducedHandler, class... Args>
-        P(DeducedHandler&& handler, Args&&... args);
-    };
-
-    P* p_;
-
+    void clear();
 public:
+    static_assert(std::is_nothrow_destructible<T>::value,
+        "T must be nothrow destructible");
+
     /// The type of element this object stores
     using element_type = T;
 
     /// The type of handler this object stores
     using handler_type = Handler;
 
-    /// Copy assignment (disallowed).
+    /// Copy assignment (deleted).
     handler_ptr& operator=(handler_ptr const&) = delete;
+
+    /// Move assignment (deleted).
+    handler_ptr& operator=(handler_ptr &&) = delete;
 
     /** Destructs the owned object if no more @ref handler_ptr link to it.
 
-        If `*this` owns an object and it is the last @ref handler_ptr
-        owning it, the object is destroyed and the memory deallocated
-        using the associated deallocator.
+        If `*this` owns an object the object is destroyed and
+        the memory deallocated using the associated deallocator.
     */
     ~handler_ptr();
+
+    /// Default constructor (deleted).
+    handler_ptr() = delete;
 
     /** Move constructor.
 
@@ -99,8 +88,9 @@ public:
     */
     handler_ptr(handler_ptr&& other);
 
-    /// Copy constructor
-    handler_ptr(handler_ptr const& other);
+    /// Copy constructor (deleted).
+    handler_ptr(handler_ptr const& other) = delete;
+
 
     /** Construct a new @ref handler_ptr
 
@@ -114,39 +104,28 @@ public:
         @endcode
 
         @param handler The handler to associate with the owned
-        object. The argument will be moved.
+        object. The argument will be moved if it is an xvalue (if allocation
+        or construction of T throws an exception, the argument is left
+        in a moved-from state).
 
         @param args Optional arguments forwarded to
         the owned object's constructor.
     */
-    template<class... Args>
-    handler_ptr(Handler&& handler, Args&&... args);
+    template<class DeducedHandler, class... Args>
+    explicit handler_ptr(DeducedHandler&& handler, Args&&... args);
 
-    /** Construct a new @ref handler_ptr
-
-        This creates a new @ref handler_ptr with an owned object
-        of type `T`. The allocator associated with the handler will
-        be used to allocate memory for the owned object. The constructor
-        for the owned object will be called thusly:
-
-        @code
-            T(handler, std::forward<Args>(args)...)
-        @endcode
-
-        @param handler The handler to associate with the owned
-        object. The argument will be copied.
-
-        @param args Optional arguments forwarded to
-        the owned object's constructor.
-    */
-    template<class... Args>
-    handler_ptr(Handler const& handler, Args&&... args);
+    /// Returns a const reference to the handler
+    handler_type const&
+    handler() const
+    {
+        return h_;
+    }
 
     /// Returns a reference to the handler
     handler_type&
-    handler() const
+    handler()
     {
-        return p_->handler;
+        return h_;
     }
 
     /** Returns a pointer to the owned object.
@@ -154,21 +133,21 @@ public:
     T*
     get() const
     {
-        return p_->t;
+        return t_;
     }
 
     /// Return a reference to the owned object.
     T&
     operator*() const
     {
-        return *p_->t;
+        return *t_;
     }
 
     /// Return a pointer to the owned object.
     T*
     operator->() const
     {
-        return p_->t;
+        return t_;
     }
 
     /** Release ownership of the handler
@@ -177,10 +156,7 @@ public:
 
         Before this function returns,
         the owned object is destroyed, satisfying the
-        deallocation-before-invocation Asio guarantee. All
-        instances of @ref handler_ptr which refer to the
-        same owned object will be reset, including this instance.
-
+        deallocation-before-invocation Asio guarantee.
         @return The released handler.
     */
     handler_type
@@ -191,9 +167,7 @@ public:
         This function invokes the handler in the owned object
         with a forwarded argument list. Before the invocation,
         the owned object is destroyed, satisfying the
-        deallocation-before-invocation Asio guarantee. All
-        instances of @ref handler_ptr which refer to the
-        same owned object will be reset, including this instance.
+        deallocation-before-invocation Asio guarantee.
 
         @note Care must be taken when the arguments are themselves
         stored in the owned object. Such arguments must first be

--- a/include/boost/beast/core/impl/buffered_read_stream.ipp
+++ b/include/boost/beast/core/impl/buffered_read_stream.ipp
@@ -55,7 +55,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type =
@@ -65,7 +65,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 

--- a/include/boost/beast/core/impl/buffered_read_stream.ipp
+++ b/include/boost/beast/core/impl/buffered_read_stream.ipp
@@ -37,7 +37,7 @@ class buffered_read_stream<
 
 public:
     read_some_op(read_some_op&&) = default;
-    read_some_op(read_some_op const&) = default;
+    read_some_op(read_some_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     read_some_op(DeducedHandler&& h,
@@ -237,7 +237,7 @@ async_read_some(
         void(error_code, std::size_t)> init{handler};
     read_some_op<MutableBufferSequence, BOOST_ASIO_HANDLER_TYPE(
         ReadHandler, void(error_code, std::size_t))>{
-            init.completion_handler, *this, buffers}(
+            std::move(init.completion_handler), *this, buffers}(
                 error_code{}, 0);
     return init.result.get();
 }

--- a/include/boost/beast/core/impl/handler_ptr.ipp
+++ b/include/boost/beast/core/impl/handler_ptr.ipp
@@ -18,87 +18,59 @@ namespace boost {
 namespace beast {
 
 template<class T, class Handler>
-template<class DeducedHandler, class... Args>
-inline
-handler_ptr<T, Handler>::P::
-P(DeducedHandler&& h, Args&&... args)
-    : n(1)
-    , handler(std::forward<DeducedHandler>(h))
+void
+handler_ptr<T, Handler>::
+clear()
 {
-    typename std::allocator_traits<
-        boost::asio::associated_allocator_t<Handler>>::
-            template rebind_alloc<T> alloc{
-                boost::asio::get_associated_allocator(handler)};
-    t = std::allocator_traits<decltype(alloc)>::allocate(alloc, 1);
-    try
-    {
-        t = new(t) T{handler,
-            std::forward<Args>(args)...};
-    }
-    catch(...)
-    {
-        std::allocator_traits<
-            decltype(alloc)>::deallocate(alloc, t, 1);
-        throw;
-    }
+    using alloc_t = typename detail::allocator_traits<
+    boost::asio::associated_allocator_t<Handler>>::template rebind_alloc<T>;
+    using alloc_traits_t = detail::allocator_traits<alloc_t>;
+
+    alloc_t alloc{boost::asio::get_associated_allocator(h_)};
+    alloc_traits_t::destroy(alloc, t_);
+    alloc_traits_t::deallocate(alloc, t_, 1);
+    t_ = nullptr;
 }
 
 template<class T, class Handler>
 handler_ptr<T, Handler>::
 ~handler_ptr()
 {
-    if(! p_)
-        return;
-    if(--p_->n)
-        return;
-    if(p_->t)
-    {
-        p_->t->~T();
-        typename std::allocator_traits<
-            boost::asio::associated_allocator_t<Handler>>::
-                template rebind_alloc<T> alloc{
-                    boost::asio::get_associated_allocator(
-                        p_->handler)};
-        std::allocator_traits<
-            decltype(alloc)>::deallocate(alloc, p_->t, 1);
-    }
-    delete p_;
+    if(t_)
+        clear();
 }
 
 template<class T, class Handler>
 handler_ptr<T, Handler>::
 handler_ptr(handler_ptr&& other)
-    : p_(other.p_)
+    : t_(other.t_)
+    , h_(std::move(other.h_))
 {
-    other.p_ = nullptr;
+    other.t_ = nullptr;
 }
 
 template<class T, class Handler>
+template<class DeducedHandler, class... Args>
 handler_ptr<T, Handler>::
-handler_ptr(handler_ptr const& other)
-    : p_(other.p_)
-{
-    if(p_)
-        ++p_->n;
-}
-
-template<class T, class Handler>
-template<class... Args>
-handler_ptr<T, Handler>::
-handler_ptr(Handler&& handler, Args&&... args)
-    : p_(new P{std::move(handler),
-        std::forward<Args>(args)...})
+handler_ptr(DeducedHandler&& handler, Args&&... args)
+    : h_(std::forward<DeducedHandler>(handler))
 {
     BOOST_STATIC_ASSERT(! std::is_array<T>::value);
-}
+    using alloc_t = typename detail::allocator_traits<
+        boost::asio::associated_allocator_t<Handler>>::template rebind_alloc<T>;
+    using alloc_traits_t = detail::allocator_traits<alloc_t>;
 
-template<class T, class Handler>
-template<class... Args>
-handler_ptr<T, Handler>::
-handler_ptr(Handler const& handler, Args&&... args)
-    : p_(new P{handler, std::forward<Args>(args)...})
-{
-    BOOST_STATIC_ASSERT(! std::is_array<T>::value);
+    alloc_t alloc{boost::asio::get_associated_allocator(h_)};
+    t_ = alloc_traits_t::allocate(alloc, 1);
+    try
+    {
+        alloc_traits_t::construct(alloc, t_, h_, std::forward<Args>(args)...);
+    }
+    catch(...)
+    {
+        alloc_traits_t::deallocate(alloc, t_, 1);
+        throw;
+    }
 }
 
 template<class T, class Handler>
@@ -107,18 +79,9 @@ handler_ptr<T, Handler>::
 release_handler() ->
     handler_type
 {
-    BOOST_ASSERT(p_);
-    BOOST_ASSERT(p_->t);
-    p_->t->~T();
-    typename std::allocator_traits<
-        boost::asio::associated_allocator_t<Handler>>::
-            template rebind_alloc<T> alloc{
-                boost::asio::get_associated_allocator(
-                    p_->handler)};
-    std::allocator_traits<
-        decltype(alloc)>::deallocate(alloc, p_->t, 1);
-    p_->t = nullptr;
-    return std::move(p_->handler);
+    BOOST_ASSERT(t_);
+    clear();
+    return std::move(h_);
 }
 
 template<class T, class Handler>
@@ -127,18 +90,9 @@ void
 handler_ptr<T, Handler>::
 invoke(Args&&... args)
 {
-    BOOST_ASSERT(p_);
-    BOOST_ASSERT(p_->t);
-    p_->t->~T();
-    typename std::allocator_traits<
-        boost::asio::associated_allocator_t<Handler>>::
-            template rebind_alloc<T> alloc{
-                boost::asio::get_associated_allocator(
-                    p_->handler)};
-    std::allocator_traits<
-        decltype(alloc)>::deallocate(alloc, p_->t, 1);
-    p_->t = nullptr;
-    p_->handler(std::forward<Args>(args)...);
+    BOOST_ASSERT(t_);
+    clear();
+    h_(std::forward<Args>(args)...);
 }
 
 } // beast

--- a/include/boost/beast/core/type_traits.hpp
+++ b/include/boost/beast/core/type_traits.hpp
@@ -52,7 +52,7 @@ template<class T, class Signature>
 using is_completion_handler = std::integral_constant<bool, ...>;
 #else
 using is_completion_handler = std::integral_constant<bool,
-    std::is_copy_constructible<typename std::decay<T>::type>::value &&
+    std::is_move_constructible<typename std::decay<T>::type>::value &&
     detail::is_invocable<T, Signature>::value>;
 #endif
 

--- a/include/boost/beast/http/fields.hpp
+++ b/include/boost/beast/http/fields.hpp
@@ -102,7 +102,7 @@ public:
         value_type& operator=(value_type const&) = delete;
 
         /// Returns the field enum, which can be @ref field::unknown
-        field const
+        field
         name() const;
 
         /// Returns the field name as a string

--- a/include/boost/beast/http/impl/fields.ipp
+++ b/include/boost/beast/http/impl/fields.ipp
@@ -291,7 +291,7 @@ value_type(field name,
 
 template<class Allocator>
 inline
-field const
+field
 basic_fields<Allocator>::
 value_type::
 name() const

--- a/include/boost/beast/http/impl/file_body_win32.ipp
+++ b/include/boost/beast/http/impl/file_body_win32.ipp
@@ -364,7 +364,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type =
@@ -374,7 +374,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, sock_.get_executor());
     }
 

--- a/include/boost/beast/http/impl/read.ipp
+++ b/include/boost/beast/http/impl/read.ipp
@@ -50,7 +50,7 @@ class read_some_op
 
 public:
     read_some_op(read_some_op&&) = default;
-    read_some_op(read_some_op const&) = default;
+    read_some_op(read_some_op const&) = delete;
 
     template<class DeducedHandler>
     read_some_op(DeducedHandler&& h, Stream& s,
@@ -208,7 +208,7 @@ class read_op
 
 public:
     read_op(read_op&&) = default;
-    read_op(read_op const&) = default;
+    read_op(read_op const&) = delete;
 
     template<class DeducedHandler>
     read_op(DeducedHandler&& h, Stream& s,
@@ -331,7 +331,7 @@ class read_msg_op
 
 public:
     read_msg_op(read_msg_op&&) = default;
-    read_msg_op(read_msg_op const&) = default;
+    read_msg_op(read_msg_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     read_msg_op(DeducedHandler&& h, Stream& s, Args&&... args)
@@ -531,7 +531,7 @@ async_read_some(
     detail::read_some_op<AsyncReadStream,
         DynamicBuffer, isRequest, Derived, BOOST_ASIO_HANDLER_TYPE(
             ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler, stream, buffer, parser}(
+                std::move(init.completion_handler), stream, buffer, parser}(
                     {}, 0, false);
     return init.result.get();
 }
@@ -619,8 +619,8 @@ async_read_header(
     detail::read_op<AsyncReadStream, DynamicBuffer,
         isRequest, Derived, detail::parser_is_header_done,
             BOOST_ASIO_HANDLER_TYPE(ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler, stream, buffer, parser}(
-                    {}, 0, false);
+                std::move(init.completion_handler), stream,
+                buffer, parser}({}, 0, false);
     return init.result.get();
 }
 
@@ -708,7 +708,7 @@ async_read(
     detail::read_op<AsyncReadStream, DynamicBuffer,
         isRequest, Derived, detail::parser_is_done,
             BOOST_ASIO_HANDLER_TYPE(ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler, stream, buffer, parser}(
+                std::move(init.completion_handler), stream, buffer, parser}(
                     {}, 0, false);
     return init.result.get();
 }
@@ -803,7 +803,7 @@ async_read(
         isRequest, Body, Allocator,
         BOOST_ASIO_HANDLER_TYPE(
             ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler, stream, buffer, msg}(
+                std::move(init.completion_handler), stream, buffer, msg}(
                     {}, 0, false);
     return init.result.get();
 }

--- a/include/boost/beast/http/impl/read.ipp
+++ b/include/boost/beast/http/impl/read.ipp
@@ -68,7 +68,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -77,7 +77,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 
@@ -227,7 +227,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -236,7 +236,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 
@@ -346,7 +346,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -355,7 +355,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->s.get_executor());
     }
 

--- a/include/boost/beast/http/impl/write.ipp
+++ b/include/boost/beast/http/impl/write.ipp
@@ -67,7 +67,7 @@ class write_some_op
 
 public:
     write_some_op(write_some_op&&) = default;
-    write_some_op(write_some_op const&) = default;
+    write_some_op(write_some_op const&) = delete;
 
     template<class DeducedHandler>
     write_some_op(DeducedHandler&& h, Stream& s,
@@ -203,7 +203,7 @@ class write_op
 
 public:
     write_op(write_op&&) = default;
-    write_op(write_op const&) = default;
+    write_op(write_op const&) = delete;
 
     template<class DeducedHandler>
     write_op(DeducedHandler&& h, Stream& s,
@@ -318,7 +318,7 @@ class write_msg_op
 
 public:
     write_msg_op(write_msg_op&&) = default;
-    write_msg_op(write_msg_op const&) = default;
+    write_msg_op(write_msg_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     write_msg_op(DeducedHandler&& h, Stream& s, Args&&... args)
@@ -479,7 +479,7 @@ async_write_some_impl(
         BOOST_ASIO_HANDLER_TYPE(WriteHandler,
             void(error_code, std::size_t)),
         isRequest, Body, Fields>{
-            init.completion_handler, stream, sr}();
+            std::move(init.completion_handler), stream, sr}();
     return init.result.get();
 }
 
@@ -638,7 +638,7 @@ async_write_header(
             void(error_code, std::size_t)),
         detail::serializer_is_header_done,
         isRequest, Body, Fields>{
-        init.completion_handler, stream, sr}();
+        std::move(init.completion_handler), stream, sr}();
     return init.result.get();
 }
 
@@ -715,7 +715,7 @@ async_write(
             void(error_code, std::size_t)),
         detail::serializer_is_done,
         isRequest, Body, Fields>{
-            init.completion_handler, stream, sr}();
+            std::move(init.completion_handler), stream, sr}();
     return init.result.get();
 }
 
@@ -788,7 +788,7 @@ async_write(
         BOOST_ASIO_HANDLER_TYPE(WriteHandler,
             void(error_code, std::size_t)),
         isRequest, Body, Fields>{
-            init.completion_handler, stream, msg}();
+            std::move(init.completion_handler), stream, msg}();
     return init.result.get();
 }
 

--- a/include/boost/beast/http/impl/write.ipp
+++ b/include/boost/beast/http/impl/write.ipp
@@ -84,7 +84,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -93,7 +93,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 
@@ -220,7 +220,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -229,7 +229,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 
@@ -333,7 +333,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -342,7 +342,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->s.get_executor());
     }
 

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 147
+#define BOOST_BEAST_VERSION 148
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/detail/pausation.hpp
+++ b/include/boost/beast/websocket/detail/pausation.hpp
@@ -10,13 +10,10 @@
 #ifndef BOOST_BEAST_WEBSOCKET_DETAIL_PAUSATION_HPP
 #define BOOST_BEAST_WEBSOCKET_DETAIL_PAUSATION_HPP
 
-#include <boost/beast/core/handler_ptr.hpp>
+#include <boost/beast/core/detail/allocator.hpp>
 #include <boost/asio/associated_allocator.hpp>
-#include <boost/asio/coroutine.hpp>
 #include <boost/assert.hpp>
-#include <array>
 #include <memory>
-#include <new>
 #include <utility>
 
 namespace boost {
@@ -30,124 +27,59 @@ namespace detail {
 //
 class pausation
 {
-    struct base
+    struct handler
     {
-        base() = default;
-        base(base &&) = delete;
-        base(base const&) = delete;
-        virtual ~base() = default;
-        virtual void operator()() = 0;
+        handler() = default;
+        handler(handler &&) = delete;
+        handler(handler const&) = delete;
+        virtual ~handler() = default;
+        virtual void destroy() = 0;
+        virtual void invoke() = 0;
     };
 
-    template<class F>
-    struct holder : base
+    template<class Handler>
+    class impl : public handler
     {
-        F f;
-
-        holder(holder&&) = default;
-
-        template<class U>
-        explicit
-        holder(U&& u)
-            : f(std::forward<U>(u))
-        {
-        }
-
-        void
-        operator()() override
-        {
-            F f_(std::move(f));
-            this->~holder();
-            // invocation of f_() can
-            // assign a new object to *this.
-            f_();
-        }
-    };
-
-    struct exemplar : boost::asio::coroutine
-    {
-        struct H
-        {
-            void operator()();
-        };
-
-        struct T
-        {
-            using handler_type = H;
-        };
-
-        handler_ptr<T, H> hp;
-
-        void operator()();
-    };
-
-    template<class Op>
-    class saved_op
-    {
-        Op* op_ = nullptr;
+        Handler h_;
 
     public:
-        ~saved_op()
+        template<class DeducedHandler>
+        impl(DeducedHandler&& h)
+            : h_(std::forward<DeducedHandler>(h))
         {
-            if(op_)
-            {
-                Op op(std::move(*op_));
-                op_->~Op();
-                typename std::allocator_traits<
-                    boost::asio::associated_allocator_t<Op>>::
-                        template rebind_alloc<Op> alloc{
-                            boost::asio::get_associated_allocator(op)};
-                std::allocator_traits<
-                    decltype(alloc)>::deallocate(alloc, op_, 1);
-            }
-        }
-
-        saved_op(saved_op&& other)
-            : op_(other.op_)
-        {
-            other.op_ = nullptr;
-        }
-
-        saved_op& operator=(saved_op&& other)
-        {
-            BOOST_ASSERT(! op_);
-            op_ = other.op_;
-            other.op_ = 0;
-            return *this;
-        }
-
-        explicit
-        saved_op(Op&& op)
-        {
-            typename std::allocator_traits<
-                boost::asio::associated_allocator_t<Op>>::
-                    template rebind_alloc<Op> alloc{
-                        boost::asio::get_associated_allocator(op)};
-            auto const p = std::allocator_traits<
-                decltype(alloc)>::allocate(alloc, 1);
-            op_ = new(p) Op{std::move(op)};
         }
 
         void
-        operator()()
+        destroy() override
         {
-            BOOST_ASSERT(op_);
-            Op op{std::move(*op_)};
-            typename std::allocator_traits<
-                boost::asio::associated_allocator_t<Op>>::
-                    template rebind_alloc<Op> alloc{
-                        boost::asio::get_associated_allocator(op)};
-            std::allocator_traits<
-                decltype(alloc)>::deallocate(alloc, op_, 1);
-            op_ = nullptr;
-            op();
+            Handler h(std::move(h_));
+            typename beast::detail::allocator_traits<
+                boost::asio::associated_allocator_t<
+                    Handler>>::template rebind_alloc<impl> alloc{
+                        boost::asio::get_associated_allocator(h)};
+            beast::detail::allocator_traits<
+                decltype(alloc)>::destroy(alloc, this);
+            beast::detail::allocator_traits<
+                decltype(alloc)>::deallocate(alloc, this, 1);
+        }
+
+        void
+        invoke() override
+        {
+            Handler h(std::move(h_));
+            typename beast::detail::allocator_traits<
+                boost::asio::associated_allocator_t<
+                    Handler>>::template rebind_alloc<impl> alloc{
+                        boost::asio::get_associated_allocator(h)};
+            beast::detail::allocator_traits<
+                decltype(alloc)>::destroy(alloc, this);
+            beast::detail::allocator_traits<
+                decltype(alloc)>::deallocate(alloc, this, 1);
+            h();
         }
     };
 
-    using buf_type = char[sizeof(holder<exemplar>)];
-
-    base* base_ = nullptr;
-    alignas(holder<exemplar>) buf_type buf_;
+    handler* h_ = nullptr;
 
 public:
     pausation() = default;
@@ -156,69 +88,73 @@ public:
 
     ~pausation()
     {
-        if(base_)
-            base_->~base();
+        if(h_)
+            h_->destroy();
     }
 
     pausation(pausation&& other)
     {
         boost::ignore_unused(other);
-        BOOST_ASSERT(! other.base_);
+        BOOST_ASSERT(! other.h_);
     }
 
     pausation&
     operator=(pausation&& other)
     {
         boost::ignore_unused(other);
-        BOOST_ASSERT(! base_);
-        BOOST_ASSERT(! other.base_);
+        BOOST_ASSERT(! h_);
+        BOOST_ASSERT(! other.h_);
         return *this;
     }
 
-    template<class F>
+    template<class CompletionHandler>
     void
-    emplace(F&& f);
-
-    template<class F>
-    void
-    save(F&& f);
+    emplace(CompletionHandler&& handler);
 
     explicit
     operator bool() const
     {
-        return base_ != nullptr;
+        return h_ != nullptr;
     }
 
     bool
     maybe_invoke()
     {
-        if(base_)
+        if(h_)
         {
-            auto const basep = base_;
-            base_ = nullptr;
-            (*basep)();
+            auto const h = h_;
+            h_ = nullptr;
+            h->invoke();
             return true;
         }
         return false;
     }
 };
 
-template<class F>
+template<class CompletionHandler>
 void
-pausation::emplace(F&& f)
+pausation::emplace(CompletionHandler&& handler)
 {
-    using type = holder<typename std::decay<F>::type>;
-    static_assert(sizeof(buf_type) >= sizeof(type),
-        "buffer too small");
-    BOOST_ASSERT(! base_);
-    base_ = ::new(buf_) type{std::forward<F>(f)};
-}
-
-template<class F>
-void
-pausation::save(F&& f)
-{
-    emplace(saved_op<F>{std::move(f)});
+    BOOST_ASSERT(! h_);
+    typename beast::detail::allocator_traits<
+        boost::asio::associated_allocator_t<
+            CompletionHandler>>::template rebind_alloc<
+                impl<CompletionHandler>> alloc{
+                    boost::asio::get_associated_allocator(handler)};
+    auto const h = beast::detail::allocator_traits<
+        decltype(alloc)>::allocate(alloc, 1);
+    try
+    {
+        beast::detail::allocator_traits<
+            decltype(alloc)>::construct(alloc, h,
+                std::forward<CompletionHandler>(handler));
+        h_ = h;
+    }
+    catch(...)
+    {
+        beast::detail::allocator_traits<
+            decltype(alloc)>::deallocate(alloc, h, 1);
+    }
 }
 
 } // detail

--- a/include/boost/beast/websocket/error.hpp
+++ b/include/boost/beast/websocket/error.hpp
@@ -30,7 +30,10 @@ enum class error
     handshake_failed,
 
     /// buffer overflow
-    buffer_overflow
+    buffer_overflow,
+
+    /// partial deflate block
+    partial_deflate_block
 };
 
 } // websocket

--- a/include/boost/beast/websocket/impl/accept.ipp
+++ b/include/boost/beast/websocket/impl/accept.ipp
@@ -74,7 +74,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -83,7 +83,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->ws.get_executor());
     }
 
@@ -170,7 +170,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -179,7 +179,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->ws.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/accept.ipp
+++ b/include/boost/beast/websocket/impl/accept.ipp
@@ -58,7 +58,7 @@ class stream<NextLayer>::response_op
 
 public:
     response_op(response_op&&) = default;
-    response_op(response_op const&) = default;
+    response_op(response_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     response_op(DeducedHandler&& h,
@@ -154,7 +154,7 @@ class stream<NextLayer>::accept_op
 
 public:
     accept_op(accept_op&&) = default;
-    accept_op(accept_op const&) = default;
+    accept_op(accept_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     accept_op(DeducedHandler&& h,
@@ -545,7 +545,7 @@ async_accept(
         decltype(&default_decorate_res),
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 &default_decorate_res}({});
     return init.result.get();
@@ -574,7 +574,7 @@ async_accept_ex(
         ResponseDecorator,
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 decorator}({});
     return init.result.get();
@@ -605,7 +605,7 @@ async_accept(
         decltype(&default_decorate_res),
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 &default_decorate_res}.run(buffers);
     return init.result.get();
@@ -641,7 +641,7 @@ async_accept_ex(
         ResponseDecorator,
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 decorator}.run(buffers);
     return init.result.get();
@@ -667,7 +667,7 @@ async_accept(
     response_op<
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 req,
                 &default_decorate_res}();
@@ -699,7 +699,7 @@ async_accept_ex(
     response_op<
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 req,
                 decorator}();

--- a/include/boost/beast/websocket/impl/close.ipp
+++ b/include/boost/beast/websocket/impl/close.ipp
@@ -64,7 +64,7 @@ class stream<NextLayer>::close_op
 
 public:
     close_op(close_op&&) = default;
-    close_op(close_op const&) = default;
+    close_op(close_op const&) = delete;
 
     template<class DeducedHandler>
     close_op(
@@ -447,7 +447,7 @@ async_close(close_reason const& cr, CloseHandler&& handler)
         void(error_code)> init{handler};
     close_op<BOOST_ASIO_HANDLER_TYPE(
         CloseHandler, void(error_code))>{
-            init.completion_handler, *this, cr}(
+            std::move(init.completion_handler), *this, cr}(
                 {}, 0, false);
     return init.result.get();
 }

--- a/include/boost/beast/websocket/impl/close.ipp
+++ b/include/boost/beast/websocket/impl/close.ipp
@@ -81,7 +81,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -90,7 +90,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->ws.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/error.ipp
+++ b/include/boost/beast/websocket/impl/error.ipp
@@ -43,6 +43,7 @@ public:
         case error::closed: return "WebSocket connection closed normally";
         case error::handshake_failed: return "WebSocket upgrade handshake failed";
         case error::buffer_overflow: return "WebSocket dynamic buffer overflow";
+        case error::partial_deflate_block: return "WebSocket partial deflate block";
         }
     }
 

--- a/include/boost/beast/websocket/impl/handshake.ipp
+++ b/include/boost/beast/websocket/impl/handshake.ipp
@@ -81,7 +81,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -90,7 +90,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->ws.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/handshake.ipp
+++ b/include/boost/beast/websocket/impl/handshake.ipp
@@ -65,7 +65,7 @@ class stream<NextLayer>::handshake_op
 
 public:
     handshake_op(handshake_op&&) = default;
-    handshake_op(handshake_op const&) = default;
+    handshake_op(handshake_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     handshake_op(DeducedHandler&& h,
@@ -161,7 +161,7 @@ async_handshake(string_view host,
         void(error_code)> init{handler};
     handshake_op<BOOST_ASIO_HANDLER_TYPE(
         HandshakeHandler, void(error_code))>{
-            init.completion_handler, *this, nullptr, host,
+            std::move(init.completion_handler), *this, nullptr, host,
                 target, &default_decorate_req}();
     return init.result.get();
 }
@@ -182,7 +182,7 @@ async_handshake(response_type& res,
         void(error_code)> init{handler};
     handshake_op<BOOST_ASIO_HANDLER_TYPE(
         HandshakeHandler, void(error_code))>{
-            init.completion_handler, *this, &res, host,
+            std::move(init.completion_handler), *this, &res, host,
                 target, &default_decorate_req}();
     return init.result.get();
 }
@@ -206,7 +206,7 @@ async_handshake_ex(string_view host,
         void(error_code)> init{handler};
     handshake_op<BOOST_ASIO_HANDLER_TYPE(
         HandshakeHandler, void(error_code))>{
-            init.completion_handler, *this, nullptr, host,
+            std::move(init.completion_handler), *this, nullptr, host,
                 target, decorator}();
     return init.result.get();
 }
@@ -231,7 +231,7 @@ async_handshake_ex(response_type& res,
         void(error_code)> init{handler};
     handshake_op<BOOST_ASIO_HANDLER_TYPE(
         HandshakeHandler, void(error_code))>{
-            init.completion_handler, *this, &res, host,
+            std::move(init.completion_handler), *this, &res, host,
                 target, decorator}();
     return init.result.get();
 }

--- a/include/boost/beast/websocket/impl/ping.ipp
+++ b/include/boost/beast/websocket/impl/ping.ipp
@@ -81,7 +81,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -90,7 +90,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->ws.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/ping.ipp
+++ b/include/boost/beast/websocket/impl/ping.ipp
@@ -62,7 +62,7 @@ class stream<NextLayer>::ping_op
 
 public:
     ping_op(ping_op&&) = default;
-    ping_op(ping_op const&) = default;
+    ping_op(ping_op const&) = delete;
 
     template<class DeducedHandler>
     ping_op(
@@ -241,7 +241,7 @@ async_ping(ping_data const& payload, WriteHandler&& handler)
         void(error_code)> init{handler};
     ping_op<BOOST_ASIO_HANDLER_TYPE(
         WriteHandler, void(error_code))>{
-            init.completion_handler, *this,
+            std::move(init.completion_handler), *this,
                 detail::opcode::ping, payload}();
     return init.result.get();
 }
@@ -259,7 +259,7 @@ async_pong(ping_data const& payload, WriteHandler&& handler)
         void(error_code)> init{handler};
     ping_op<BOOST_ASIO_HANDLER_TYPE(
         WriteHandler, void(error_code))>{
-            init.completion_handler, *this,
+            std::move(init.completion_handler), *this,
                 detail::opcode::pong, payload}();
     return init.result.get();
 }

--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -59,7 +59,7 @@ class stream<NextLayer>::read_some_op
 
 public:
     read_some_op(read_some_op&&) = default;
-    read_some_op(read_some_op const&) = default;
+    read_some_op(read_some_op const&) = delete;
 
     template<class DeducedHandler>
     read_some_op(
@@ -683,7 +683,7 @@ public:
         boost::asio::associated_allocator_t<Handler>;
 
     read_op(read_op&&) = default;
-    read_op(read_op const&) = default;
+    read_op(read_op const&) = delete;
 
     template<class DeducedHandler>
     read_op(
@@ -839,7 +839,7 @@ async_read(DynamicBuffer& buffer, ReadHandler&& handler)
         DynamicBuffer,
         BOOST_ASIO_HANDLER_TYPE(
             ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 buffer,
                 0,
@@ -927,7 +927,7 @@ async_read_some(
         DynamicBuffer,
         BOOST_ASIO_HANDLER_TYPE(
             ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 buffer,
                 limit,
@@ -1311,7 +1311,7 @@ async_read_some(
         void(error_code, std::size_t)> init{handler};
     read_some_op<MutableBufferSequence, BOOST_ASIO_HANDLER_TYPE(
         ReadHandler, void(error_code, std::size_t))>{
-            init.completion_handler,*this, buffers}(
+            std::move(init.completion_handler), *this, buffers}(
                 {}, 0, false);
     return init.result.get();
 }

--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -152,7 +152,7 @@ operator()(
             // Suspend
             BOOST_ASSERT(ws_.rd_block_ != tok_);
             BOOST_ASIO_CORO_YIELD
-            ws_.paused_r_rd_.save(std::move(*this));
+            ws_.paused_r_rd_.emplace(std::move(*this));
 
             // Acquire the read block
             BOOST_ASSERT(! ws_.rd_block_);
@@ -275,7 +275,7 @@ operator()(
                         // Suspend
                         BOOST_ASSERT(ws_.wr_block_ != tok_);
                         BOOST_ASIO_CORO_YIELD
-                        ws_.paused_rd_.save(std::move(*this));
+                        ws_.paused_rd_.emplace(std::move(*this));
 
                         // Acquire the write block
                         BOOST_ASSERT(! ws_.wr_block_);
@@ -580,7 +580,7 @@ operator()(
             // Suspend
             BOOST_ASSERT(ws_.wr_block_ != tok_);
             BOOST_ASIO_CORO_YIELD
-            ws_.paused_rd_.save(std::move(*this));
+            ws_.paused_rd_.emplace(std::move(*this));
 
             // Acquire the write block
             BOOST_ASSERT(! ws_.wr_block_);

--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -81,7 +81,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -90,7 +90,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, ws_.get_executor());
     }
 
@@ -704,7 +704,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -713,7 +713,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, ws_.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/teardown.ipp
+++ b/include/boost/beast/websocket/impl/teardown.ipp
@@ -56,7 +56,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -65,7 +65,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/write.ipp
+++ b/include/boost/beast/websocket/impl/write.ipp
@@ -76,7 +76,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -85,7 +85,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, ws_.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/write.ipp
+++ b/include/boost/beast/websocket/impl/write.ipp
@@ -54,7 +54,7 @@ class stream<NextLayer>::write_some_op
 
 public:
     write_some_op(write_some_op&&) = default;
-    write_some_op(write_some_op const&) = default;
+    write_some_op(write_some_op const&) = delete;
 
     template<class DeducedHandler>
     write_some_op(
@@ -728,7 +728,7 @@ async_write_some(bool fin,
         void(error_code, std::size_t)> init{handler};
     write_some_op<ConstBufferSequence, BOOST_ASIO_HANDLER_TYPE(
         WriteHandler, void(error_code, std::size_t))>{
-            init.completion_handler, *this, fin, bs}(
+            std::move(init.completion_handler), *this, fin, bs}(
                 {}, 0, false);
     return init.result.get();
 }
@@ -784,7 +784,7 @@ async_write(
         void(error_code, std::size_t)> init{handler};
     write_some_op<ConstBufferSequence, BOOST_ASIO_HANDLER_TYPE(
         WriteHandler, void(error_code, std::size_t))>{
-            init.completion_handler, *this, true, bs}(
+            std::move(init.completion_handler), *this, true, bs}(
                 {}, 0, false);
     return init.result.get();
 }

--- a/include/boost/beast/websocket/impl/write.ipp
+++ b/include/boost/beast/websocket/impl/write.ipp
@@ -208,7 +208,7 @@ operator()(
             // Suspend
             BOOST_ASSERT(ws_.wr_block_ != tok_);
             BOOST_ASIO_CORO_YIELD
-            ws_.paused_wr_.save(std::move(*this));
+            ws_.paused_wr_.emplace(std::move(*this));
 
             // Acquire the write block
             BOOST_ASSERT(! ws_.wr_block_);

--- a/include/boost/beast/zlib/impl/error.ipp
+++ b/include/boost/beast/zlib/impl/error.ipp
@@ -69,7 +69,7 @@ public:
         switch(static_cast<error>(ev))
         {
         case error::need_buffers: return "need buffers";
-        case error::end_of_stream: return "end of stream";
+        case error::end_of_stream: return "unexpected end of deflate stream";
         case error::stream_error: return "stream error";
 
         case error::invalid_block_type: return "invalid block type";

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,7 @@ include_directories (./extern)
 include_directories (./extras/include)
 include_directories (../subtree/unit_test/include)
 
-file (GLOB_RECURSE EXTRAS_INCLUDES
+file (GLOB_RECURSE EXTRAS_FILES
     ${PROJECT_SOURCE_DIR}/test/extras/include/*.hpp
     ${PROJECT_SOURCE_DIR}/test/extras/include/*.ipp
     ${PROJECT_SOURCE_DIR}/subtree/unit_test/include/*.hpp

--- a/test/beast/core/handler_ptr.cpp
+++ b/test/beast/core/handler_ptr.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/beast/unit_test/suite.hpp>
 #include <exception>
+#include <memory>
 #include <utility>
 
 namespace boost {
@@ -22,8 +23,7 @@ class handler_ptr_test : public beast::unit_test::suite
 public:
     struct handler
     {
-        handler() = default;
-        handler(handler const&) = default;
+        std::unique_ptr<int> ptr;
 
         void
         operator()(bool& b) const
@@ -54,12 +54,10 @@ public:
     void
     run() override
     {
-        handler h;
-        handler_ptr<T, handler> p1{h};
-        handler_ptr<T, handler> p2{p1};
+        handler_ptr<T, handler> p1{handler{}};
         try
         {
-            handler_ptr<U, handler> p3{h};
+            handler_ptr<U, handler> p2{handler{}};
             fail();
         }
         catch(std::exception const&)
@@ -70,9 +68,9 @@ public:
         {
             fail();
         }
-        handler_ptr<T, handler> p4{std::move(h)};
+        handler_ptr<T, handler> p3{handler{}};
         bool b = false;
-        p4.invoke(std::ref(b));
+        p3.invoke(std::ref(b));
         BEAST_EXPECT(b);
     }
 };

--- a/test/beast/http/fields.cpp
+++ b/test/beast/http/fields.cpp
@@ -24,7 +24,7 @@ namespace http {
 class fields_test : public beast::unit_test::suite
 {
 public:
-    template <class T>
+    template<class T>
     class test_allocator
     {
     public:
@@ -32,7 +32,8 @@ public:
 
         test_allocator() noexcept(false) {}
 
-        template <typename  U, typename = typename std::enable_if<!std::is_same<test_allocator, U>::value>::type>
+        template<class U, class = typename
+            std::enable_if<!std::is_same<test_allocator, U>::value>::type>
         test_allocator(test_allocator<U> const&) noexcept {}
 
         value_type*
@@ -55,7 +56,7 @@ public:
             return true;
         }
 
-        template <class U>
+        template<class U>
         friend
         bool
         operator!=(test_allocator<T> const& x, test_allocator<U> const& y) noexcept

--- a/test/beast/websocket/error.cpp
+++ b/test/beast/websocket/error.cpp
@@ -41,6 +41,7 @@ public:
         check("boost.beast.websocket", error::failed);
         check("boost.beast.websocket", error::handshake_failed);
         check("boost.beast.websocket", error::buffer_overflow);
+        check("boost.beast.websocket", error::partial_deflate_block);
     }
 };
 

--- a/test/beast/websocket/read.cpp
+++ b/test/beast/websocket/read.cpp
@@ -14,6 +14,8 @@
 
 #include <boost/asio/write.hpp>
 
+#include <boost/beast/core/buffers_to_string.hpp>
+
 namespace boost {
 namespace beast {
 namespace websocket {
@@ -1042,6 +1044,184 @@ public:
         BEAST_EXPECT(n == 0);
     }
 
+    /*  Bishop Fox Hybrid Assessment issue 1
+
+        Happens with permessage-deflate enabled and a
+        compressed frame with the FIN bit set ends with an
+        invalid prefix.
+    */
+    void
+    testIssueBF1()
+    {
+        permessage_deflate pmd;
+        pmd.client_enable = true;
+        pmd.server_enable = true;
+
+        // read
+#if 0
+        {
+            echo_server es{log};
+            boost::asio::io_context ioc;
+            stream<test::stream> ws{ioc};
+            ws.set_option(pmd);
+            ws.next_layer().connect(es.stream());
+            ws.handshake("localhost", "/");
+            // invalid 1-byte deflate block in frame
+            boost::asio::write(ws.next_layer(), sbuf(
+                "\xc1\x81\x3a\xa1\x74\x3b\x49"));
+        }
+#endif
+        {
+            boost::asio::io_context ioc;
+            stream<test::stream> wsc{ioc};
+            stream<test::stream> wss{ioc};
+            wsc.set_option(pmd);
+            wss.set_option(pmd);
+            wsc.next_layer().connect(wss.next_layer());
+            wsc.async_handshake(
+                "localhost", "/", [](error_code){});
+            wss.async_accept([](error_code){});
+            ioc.run();
+            ioc.restart();
+            BEAST_EXPECT(wsc.is_open());
+            BEAST_EXPECT(wss.is_open());
+            // invalid 1-byte deflate block in frame
+            boost::asio::write(wsc.next_layer(), sbuf(
+                "\xc1\x81\x3a\xa1\x74\x3b\x49"));
+            error_code ec;
+            multi_buffer b;
+            wss.read(b, ec);
+            BEAST_EXPECTS(ec == zlib::error::end_of_stream, ec.message());
+        }
+
+        // async read
+#if 0
+        {
+            echo_server es{log, kind::async};
+            boost::asio::io_context ioc;
+            stream<test::stream> ws{ioc};
+            ws.set_option(pmd);
+            ws.next_layer().connect(es.stream());
+            ws.handshake("localhost", "/");
+            // invalid 1-byte deflate block in frame
+            boost::asio::write(ws.next_layer(), sbuf(
+                "\xc1\x81\x3a\xa1\x74\x3b\x49"));
+        }
+#endif
+        {
+            boost::asio::io_context ioc;
+            stream<test::stream> wsc{ioc};
+            stream<test::stream> wss{ioc};
+            wsc.set_option(pmd);
+            wss.set_option(pmd);
+            wsc.next_layer().connect(wss.next_layer());
+            wsc.async_handshake(
+                "localhost", "/", [](error_code){});
+            wss.async_accept([](error_code){});
+            ioc.run();
+            ioc.restart();
+            BEAST_EXPECT(wsc.is_open());
+            BEAST_EXPECT(wss.is_open());
+            // invalid 1-byte deflate block in frame
+            boost::asio::write(wsc.next_layer(), sbuf(
+                "\xc1\x81\x3a\xa1\x74\x3b\x49"));
+            error_code ec;
+            flat_buffer b;
+            wss.async_read(b,
+                [&ec](error_code ec_, std::size_t){ ec = ec_; });
+            ioc.run();
+            BEAST_EXPECTS(ec == zlib::error::end_of_stream, ec.message());
+        }
+    }
+
+    /*  Bishop Fox Hybrid Assessment issue 2
+
+        Happens with permessage-deflate enabled,
+        and a deflate block with the BFINAL bit set
+        is encountered in a compressed payload.
+    */
+    void
+    testIssueBF2()
+    {
+        permessage_deflate pmd;
+        pmd.client_enable = true;
+        pmd.server_enable = true;
+
+        // read
+        {
+            boost::asio::io_context ioc;
+            stream<test::stream> wsc{ioc};
+            stream<test::stream> wss{ioc};
+            wsc.set_option(pmd);
+            wss.set_option(pmd);
+            wsc.next_layer().connect(wss.next_layer());
+            wsc.async_handshake(
+                "localhost", "/", [](error_code){});
+            wss.async_accept([](error_code){});
+            ioc.run();
+            ioc.restart();
+            BEAST_EXPECT(wsc.is_open());
+            BEAST_EXPECT(wss.is_open());
+            // contains a deflate block with BFINAL set
+            boost::asio::write(wsc.next_layer(), sbuf(
+                "\xc1\xf8\xd1\xe4\xcc\x3e\xda\xe4\xcc\x3e"
+                "\x2b\x1e\x36\xc4\x2b\x1e\x36\xc4\x2b\x1e"
+                "\x36\x3e\x35\xae\x4f\x54\x18\xae\x4f\x7b"
+                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e"
+                "\xd1\x1e\x36\xc4\x2b\x1e\x36\xc4\x2b\xe4"
+                "\x28\x74\x52\x8e\x05\x74\x52\xa1\xcc\x3e"
+                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e"
+                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\x36\x3e"
+                "\xd1\xec\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e"));
+            error_code ec;
+            flat_buffer b;
+            wss.read(b, ec);
+            BEAST_EXPECTS(ec == zlib::error::end_of_stream, ec.message());
+        }
+
+        // async read
+        {
+            boost::asio::io_context ioc;
+            stream<test::stream> wsc{ioc};
+            stream<test::stream> wss{ioc};
+            wsc.set_option(pmd);
+            wss.set_option(pmd);
+            wsc.next_layer().connect(wss.next_layer());
+            wsc.async_handshake(
+                "localhost", "/", [](error_code){});
+            wss.async_accept([](error_code){});
+            ioc.run();
+            ioc.restart();
+            BEAST_EXPECT(wsc.is_open());
+            BEAST_EXPECT(wss.is_open());
+            // contains a deflate block with BFINAL set
+            boost::asio::write(wsc.next_layer(), sbuf(
+                "\xc1\xf8\xd1\xe4\xcc\x3e\xda\xe4\xcc\x3e"
+                "\x2b\x1e\x36\xc4\x2b\x1e\x36\xc4\x2b\x1e"
+                "\x36\x3e\x35\xae\x4f\x54\x18\xae\x4f\x7b"
+                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e"
+                "\xd1\x1e\x36\xc4\x2b\x1e\x36\xc4\x2b\xe4"
+                "\x28\x74\x52\x8e\x05\x74\x52\xa1\xcc\x3e"
+                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e"
+                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\x36\x3e"
+                "\xd1\xec\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e"));
+            error_code ec;
+            flat_buffer b;
+            wss.async_read(b,
+                [&ec](error_code ec_, std::size_t){ ec = ec_; });
+            ioc.run();
+            BEAST_EXPECTS(ec == zlib::error::end_of_stream, ec.message());
+        }
+    }
+
     void
     run() override
     {
@@ -1051,6 +1231,8 @@ public:
         testContHook();
         testIssue802();
         testIssue807();
+        testIssueBF1();
+        testIssueBF2();
     }
 };
 


### PR DESCRIPTION
It is no longer a reference counted object and now has semantics close to a std::unique_ptr.