### PR TITLE
Version 149

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version 148:
 * Install codecov on codecov CI targets only
 * Update reports for hybrid assessment
 * Handle invalid deflate frames
+* Fix CMakeLists.txt variable
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 149:
 
 * built-in r-value return values can't be assigned
+* Tidy up ssl_stream special members
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version 148:
 * Update reports for hybrid assessment
 * Handle invalid deflate frames
 * Fix CMakeLists.txt variable
+* Protect calls from macros
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 149:
 * Protect calls from macros
 * pausation always allocates
 * Don't copy completion handlers
+* handler_ptr is move-only
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Version 149:
 * pausation always allocates
 * Don't copy completion handlers
 * handler_ptr is move-only
+* Fix Travis memory utilization
 
 API Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 149:
 * Fix CMakeLists.txt variable
 * Protect calls from macros
 * pausation always allocates
+* Don't copy completion handlers
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Version 149:
 
 * built-in r-value return values can't be assigned
 * Tidy up ssl_stream special members
+* Fix CMakeLists.txt variable
+* Protect calls from macros
+* pausation always allocates
 
 --------------------------------------------------------------------------------
 
@@ -10,8 +13,6 @@ Version 148:
 * Install codecov on codecov CI targets only
 * Update reports for hybrid assessment
 * Handle invalid deflate frames
-* Fix CMakeLists.txt variable
-* Protect calls from macros
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 149:
+
+* built-in r-value return values can't be assigned
+
+--------------------------------------------------------------------------------
+
 Version 148:
 
 * Install codecov on codecov CI targets only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Version 149:
 * Don't copy completion handlers
 * handler_ptr is move-only
 
+API Changes:
+
+* handler_ptr gives the strong exception guarantee
+
+Actions Required:
+
+* Change the constructor signature for state objects
+  used with handler_ptr to receive a const reference to
+  the handler.
+
 --------------------------------------------------------------------------------
 
 Version 148:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.5.1)
 
-project (Beast VERSION 148)
+project (Beast VERSION 149)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/example/common/detect_ssl.hpp
+++ b/example/common/detect_ssl.hpp
@@ -353,7 +353,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(handler_);
+        return (boost::asio::get_associated_allocator)(handler_);
     }
 
     // Executor hook. This is Asio's system for customizing the
@@ -367,7 +367,7 @@ public:
 
     executor_type get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(handler_, stream_.get_executor());
+        return (boost::asio::get_associated_executor)(handler_, stream_.get_executor());
     }
 
     // Determines if the next asynchronous operation represents a

--- a/example/echo-op/echo_op.cpp
+++ b/example/echo-op/echo_op.cpp
@@ -154,7 +154,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(p_.handler());
+        return (boost::asio::get_associated_allocator)(p_.handler());
     }
 
     // Executor hook. This is Asio's system for customizing the
@@ -168,7 +168,7 @@ public:
 
     executor_type get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             p_.handler(), p_->stream.get_executor());
     }
 

--- a/example/echo-op/echo_op.cpp
+++ b/example/echo-op/echo_op.cpp
@@ -107,7 +107,7 @@ class echo_op
         // contained object constructor is a reference to the
         // managed final completion handler.
         //
-        explicit state(Handler& handler, AsyncStream& stream_)
+        explicit state(Handler const& handler, AsyncStream& stream_)
             : stream(stream_)
             , buffer((std::numeric_limits<std::size_t>::max)(),
                 boost::asio::get_associated_allocator(handler))

--- a/include/boost/beast/core/detail/bind_handler.hpp
+++ b/include/boost/beast/core/detail/bind_handler.hpp
@@ -123,7 +123,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     friend

--- a/include/boost/beast/core/detail/bind_handler.hpp
+++ b/include/boost/beast/core/detail/bind_handler.hpp
@@ -109,7 +109,7 @@ public:
         boost::asio::associated_allocator_t<Handler>;
 
     bound_handler(bound_handler&&) = default;
-    bound_handler(bound_handler const&) = default;
+    bound_handler(bound_handler const&) = delete;
 
     template<class DeducedHandler>
     explicit

--- a/include/boost/beast/core/handler_ptr.hpp
+++ b/include/boost/beast/core/handler_ptr.hpp
@@ -49,8 +49,10 @@ namespace beast {
 template<class T, class Handler>
 class handler_ptr
 {
+    using handler_storage_t = typename detail::aligned_union<1, Handler>::type;
+
     T* t_ = nullptr;
-    Handler h_;
+    handler_storage_t h_;
 
     void clear();
 
@@ -100,8 +102,11 @@ public:
         following equivalent signature:
 
         @code
-            T::T(Handler&, Args&&...)
+            T::T(Handler const&, Args&&...)
         @endcode
+
+        @par Exception Safety
+        Strong guarantee.
 
         @param handler The handler to associate with the owned
         object. The argument will be moved if it is an xvalue.
@@ -116,14 +121,14 @@ public:
     handler_type const&
     handler() const
     {
-        return h_;
+        return *reinterpret_cast<Handler const*>(&h_);
     }
 
     /// Returns a reference to the handler
     handler_type&
     handler()
     {
-        return h_;
+        return *reinterpret_cast<Handler*>(&h_);
     }
 
     /** Returns a pointer to the owned object.

--- a/include/boost/beast/core/impl/buffered_read_stream.ipp
+++ b/include/boost/beast/core/impl/buffered_read_stream.ipp
@@ -55,7 +55,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type =
@@ -65,7 +65,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 

--- a/include/boost/beast/core/impl/buffered_read_stream.ipp
+++ b/include/boost/beast/core/impl/buffered_read_stream.ipp
@@ -37,7 +37,7 @@ class buffered_read_stream<
 
 public:
     read_some_op(read_some_op&&) = default;
-    read_some_op(read_some_op const&) = default;
+    read_some_op(read_some_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     read_some_op(DeducedHandler&& h,
@@ -237,7 +237,7 @@ async_read_some(
         void(error_code, std::size_t)> init{handler};
     read_some_op<MutableBufferSequence, BOOST_ASIO_HANDLER_TYPE(
         ReadHandler, void(error_code, std::size_t))>{
-            init.completion_handler, *this, buffers}(
+            std::move(init.completion_handler), *this, buffers}(
                 error_code{}, 0);
     return init.result.get();
 }

--- a/include/boost/beast/core/type_traits.hpp
+++ b/include/boost/beast/core/type_traits.hpp
@@ -52,7 +52,7 @@ template<class T, class Signature>
 using is_completion_handler = std::integral_constant<bool, ...>;
 #else
 using is_completion_handler = std::integral_constant<bool,
-    std::is_copy_constructible<typename std::decay<T>::type>::value &&
+    std::is_move_constructible<typename std::decay<T>::type>::value &&
     detail::is_invocable<T, Signature>::value>;
 #endif
 

--- a/include/boost/beast/http/fields.hpp
+++ b/include/boost/beast/http/fields.hpp
@@ -102,7 +102,7 @@ public:
         value_type& operator=(value_type const&) = delete;
 
         /// Returns the field enum, which can be @ref field::unknown
-        field const
+        field
         name() const;
 
         /// Returns the field name as a string

--- a/include/boost/beast/http/impl/fields.ipp
+++ b/include/boost/beast/http/impl/fields.ipp
@@ -291,7 +291,7 @@ value_type(field name,
 
 template<class Allocator>
 inline
-field const
+field
 basic_fields<Allocator>::
 value_type::
 name() const

--- a/include/boost/beast/http/impl/file_body_win32.ipp
+++ b/include/boost/beast/http/impl/file_body_win32.ipp
@@ -364,7 +364,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type =
@@ -374,7 +374,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, sock_.get_executor());
     }
 

--- a/include/boost/beast/http/impl/read.ipp
+++ b/include/boost/beast/http/impl/read.ipp
@@ -50,7 +50,7 @@ class read_some_op
 
 public:
     read_some_op(read_some_op&&) = default;
-    read_some_op(read_some_op const&) = default;
+    read_some_op(read_some_op const&) = delete;
 
     template<class DeducedHandler>
     read_some_op(DeducedHandler&& h, Stream& s,
@@ -208,7 +208,7 @@ class read_op
 
 public:
     read_op(read_op&&) = default;
-    read_op(read_op const&) = default;
+    read_op(read_op const&) = delete;
 
     template<class DeducedHandler>
     read_op(DeducedHandler&& h, Stream& s,
@@ -331,7 +331,7 @@ class read_msg_op
 
 public:
     read_msg_op(read_msg_op&&) = default;
-    read_msg_op(read_msg_op const&) = default;
+    read_msg_op(read_msg_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     read_msg_op(DeducedHandler&& h, Stream& s, Args&&... args)
@@ -531,7 +531,7 @@ async_read_some(
     detail::read_some_op<AsyncReadStream,
         DynamicBuffer, isRequest, Derived, BOOST_ASIO_HANDLER_TYPE(
             ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler, stream, buffer, parser}(
+                std::move(init.completion_handler), stream, buffer, parser}(
                     {}, 0, false);
     return init.result.get();
 }
@@ -619,8 +619,8 @@ async_read_header(
     detail::read_op<AsyncReadStream, DynamicBuffer,
         isRequest, Derived, detail::parser_is_header_done,
             BOOST_ASIO_HANDLER_TYPE(ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler, stream, buffer, parser}(
-                    {}, 0, false);
+                std::move(init.completion_handler), stream,
+                buffer, parser}({}, 0, false);
     return init.result.get();
 }
 
@@ -708,7 +708,7 @@ async_read(
     detail::read_op<AsyncReadStream, DynamicBuffer,
         isRequest, Derived, detail::parser_is_done,
             BOOST_ASIO_HANDLER_TYPE(ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler, stream, buffer, parser}(
+                std::move(init.completion_handler), stream, buffer, parser}(
                     {}, 0, false);
     return init.result.get();
 }
@@ -803,7 +803,7 @@ async_read(
         isRequest, Body, Allocator,
         BOOST_ASIO_HANDLER_TYPE(
             ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler, stream, buffer, msg}(
+                std::move(init.completion_handler), stream, buffer, msg}(
                     {}, 0, false);
     return init.result.get();
 }

--- a/include/boost/beast/http/impl/read.ipp
+++ b/include/boost/beast/http/impl/read.ipp
@@ -316,7 +316,7 @@ class read_msg_op
         std::size_t bytes_transferred = 0;
         bool cont = false;
 
-        data(Handler&, Stream& s_,
+        data(Handler const&, Stream& s_,
                 DynamicBuffer& b_, message_type& m_)
             : s(s_)
             , b(b_)

--- a/include/boost/beast/http/impl/read.ipp
+++ b/include/boost/beast/http/impl/read.ipp
@@ -68,7 +68,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -77,7 +77,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 
@@ -227,7 +227,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -236,7 +236,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 
@@ -346,7 +346,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -355,7 +355,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->s.get_executor());
     }
 

--- a/include/boost/beast/http/impl/write.ipp
+++ b/include/boost/beast/http/impl/write.ipp
@@ -67,7 +67,7 @@ class write_some_op
 
 public:
     write_some_op(write_some_op&&) = default;
-    write_some_op(write_some_op const&) = default;
+    write_some_op(write_some_op const&) = delete;
 
     template<class DeducedHandler>
     write_some_op(DeducedHandler&& h, Stream& s,
@@ -203,7 +203,7 @@ class write_op
 
 public:
     write_op(write_op&&) = default;
-    write_op(write_op const&) = default;
+    write_op(write_op const&) = delete;
 
     template<class DeducedHandler>
     write_op(DeducedHandler&& h, Stream& s,
@@ -318,7 +318,7 @@ class write_msg_op
 
 public:
     write_msg_op(write_msg_op&&) = default;
-    write_msg_op(write_msg_op const&) = default;
+    write_msg_op(write_msg_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     write_msg_op(DeducedHandler&& h, Stream& s, Args&&... args)
@@ -479,7 +479,7 @@ async_write_some_impl(
         BOOST_ASIO_HANDLER_TYPE(WriteHandler,
             void(error_code, std::size_t)),
         isRequest, Body, Fields>{
-            init.completion_handler, stream, sr}();
+            std::move(init.completion_handler), stream, sr}();
     return init.result.get();
 }
 
@@ -638,7 +638,7 @@ async_write_header(
             void(error_code, std::size_t)),
         detail::serializer_is_header_done,
         isRequest, Body, Fields>{
-        init.completion_handler, stream, sr}();
+        std::move(init.completion_handler), stream, sr}();
     return init.result.get();
 }
 
@@ -715,7 +715,7 @@ async_write(
             void(error_code, std::size_t)),
         detail::serializer_is_done,
         isRequest, Body, Fields>{
-            init.completion_handler, stream, sr}();
+            std::move(init.completion_handler), stream, sr}();
     return init.result.get();
 }
 
@@ -788,7 +788,7 @@ async_write(
         BOOST_ASIO_HANDLER_TYPE(WriteHandler,
             void(error_code, std::size_t)),
         isRequest, Body, Fields>{
-            init.completion_handler, stream, msg}();
+            std::move(init.completion_handler), stream, msg}();
     return init.result.get();
 }
 

--- a/include/boost/beast/http/impl/write.ipp
+++ b/include/boost/beast/http/impl/write.ipp
@@ -306,7 +306,7 @@ class write_msg_op
         Stream& s;
         serializer<isRequest, Body, Fields> sr;
 
-        data(Handler&, Stream& s_, message<
+        data(Handler const&, Stream& s_, message<
                 isRequest, Body, Fields>& m_)
             : s(s_)
             , sr(m_)

--- a/include/boost/beast/http/impl/write.ipp
+++ b/include/boost/beast/http/impl/write.ipp
@@ -84,7 +84,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -93,7 +93,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 
@@ -220,7 +220,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -229,7 +229,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 
@@ -333,7 +333,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -342,7 +342,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->s.get_executor());
     }
 

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 148
+#define BOOST_BEAST_VERSION 149
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/impl/accept.ipp
+++ b/include/boost/beast/websocket/impl/accept.ipp
@@ -45,7 +45,7 @@ class stream<NextLayer>::response_op
         response_type res;
 
         template<class Body, class Allocator, class Decorator>
-        data(Handler&, stream<NextLayer>& ws_, http::request<
+        data(Handler const&, stream<NextLayer>& ws_, http::request<
             Body, http::basic_fields<Allocator>> const& req,
                 Decorator const& decorator)
             : ws(ws_)
@@ -142,7 +142,7 @@ class stream<NextLayer>::accept_op
         stream<NextLayer>& ws;
         Decorator decorator;
         http::request_parser<http::empty_body> p;
-        data(Handler&, stream<NextLayer>& ws_,
+        data(Handler const&, stream<NextLayer>& ws_,
                 Decorator const& decorator_)
             : ws(ws_)
             , decorator(decorator_)

--- a/include/boost/beast/websocket/impl/accept.ipp
+++ b/include/boost/beast/websocket/impl/accept.ipp
@@ -74,7 +74,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -83,7 +83,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->ws.get_executor());
     }
 
@@ -170,7 +170,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -179,7 +179,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->ws.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/accept.ipp
+++ b/include/boost/beast/websocket/impl/accept.ipp
@@ -58,7 +58,7 @@ class stream<NextLayer>::response_op
 
 public:
     response_op(response_op&&) = default;
-    response_op(response_op const&) = default;
+    response_op(response_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     response_op(DeducedHandler&& h,
@@ -154,7 +154,7 @@ class stream<NextLayer>::accept_op
 
 public:
     accept_op(accept_op&&) = default;
-    accept_op(accept_op const&) = default;
+    accept_op(accept_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     accept_op(DeducedHandler&& h,
@@ -545,7 +545,7 @@ async_accept(
         decltype(&default_decorate_res),
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 &default_decorate_res}({});
     return init.result.get();
@@ -574,7 +574,7 @@ async_accept_ex(
         ResponseDecorator,
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 decorator}({});
     return init.result.get();
@@ -605,7 +605,7 @@ async_accept(
         decltype(&default_decorate_res),
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 &default_decorate_res}.run(buffers);
     return init.result.get();
@@ -641,7 +641,7 @@ async_accept_ex(
         ResponseDecorator,
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 decorator}.run(buffers);
     return init.result.get();
@@ -667,7 +667,7 @@ async_accept(
     response_op<
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 req,
                 &default_decorate_res}();
@@ -699,7 +699,7 @@ async_accept_ex(
     response_op<
         BOOST_ASIO_HANDLER_TYPE(
             AcceptHandler, void(error_code))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 req,
                 decorator}();

--- a/include/boost/beast/websocket/impl/close.ipp
+++ b/include/boost/beast/websocket/impl/close.ipp
@@ -64,7 +64,7 @@ class stream<NextLayer>::close_op
 
 public:
     close_op(close_op&&) = default;
-    close_op(close_op const&) = default;
+    close_op(close_op const&) = delete;
 
     template<class DeducedHandler>
     close_op(
@@ -447,7 +447,7 @@ async_close(close_reason const& cr, CloseHandler&& handler)
         void(error_code)> init{handler};
     close_op<BOOST_ASIO_HANDLER_TYPE(
         CloseHandler, void(error_code))>{
-            init.completion_handler, *this, cr}(
+            std::move(init.completion_handler), *this, cr}(
                 {}, 0, false);
     return init.result.get();
 }

--- a/include/boost/beast/websocket/impl/close.ipp
+++ b/include/boost/beast/websocket/impl/close.ipp
@@ -48,7 +48,7 @@ class stream<NextLayer>::close_op
         bool cont = false;
 
         state(
-            Handler&,
+            Handler const&,
             stream<NextLayer>& ws_,
             close_reason const& cr)
             : ws(ws_)

--- a/include/boost/beast/websocket/impl/close.ipp
+++ b/include/boost/beast/websocket/impl/close.ipp
@@ -81,7 +81,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -90,7 +90,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->ws.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/handshake.ipp
+++ b/include/boost/beast/websocket/impl/handshake.ipp
@@ -47,7 +47,7 @@ class stream<NextLayer>::handshake_op
         response_type res;
 
         template<class Decorator>
-        data(Handler&, stream<NextLayer>& ws_,
+        data(Handler const&, stream<NextLayer>& ws_,
             response_type* res_p_,
                 string_view host,
                     string_view target,

--- a/include/boost/beast/websocket/impl/handshake.ipp
+++ b/include/boost/beast/websocket/impl/handshake.ipp
@@ -81,7 +81,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -90,7 +90,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->ws.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/handshake.ipp
+++ b/include/boost/beast/websocket/impl/handshake.ipp
@@ -65,7 +65,7 @@ class stream<NextLayer>::handshake_op
 
 public:
     handshake_op(handshake_op&&) = default;
-    handshake_op(handshake_op const&) = default;
+    handshake_op(handshake_op const&) = delete;
 
     template<class DeducedHandler, class... Args>
     handshake_op(DeducedHandler&& h,
@@ -161,7 +161,7 @@ async_handshake(string_view host,
         void(error_code)> init{handler};
     handshake_op<BOOST_ASIO_HANDLER_TYPE(
         HandshakeHandler, void(error_code))>{
-            init.completion_handler, *this, nullptr, host,
+            std::move(init.completion_handler), *this, nullptr, host,
                 target, &default_decorate_req}();
     return init.result.get();
 }
@@ -182,7 +182,7 @@ async_handshake(response_type& res,
         void(error_code)> init{handler};
     handshake_op<BOOST_ASIO_HANDLER_TYPE(
         HandshakeHandler, void(error_code))>{
-            init.completion_handler, *this, &res, host,
+            std::move(init.completion_handler), *this, &res, host,
                 target, &default_decorate_req}();
     return init.result.get();
 }
@@ -206,7 +206,7 @@ async_handshake_ex(string_view host,
         void(error_code)> init{handler};
     handshake_op<BOOST_ASIO_HANDLER_TYPE(
         HandshakeHandler, void(error_code))>{
-            init.completion_handler, *this, nullptr, host,
+            std::move(init.completion_handler), *this, nullptr, host,
                 target, decorator}();
     return init.result.get();
 }
@@ -231,7 +231,7 @@ async_handshake_ex(response_type& res,
         void(error_code)> init{handler};
     handshake_op<BOOST_ASIO_HANDLER_TYPE(
         HandshakeHandler, void(error_code))>{
-            init.completion_handler, *this, &res, host,
+            std::move(init.completion_handler), *this, &res, host,
                 target, decorator}();
     return init.result.get();
 }

--- a/include/boost/beast/websocket/impl/ping.ipp
+++ b/include/boost/beast/websocket/impl/ping.ipp
@@ -44,7 +44,7 @@ class stream<NextLayer>::ping_op
         token tok;
 
         state(
-            Handler&,
+            Handler const&,
             stream<NextLayer>& ws_,
             detail::opcode op,
             ping_data const& payload)

--- a/include/boost/beast/websocket/impl/ping.ipp
+++ b/include/boost/beast/websocket/impl/ping.ipp
@@ -81,7 +81,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(d_.handler());
+        return (boost::asio::get_associated_allocator)(d_.handler());
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -90,7 +90,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             d_.handler(), d_->ws.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/ping.ipp
+++ b/include/boost/beast/websocket/impl/ping.ipp
@@ -62,7 +62,7 @@ class stream<NextLayer>::ping_op
 
 public:
     ping_op(ping_op&&) = default;
-    ping_op(ping_op const&) = default;
+    ping_op(ping_op const&) = delete;
 
     template<class DeducedHandler>
     ping_op(
@@ -241,7 +241,7 @@ async_ping(ping_data const& payload, WriteHandler&& handler)
         void(error_code)> init{handler};
     ping_op<BOOST_ASIO_HANDLER_TYPE(
         WriteHandler, void(error_code))>{
-            init.completion_handler, *this,
+            std::move(init.completion_handler), *this,
                 detail::opcode::ping, payload}();
     return init.result.get();
 }
@@ -259,7 +259,7 @@ async_pong(ping_data const& payload, WriteHandler&& handler)
         void(error_code)> init{handler};
     ping_op<BOOST_ASIO_HANDLER_TYPE(
         WriteHandler, void(error_code))>{
-            init.completion_handler, *this,
+            std::move(init.completion_handler), *this,
                 detail::opcode::pong, payload}();
     return init.result.get();
 }

--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -59,7 +59,7 @@ class stream<NextLayer>::read_some_op
 
 public:
     read_some_op(read_some_op&&) = default;
-    read_some_op(read_some_op const&) = default;
+    read_some_op(read_some_op const&) = delete;
 
     template<class DeducedHandler>
     read_some_op(
@@ -683,7 +683,7 @@ public:
         boost::asio::associated_allocator_t<Handler>;
 
     read_op(read_op&&) = default;
-    read_op(read_op const&) = default;
+    read_op(read_op const&) = delete;
 
     template<class DeducedHandler>
     read_op(
@@ -839,7 +839,7 @@ async_read(DynamicBuffer& buffer, ReadHandler&& handler)
         DynamicBuffer,
         BOOST_ASIO_HANDLER_TYPE(
             ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 buffer,
                 0,
@@ -927,7 +927,7 @@ async_read_some(
         DynamicBuffer,
         BOOST_ASIO_HANDLER_TYPE(
             ReadHandler, void(error_code, std::size_t))>{
-                init.completion_handler,
+                std::move(init.completion_handler),
                 *this,
                 buffer,
                 limit,
@@ -1311,7 +1311,7 @@ async_read_some(
         void(error_code, std::size_t)> init{handler};
     read_some_op<MutableBufferSequence, BOOST_ASIO_HANDLER_TYPE(
         ReadHandler, void(error_code, std::size_t))>{
-            init.completion_handler,*this, buffers}(
+            std::move(init.completion_handler), *this, buffers}(
                 {}, 0, false);
     return init.result.get();
 }

--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -152,7 +152,7 @@ operator()(
             // Suspend
             BOOST_ASSERT(ws_.rd_block_ != tok_);
             BOOST_ASIO_CORO_YIELD
-            ws_.paused_r_rd_.save(std::move(*this));
+            ws_.paused_r_rd_.emplace(std::move(*this));
 
             // Acquire the read block
             BOOST_ASSERT(! ws_.rd_block_);
@@ -275,7 +275,7 @@ operator()(
                         // Suspend
                         BOOST_ASSERT(ws_.wr_block_ != tok_);
                         BOOST_ASIO_CORO_YIELD
-                        ws_.paused_rd_.save(std::move(*this));
+                        ws_.paused_rd_.emplace(std::move(*this));
 
                         // Acquire the write block
                         BOOST_ASSERT(! ws_.wr_block_);
@@ -580,7 +580,7 @@ operator()(
             // Suspend
             BOOST_ASSERT(ws_.wr_block_ != tok_);
             BOOST_ASIO_CORO_YIELD
-            ws_.paused_rd_.save(std::move(*this));
+            ws_.paused_rd_.emplace(std::move(*this));
 
             // Acquire the write block
             BOOST_ASSERT(! ws_.wr_block_);

--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -81,7 +81,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -90,7 +90,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, ws_.get_executor());
     }
 
@@ -704,7 +704,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -713,7 +713,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, ws_.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/teardown.ipp
+++ b/include/boost/beast/websocket/impl/teardown.ipp
@@ -56,7 +56,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -65,7 +65,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, s_.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/write.ipp
+++ b/include/boost/beast/websocket/impl/write.ipp
@@ -76,7 +76,7 @@ public:
     allocator_type
     get_allocator() const noexcept
     {
-        return boost::asio::get_associated_allocator(h_);
+        return (boost::asio::get_associated_allocator)(h_);
     }
 
     using executor_type = boost::asio::associated_executor_t<
@@ -85,7 +85,7 @@ public:
     executor_type
     get_executor() const noexcept
     {
-        return boost::asio::get_associated_executor(
+        return (boost::asio::get_associated_executor)(
             h_, ws_.get_executor());
     }
 

--- a/include/boost/beast/websocket/impl/write.ipp
+++ b/include/boost/beast/websocket/impl/write.ipp
@@ -54,7 +54,7 @@ class stream<NextLayer>::write_some_op
 
 public:
     write_some_op(write_some_op&&) = default;
-    write_some_op(write_some_op const&) = default;
+    write_some_op(write_some_op const&) = delete;
 
     template<class DeducedHandler>
     write_some_op(
@@ -728,7 +728,7 @@ async_write_some(bool fin,
         void(error_code, std::size_t)> init{handler};
     write_some_op<ConstBufferSequence, BOOST_ASIO_HANDLER_TYPE(
         WriteHandler, void(error_code, std::size_t))>{
-            init.completion_handler, *this, fin, bs}(
+            std::move(init.completion_handler), *this, fin, bs}(
                 {}, 0, false);
     return init.result.get();
 }
@@ -784,7 +784,7 @@ async_write(
         void(error_code, std::size_t)> init{handler};
     write_some_op<ConstBufferSequence, BOOST_ASIO_HANDLER_TYPE(
         WriteHandler, void(error_code, std::size_t))>{
-            init.completion_handler, *this, true, bs}(
+            std::move(init.completion_handler), *this, true, bs}(
                 {}, 0, false);
     return init.result.get();
 }

--- a/include/boost/beast/websocket/impl/write.ipp
+++ b/include/boost/beast/websocket/impl/write.ipp
@@ -208,7 +208,7 @@ operator()(
             // Suspend
             BOOST_ASSERT(ws_.wr_block_ != tok_);
             BOOST_ASIO_CORO_YIELD
-            ws_.paused_wr_.save(std::move(*this));
+            ws_.paused_wr_.emplace(std::move(*this));
 
             // Acquire the write block
             BOOST_ASSERT(! ws_.wr_block_);

--- a/include/boost/beast/websocket/stream.hpp
+++ b/include/boost/beast/websocket/stream.hpp
@@ -123,7 +123,8 @@ class stream
     friend class close_test;
     friend class frame_test;
     friend class ping_test;
-    friend class read_test;
+    friend class read1_test;
+    friend class read2_test;
     friend class stream_test;
     friend class write_test;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,7 @@ include_directories (./extern)
 include_directories (./extras/include)
 include_directories (../subtree/unit_test/include)
 
-file (GLOB_RECURSE EXTRAS_INCLUDES
+file (GLOB_RECURSE EXTRAS_FILES
     ${PROJECT_SOURCE_DIR}/test/extras/include/*.hpp
     ${PROJECT_SOURCE_DIR}/test/extras/include/*.ipp
     ${PROJECT_SOURCE_DIR}/subtree/unit_test/include/*.hpp

--- a/test/beast/core/handler_ptr.cpp
+++ b/test/beast/core/handler_ptr.cpp
@@ -34,7 +34,8 @@ public:
 
     struct T
     {
-        T(handler&)
+        explicit
+        T(handler const&)
         {
         }
 
@@ -45,7 +46,8 @@ public:
 
     struct U
     {
-        U(handler&)
+        explicit
+        U(handler const&)
         {
             throw std::exception{};
         }

--- a/test/beast/core/handler_ptr.cpp
+++ b/test/beast/core/handler_ptr.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/beast/unit_test/suite.hpp>
 #include <exception>
+#include <memory>
 #include <utility>
 
 namespace boost {
@@ -22,8 +23,7 @@ class handler_ptr_test : public beast::unit_test::suite
 public:
     struct handler
     {
-        handler() = default;
-        handler(handler const&) = default;
+        std::unique_ptr<int> ptr;
 
         void
         operator()(bool& b) const
@@ -54,12 +54,10 @@ public:
     void
     run() override
     {
-        handler h;
-        handler_ptr<T, handler> p1{h};
-        handler_ptr<T, handler> p2{p1};
+        handler_ptr<T, handler> p1{handler{}};
         try
         {
-            handler_ptr<U, handler> p3{h};
+            handler_ptr<U, handler> p2{handler{}};
             fail();
         }
         catch(std::exception const&)
@@ -70,9 +68,9 @@ public:
         {
             fail();
         }
-        handler_ptr<T, handler> p4{std::move(h)};
+        handler_ptr<T, handler> p3{handler{}};
         bool b = false;
-        p4.invoke(std::ref(b));
+        p3.invoke(std::ref(b));
         BEAST_EXPECT(b);
     }
 };

--- a/test/beast/http/fields.cpp
+++ b/test/beast/http/fields.cpp
@@ -24,7 +24,7 @@ namespace http {
 class fields_test : public beast::unit_test::suite
 {
 public:
-    template <class T>
+    template<class T>
     class test_allocator
     {
     public:
@@ -32,7 +32,8 @@ public:
 
         test_allocator() noexcept(false) {}
 
-        template <typename  U, typename = typename std::enable_if<!std::is_same<test_allocator, U>::value>::type>
+        template<class U, class = typename
+            std::enable_if<!std::is_same<test_allocator, U>::value>::type>
         test_allocator(test_allocator<U> const&) noexcept {}
 
         value_type*
@@ -55,7 +56,7 @@ public:
             return true;
         }
 
-        template <class U>
+        template<class U>
         friend
         bool
         operator!=(test_allocator<T> const& x, test_allocator<U> const& y) noexcept

--- a/test/beast/websocket/CMakeLists.txt
+++ b/test/beast/websocket/CMakeLists.txt
@@ -26,7 +26,8 @@ add_executable (tests-beast-websocket
     mask.cpp
     option.cpp
     ping.cpp
-    read.cpp
+    read1.cpp
+    read2.cpp
     rfc6455.cpp
     role.cpp
     stream.cpp

--- a/test/beast/websocket/Jamfile
+++ b/test/beast/websocket/Jamfile
@@ -16,7 +16,8 @@ local SOURCES =
     mask.cpp
     option.cpp
     ping.cpp
-    read.cpp
+    read1.cpp
+    read2.cpp
     rfc6455.cpp
     role.cpp
     stream.cpp

--- a/test/beast/websocket/read1.cpp
+++ b/test/beast/websocket/read1.cpp
@@ -20,7 +20,7 @@ namespace boost {
 namespace beast {
 namespace websocket {
 
-class read_test : public websocket_test_suite
+class read1_test : public websocket_test_suite
 {
 public:
     template<class Wrap>
@@ -1009,234 +1009,16 @@ public:
     }
 
     void
-    testIssue802()
-    {
-        for(std::size_t i = 0; i < 100; ++i)
-        {
-            echo_server es{log, kind::async};
-            boost::asio::io_context ioc;
-            stream<test::stream> ws{ioc};
-            ws.next_layer().connect(es.stream());
-            ws.handshake("localhost", "/");
-            // too-big message frame indicates payload of 2^64-1
-            boost::asio::write(ws.next_layer(), sbuf(
-                "\x81\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"));
-            multi_buffer b;
-            error_code ec;
-            ws.read(b, ec);
-            BEAST_EXPECT(ec == error::closed);
-            BEAST_EXPECT(ws.reason().code == 1009);
-        }
-    }
-
-    void
-    testIssue807()
-    {
-        echo_server es{log};
-        boost::asio::io_context ioc;
-        stream<test::stream> ws{ioc};
-        ws.next_layer().connect(es.stream());
-        ws.handshake("localhost", "/");
-        ws.write(sbuf("Hello, world!"));
-        char buf[4];
-        boost::asio::mutable_buffer b{buf, 0};
-        auto const n = ws.read_some(b);
-        BEAST_EXPECT(n == 0);
-    }
-
-    /*  Bishop Fox Hybrid Assessment issue 1
-
-        Happens with permessage-deflate enabled and a
-        compressed frame with the FIN bit set ends with an
-        invalid prefix.
-    */
-    void
-    testIssueBF1()
-    {
-        permessage_deflate pmd;
-        pmd.client_enable = true;
-        pmd.server_enable = true;
-
-        // read
-#if 0
-        {
-            echo_server es{log};
-            boost::asio::io_context ioc;
-            stream<test::stream> ws{ioc};
-            ws.set_option(pmd);
-            ws.next_layer().connect(es.stream());
-            ws.handshake("localhost", "/");
-            // invalid 1-byte deflate block in frame
-            boost::asio::write(ws.next_layer(), sbuf(
-                "\xc1\x81\x3a\xa1\x74\x3b\x49"));
-        }
-#endif
-        {
-            boost::asio::io_context ioc;
-            stream<test::stream> wsc{ioc};
-            stream<test::stream> wss{ioc};
-            wsc.set_option(pmd);
-            wss.set_option(pmd);
-            wsc.next_layer().connect(wss.next_layer());
-            wsc.async_handshake(
-                "localhost", "/", [](error_code){});
-            wss.async_accept([](error_code){});
-            ioc.run();
-            ioc.restart();
-            BEAST_EXPECT(wsc.is_open());
-            BEAST_EXPECT(wss.is_open());
-            // invalid 1-byte deflate block in frame
-            boost::asio::write(wsc.next_layer(), sbuf(
-                "\xc1\x81\x3a\xa1\x74\x3b\x49"));
-            error_code ec;
-            multi_buffer b;
-            wss.read(b, ec);
-            BEAST_EXPECTS(ec == zlib::error::end_of_stream, ec.message());
-        }
-
-        // async read
-#if 0
-        {
-            echo_server es{log, kind::async};
-            boost::asio::io_context ioc;
-            stream<test::stream> ws{ioc};
-            ws.set_option(pmd);
-            ws.next_layer().connect(es.stream());
-            ws.handshake("localhost", "/");
-            // invalid 1-byte deflate block in frame
-            boost::asio::write(ws.next_layer(), sbuf(
-                "\xc1\x81\x3a\xa1\x74\x3b\x49"));
-        }
-#endif
-        {
-            boost::asio::io_context ioc;
-            stream<test::stream> wsc{ioc};
-            stream<test::stream> wss{ioc};
-            wsc.set_option(pmd);
-            wss.set_option(pmd);
-            wsc.next_layer().connect(wss.next_layer());
-            wsc.async_handshake(
-                "localhost", "/", [](error_code){});
-            wss.async_accept([](error_code){});
-            ioc.run();
-            ioc.restart();
-            BEAST_EXPECT(wsc.is_open());
-            BEAST_EXPECT(wss.is_open());
-            // invalid 1-byte deflate block in frame
-            boost::asio::write(wsc.next_layer(), sbuf(
-                "\xc1\x81\x3a\xa1\x74\x3b\x49"));
-            error_code ec;
-            flat_buffer b;
-            wss.async_read(b,
-                [&ec](error_code ec_, std::size_t){ ec = ec_; });
-            ioc.run();
-            BEAST_EXPECTS(ec == zlib::error::end_of_stream, ec.message());
-        }
-    }
-
-    /*  Bishop Fox Hybrid Assessment issue 2
-
-        Happens with permessage-deflate enabled,
-        and a deflate block with the BFINAL bit set
-        is encountered in a compressed payload.
-    */
-    void
-    testIssueBF2()
-    {
-        permessage_deflate pmd;
-        pmd.client_enable = true;
-        pmd.server_enable = true;
-
-        // read
-        {
-            boost::asio::io_context ioc;
-            stream<test::stream> wsc{ioc};
-            stream<test::stream> wss{ioc};
-            wsc.set_option(pmd);
-            wss.set_option(pmd);
-            wsc.next_layer().connect(wss.next_layer());
-            wsc.async_handshake(
-                "localhost", "/", [](error_code){});
-            wss.async_accept([](error_code){});
-            ioc.run();
-            ioc.restart();
-            BEAST_EXPECT(wsc.is_open());
-            BEAST_EXPECT(wss.is_open());
-            // contains a deflate block with BFINAL set
-            boost::asio::write(wsc.next_layer(), sbuf(
-                "\xc1\xf8\xd1\xe4\xcc\x3e\xda\xe4\xcc\x3e"
-                "\x2b\x1e\x36\xc4\x2b\x1e\x36\xc4\x2b\x1e"
-                "\x36\x3e\x35\xae\x4f\x54\x18\xae\x4f\x7b"
-                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
-                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e"
-                "\xd1\x1e\x36\xc4\x2b\x1e\x36\xc4\x2b\xe4"
-                "\x28\x74\x52\x8e\x05\x74\x52\xa1\xcc\x3e"
-                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
-                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e"
-                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
-                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\x36\x3e"
-                "\xd1\xec\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
-                "\xcc\x3e\xd1\xe4\xcc\x3e"));
-            error_code ec;
-            flat_buffer b;
-            wss.read(b, ec);
-            BEAST_EXPECTS(ec == zlib::error::end_of_stream, ec.message());
-        }
-
-        // async read
-        {
-            boost::asio::io_context ioc;
-            stream<test::stream> wsc{ioc};
-            stream<test::stream> wss{ioc};
-            wsc.set_option(pmd);
-            wss.set_option(pmd);
-            wsc.next_layer().connect(wss.next_layer());
-            wsc.async_handshake(
-                "localhost", "/", [](error_code){});
-            wss.async_accept([](error_code){});
-            ioc.run();
-            ioc.restart();
-            BEAST_EXPECT(wsc.is_open());
-            BEAST_EXPECT(wss.is_open());
-            // contains a deflate block with BFINAL set
-            boost::asio::write(wsc.next_layer(), sbuf(
-                "\xc1\xf8\xd1\xe4\xcc\x3e\xda\xe4\xcc\x3e"
-                "\x2b\x1e\x36\xc4\x2b\x1e\x36\xc4\x2b\x1e"
-                "\x36\x3e\x35\xae\x4f\x54\x18\xae\x4f\x7b"
-                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
-                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e"
-                "\xd1\x1e\x36\xc4\x2b\x1e\x36\xc4\x2b\xe4"
-                "\x28\x74\x52\x8e\x05\x74\x52\xa1\xcc\x3e"
-                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
-                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e"
-                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
-                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\x36\x3e"
-                "\xd1\xec\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
-                "\xcc\x3e\xd1\xe4\xcc\x3e"));
-            error_code ec;
-            flat_buffer b;
-            wss.async_read(b,
-                [&ec](error_code ec_, std::size_t){ ec = ec_; });
-            ioc.run();
-            BEAST_EXPECTS(ec == zlib::error::end_of_stream, ec.message());
-        }
-    }
-
-    void
     run() override
     {
         testRead();
         testSuspend();
         testParseFrame();
         testContHook();
-        testIssue802();
-        testIssue807();
-        testIssueBF1();
-        testIssueBF2();
     }
 };
 
-BEAST_DEFINE_TESTSUITE(beast,websocket,read);
+BEAST_DEFINE_TESTSUITE(beast,websocket,read1);
 
 } // websocket
 } // beast

--- a/test/beast/websocket/read2.cpp
+++ b/test/beast/websocket/read2.cpp
@@ -1,0 +1,254 @@
+//
+// Copyright (w) 2016-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+// Test that header file is self-contained.
+#include <boost/beast/websocket/stream.hpp>
+
+#include "test.hpp"
+
+#include <boost/asio/write.hpp>
+
+#include <boost/beast/core/buffers_to_string.hpp>
+
+namespace boost {
+namespace beast {
+namespace websocket {
+
+class read2_test : public websocket_test_suite
+{
+public:
+    void
+    testIssue802()
+    {
+        for(std::size_t i = 0; i < 100; ++i)
+        {
+            echo_server es{log, kind::async};
+            boost::asio::io_context ioc;
+            stream<test::stream> ws{ioc};
+            ws.next_layer().connect(es.stream());
+            ws.handshake("localhost", "/");
+            // too-big message frame indicates payload of 2^64-1
+            boost::asio::write(ws.next_layer(), sbuf(
+                "\x81\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"));
+            multi_buffer b;
+            error_code ec;
+            ws.read(b, ec);
+            BEAST_EXPECT(ec == error::closed);
+            BEAST_EXPECT(ws.reason().code == 1009);
+        }
+    }
+
+    void
+    testIssue807()
+    {
+        echo_server es{log};
+        boost::asio::io_context ioc;
+        stream<test::stream> ws{ioc};
+        ws.next_layer().connect(es.stream());
+        ws.handshake("localhost", "/");
+        ws.write(sbuf("Hello, world!"));
+        char buf[4];
+        boost::asio::mutable_buffer b{buf, 0};
+        auto const n = ws.read_some(b);
+        BEAST_EXPECT(n == 0);
+    }
+
+    /*  Bishop Fox Hybrid Assessment issue 1
+
+        Happens with permessage-deflate enabled and a
+        compressed frame with the FIN bit set ends with an
+        invalid prefix.
+    */
+    void
+    testIssueBF1()
+    {
+        permessage_deflate pmd;
+        pmd.client_enable = true;
+        pmd.server_enable = true;
+
+        // read
+#if 0
+        {
+            echo_server es{log};
+            boost::asio::io_context ioc;
+            stream<test::stream> ws{ioc};
+            ws.set_option(pmd);
+            ws.next_layer().connect(es.stream());
+            ws.handshake("localhost", "/");
+            // invalid 1-byte deflate block in frame
+            boost::asio::write(ws.next_layer(), sbuf(
+                "\xc1\x81\x3a\xa1\x74\x3b\x49"));
+        }
+#endif
+        {
+            boost::asio::io_context ioc;
+            stream<test::stream> wsc{ioc};
+            stream<test::stream> wss{ioc};
+            wsc.set_option(pmd);
+            wss.set_option(pmd);
+            wsc.next_layer().connect(wss.next_layer());
+            wsc.async_handshake(
+                "localhost", "/", [](error_code){});
+            wss.async_accept([](error_code){});
+            ioc.run();
+            ioc.restart();
+            BEAST_EXPECT(wsc.is_open());
+            BEAST_EXPECT(wss.is_open());
+            // invalid 1-byte deflate block in frame
+            boost::asio::write(wsc.next_layer(), sbuf(
+                "\xc1\x81\x3a\xa1\x74\x3b\x49"));
+            error_code ec;
+            multi_buffer b;
+            wss.read(b, ec);
+            BEAST_EXPECTS(ec == zlib::error::end_of_stream, ec.message());
+        }
+
+        // async read
+#if 0
+        {
+            echo_server es{log, kind::async};
+            boost::asio::io_context ioc;
+            stream<test::stream> ws{ioc};
+            ws.set_option(pmd);
+            ws.next_layer().connect(es.stream());
+            ws.handshake("localhost", "/");
+            // invalid 1-byte deflate block in frame
+            boost::asio::write(ws.next_layer(), sbuf(
+                "\xc1\x81\x3a\xa1\x74\x3b\x49"));
+        }
+#endif
+        {
+            boost::asio::io_context ioc;
+            stream<test::stream> wsc{ioc};
+            stream<test::stream> wss{ioc};
+            wsc.set_option(pmd);
+            wss.set_option(pmd);
+            wsc.next_layer().connect(wss.next_layer());
+            wsc.async_handshake(
+                "localhost", "/", [](error_code){});
+            wss.async_accept([](error_code){});
+            ioc.run();
+            ioc.restart();
+            BEAST_EXPECT(wsc.is_open());
+            BEAST_EXPECT(wss.is_open());
+            // invalid 1-byte deflate block in frame
+            boost::asio::write(wsc.next_layer(), sbuf(
+                "\xc1\x81\x3a\xa1\x74\x3b\x49"));
+            error_code ec;
+            flat_buffer b;
+            wss.async_read(b,
+                [&ec](error_code ec_, std::size_t){ ec = ec_; });
+            ioc.run();
+            BEAST_EXPECTS(ec == zlib::error::end_of_stream, ec.message());
+        }
+    }
+
+    /*  Bishop Fox Hybrid Assessment issue 2
+
+        Happens with permessage-deflate enabled,
+        and a deflate block with the BFINAL bit set
+        is encountered in a compressed payload.
+    */
+    void
+    testIssueBF2()
+    {
+        permessage_deflate pmd;
+        pmd.client_enable = true;
+        pmd.server_enable = true;
+
+        // read
+        {
+            boost::asio::io_context ioc;
+            stream<test::stream> wsc{ioc};
+            stream<test::stream> wss{ioc};
+            wsc.set_option(pmd);
+            wss.set_option(pmd);
+            wsc.next_layer().connect(wss.next_layer());
+            wsc.async_handshake(
+                "localhost", "/", [](error_code){});
+            wss.async_accept([](error_code){});
+            ioc.run();
+            ioc.restart();
+            BEAST_EXPECT(wsc.is_open());
+            BEAST_EXPECT(wss.is_open());
+            // contains a deflate block with BFINAL set
+            boost::asio::write(wsc.next_layer(), sbuf(
+                "\xc1\xf8\xd1\xe4\xcc\x3e\xda\xe4\xcc\x3e"
+                "\x2b\x1e\x36\xc4\x2b\x1e\x36\xc4\x2b\x1e"
+                "\x36\x3e\x35\xae\x4f\x54\x18\xae\x4f\x7b"
+                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e"
+                "\xd1\x1e\x36\xc4\x2b\x1e\x36\xc4\x2b\xe4"
+                "\x28\x74\x52\x8e\x05\x74\x52\xa1\xcc\x3e"
+                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e"
+                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\x36\x3e"
+                "\xd1\xec\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e"));
+            error_code ec;
+            flat_buffer b;
+            wss.read(b, ec);
+            BEAST_EXPECTS(ec == zlib::error::end_of_stream, ec.message());
+        }
+
+        // async read
+        {
+            boost::asio::io_context ioc;
+            stream<test::stream> wsc{ioc};
+            stream<test::stream> wss{ioc};
+            wsc.set_option(pmd);
+            wss.set_option(pmd);
+            wsc.next_layer().connect(wss.next_layer());
+            wsc.async_handshake(
+                "localhost", "/", [](error_code){});
+            wss.async_accept([](error_code){});
+            ioc.run();
+            ioc.restart();
+            BEAST_EXPECT(wsc.is_open());
+            BEAST_EXPECT(wss.is_open());
+            // contains a deflate block with BFINAL set
+            boost::asio::write(wsc.next_layer(), sbuf(
+                "\xc1\xf8\xd1\xe4\xcc\x3e\xda\xe4\xcc\x3e"
+                "\x2b\x1e\x36\xc4\x2b\x1e\x36\xc4\x2b\x1e"
+                "\x36\x3e\x35\xae\x4f\x54\x18\xae\x4f\x7b"
+                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e"
+                "\xd1\x1e\x36\xc4\x2b\x1e\x36\xc4\x2b\xe4"
+                "\x28\x74\x52\x8e\x05\x74\x52\xa1\xcc\x3e"
+                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e"
+                "\xd1\xe4\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4\x36\x3e"
+                "\xd1\xec\xcc\x3e\xd1\xe4\xcc\x3e\xd1\xe4"
+                "\xcc\x3e\xd1\xe4\xcc\x3e"));
+            error_code ec;
+            flat_buffer b;
+            wss.async_read(b,
+                [&ec](error_code ec_, std::size_t){ ec = ec_; });
+            ioc.run();
+            BEAST_EXPECTS(ec == zlib::error::end_of_stream, ec.message());
+        }
+    }
+
+    void
+    run() override
+    {
+        testIssue802();
+        testIssue807();
+        testIssueBF1();
+        testIssueBF2();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(beast,websocket,read2);
+
+} // websocket
+} // beast
+} // boost


### PR DESCRIPTION
* built-in r-value return values can't be assigned
* Tidy up ssl_stream special members
* Fix CMakeLists.txt variable
* Protect calls from macros
* pausation always allocates
* Don't copy completion handlers
* handler_ptr is move-only

API Changes:

* handler_ptr gives the strong exception guarantee

Actions Required:

* Change the constructor signature for state objects
  used with handler_ptr to receive a const reference to
  the handler.
