### PR TITLE
Enable body composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ Version 150:
 
 * handler_ptr tests
 
+API Changes:
+
+* serializer::reader_impl is deprecated
+
+Actions Required:
+
+* Call serializer::writer_impl instead of reader_impl
+
 --------------------------------------------------------------------------------
 
 Version 149:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 150:
+
+* handler_ptr tests
+
+--------------------------------------------------------------------------------
+
 Version 149:
 
 * built-in r-value return values can't be assigned

--- a/doc/qbk/07_concepts/BodyReader.qbk
+++ b/doc/qbk/07_concepts/BodyReader.qbk
@@ -41,27 +41,25 @@ In this table:
       `std::is_same<R, B::reader>::value == true`.
 * `a` denotes a value of type `R`.
 * `b` is an object whose type meets the requirements of __ConstBufferSequence__
-* `m` denotes a value of type `message&` where
-    `std::is_same<decltype(m.body), Body::value_type>::value == true`.
+* `h` denotes a value of type `header<isRequest, Fields>&`.
+* `v` denotes a value of type `Body::value_type&`.
 * `n` is a value of type `boost::optional<std::uint64_t>`.
 * `ec` is a value of type [link beast.ref.boost__beast__error_code `error_code&`].
 
 [table Valid expressions
 [[Expression] [Type] [Semantics, Pre/Post-conditions]]
 [
-    [`R{m};`]
+    [`R{h, v};`]
     []
     [
-        Constructible from `m`. The lifetime of `m` is guaranteed to
+        Constructible from `h` and `v`. The lifetime of `h` and `v`
+        is guaranteed to
         end no earlier than after the `R` is destroyed. The constructor
-        will be called after a complete header is stored in `m`, and
+        will be called after a complete header is stored in `h`, and
         before parsing body octets for messages indicating that a body
-        is present The reader shall not access the contents of `m` before
-        the first call to `init`, permitting lazy construction of the
+        is present The reader shall not access the contents of `h` or `v`
+        before the first call to `init`, permitting lazy construction of the
         message.
-
-        The function will ensure that `!ec` is `true` if there was
-        no error or set to the appropriate error code if there was one. 
     ]
 ][
     [`a.init(n, ec)`]

--- a/doc/qbk/07_concepts/BodyWriter.qbk
+++ b/doc/qbk/07_concepts/BodyWriter.qbk
@@ -42,8 +42,8 @@ In this table:
 * `B` denotes a __Body__ where
       `std::is_same<W, B::writer>::value == true`.
 * `a` denotes a value of type `W`.
-* `m` denotes a possibly const value of type `message&` where
-      `std::is_same<decltype(m.body), Body::value_type>:value == true`.
+* `h` denotes a const value of type `header<isRequest, Fields> const&`.
+* `v` denotes a possibly const value of type `Body::value_type&`.
 * `ec` is a value of type [link beast.ref.boost__beast__error_code `error_code&`].
 * `W<T>` is the type `boost::optional<std::pair<T, bool>>`.
 
@@ -57,23 +57,24 @@ In this table:
         This is the type of buffer returned by `W::get`.
     ]
 ][
-    [`W{m};`]
+    [`W{h, v};`]
     []
     [
-        Constructible from `m`. The lifetime of `m` is guaranteed
+        Constructible from `h` and `v`. The lifetime of both `h` and `v`
+        is guaranteed
         to end no earlier than after the `W` is destroyed.
-        The writer shall not access the contents of `m` before the
-        first call to `init`, permitting lazy construction of the
+        The writer shall not access the contents of either `h` or `v`
+        before the first call to `init`, permitting lazy construction of the
         message.
 
-        The constructor may optionally require that `m` is const, which
+        The constructor may optionally require that `v` is const, which
         has these consequences:
 
-        * If `W` requires that `m` is a const reference, then serializers
+        * If `W` requires that `v` is a const reference, then serializers
         constructed for messages with this body type will also require a
         const reference to a message, otherwise:
 
-        * If `W` requires that `m` is a non-const reference, then serializers
+        * If `W` requires that `v` is a non-const reference, then serializers
         constructed for messages with this body type will aso require
         a non-const reference to a message.
     ]

--- a/include/boost/beast/core/detail/config.hpp
+++ b/include/boost/beast/core/detail/config.hpp
@@ -54,4 +54,7 @@
 # define BOOST_BEAST_FALLTHROUGH __attribute__((fallthrough))
 #endif
 
+#define BOOST_BEAST_DEPRECATION_STRING \
+    "This is a deprecated interface, define BOOST_BEAST_ALLOW_DEPRECATED=1 to allow it"
+
 #endif

--- a/include/boost/beast/http/basic_dynamic_body.hpp
+++ b/include/boost/beast/http/basic_dynamic_body.hpp
@@ -70,9 +70,8 @@ struct basic_dynamic_body
     public:
         template<bool isRequest, class Fields>
         explicit
-        reader(message<isRequest,
-                basic_dynamic_body, Fields>& msg)
-            : body_(msg.body())
+        reader(header<isRequest, Fields>&, value_type& b)
+            : body_(b)
         {
         }
 
@@ -140,9 +139,8 @@ struct basic_dynamic_body
 
         template<bool isRequest, class Fields>
         explicit
-        writer(message<isRequest,
-                basic_dynamic_body, Fields> const& m)
-            : body_(m.body())
+        writer(header<isRequest, Fields> const&, value_type const& b)
+            : body_(b)
         {
         }
 

--- a/include/boost/beast/http/basic_file_body.hpp
+++ b/include/boost/beast/http/basic_file_body.hpp
@@ -262,8 +262,7 @@ public:
     // a time.
     //
     template<bool isRequest, class Fields>
-    writer(message<
-        isRequest, basic_file_body, Fields>& m);
+    writer(header<isRequest, Fields>&, value_type& b);
 
     // Initializer
     //
@@ -296,8 +295,8 @@ template<class File>
 template<bool isRequest, class Fields>
 basic_file_body<File>::
 writer::
-writer(message<isRequest, basic_file_body, Fields>& m)
-    : body_(m.body())
+writer(header<isRequest, Fields>&, value_type& b)
+    : body_(b)
 {
     // The file must already be open
     BOOST_ASSERT(body_.file_.is_open());
@@ -398,13 +397,12 @@ public:
     //
     // This is called after the header is parsed and
     // indicates that a non-zero sized body may be present.
-    // `m` holds the message we are receiving, which will
-    // always have the `basic_file_body` as the body type.
-    //
+    // `h` holds the message headers we are receiving.
+    // `b` is an instance of `basic_file_body`.
     template<bool isRequest, class Fields>
     explicit
     reader(
-        message<isRequest, basic_file_body, Fields>& m);
+        header<isRequest, Fields>&, value_type& b);
 
     // Initializer
     //
@@ -447,8 +445,8 @@ template<class File>
 template<bool isRequest, class Fields>
 basic_file_body<File>::
 reader::
-reader(message<isRequest, basic_file_body, Fields>& m)
-    : body_(m.body())
+reader(header<isRequest, Fields>&, value_type& body)
+    : body_(body)
 {
 }
 

--- a/include/boost/beast/http/buffer_body.hpp
+++ b/include/boost/beast/http/buffer_body.hpp
@@ -105,8 +105,8 @@ struct buffer_body
     public:
         template<bool isRequest, class Fields>
         explicit
-        reader(message<isRequest, buffer_body, Fields>& m)
-            : body_(m.body())
+        reader(header<isRequest, Fields>&, value_type& b)
+            : body_(b)
         {
         }
 
@@ -167,9 +167,8 @@ struct buffer_body
 
         template<bool isRequest, class Fields>
         explicit
-        writer(message<isRequest,
-                buffer_body, Fields> const& msg)
-            : body_(msg.body())
+        writer(header<isRequest, Fields> const&, value_type const& b)
+            : body_(b)
         {
         }
 

--- a/include/boost/beast/http/detail/type_traits.hpp
+++ b/include/boost/beast/http/detail/type_traits.hpp
@@ -194,6 +194,22 @@ struct is_fields_helper : T
         t10::value && t11::value && t12::value>;
 };
 
+template<typename T>
+using has_deprecated_body_writer = std::integral_constant<bool,
+        std::is_constructible<typename T::writer,
+            message<true, T, detail::fields_model>&>::value &&
+        std::is_constructible<typename T::writer,
+            message<false, T, detail::fields_model>&>::value
+    >;
+
+template<typename T>
+using has_deprecated_body_reader = std::integral_constant<bool,
+        std::is_constructible<typename T::reader,
+            message<true, T, detail::fields_model>&>::value &&
+        std::is_constructible<typename T::reader,
+            message<false, T, detail::fields_model>&>::value
+    >;
+
 } // detail
 } // http
 } // beast

--- a/include/boost/beast/http/empty_body.hpp
+++ b/include/boost/beast/http/empty_body.hpp
@@ -63,7 +63,7 @@ struct empty_body
     {
         template<bool isRequest, class Fields>
         explicit
-        reader(message<isRequest, empty_body, Fields>&)
+        reader(header<isRequest, Fields>&, value_type&)
         {
         }
 
@@ -104,8 +104,7 @@ struct empty_body
 
         template<bool isRequest, class Fields>
         explicit
-        writer(message<isRequest,
-            empty_body, Fields> const&)
+        writer(header<isRequest, Fields> const&, value_type const&)
         {
         }
 

--- a/include/boost/beast/http/impl/file_body_win32.ipp
+++ b/include/boost/beast/http/impl/file_body_win32.ipp
@@ -123,9 +123,8 @@ struct basic_file_body<file_win32>
             boost::asio::const_buffer;
 
         template<bool isRequest, class Fields>
-        writer(message<isRequest,
-                basic_file_body<file_win32>, Fields>& m)
-            : body_(m.body())
+        writer(header<isRequest, basic_file_body, Fields>&, value_type& b)
+            : body_(b)
         {
         }
 
@@ -167,8 +166,8 @@ struct basic_file_body<file_win32>
     public:
         template<bool isRequest, class Fields>
         explicit
-        reader(message<isRequest, basic_file_body, Fields>& m)
-            : body_(m.body())
+        reader(header<isRequest, basic_file_body, Fields>&, value_type& b)
+            : body_(b)
         {
         }
 

--- a/include/boost/beast/http/impl/parser.ipp
+++ b/include/boost/beast/http/impl/parser.ipp
@@ -20,7 +20,7 @@ namespace http {
 template<bool isRequest, class Body, class Allocator>
 parser<isRequest, Body, Allocator>::
 parser()
-    : wr_(m_)
+    : rd_(m_)
 {
 }
 
@@ -30,7 +30,7 @@ parser<isRequest, Body, Allocator>::
 parser(Arg1&& arg1, ArgN&&... argn)
     : m_(std::forward<Arg1>(arg1),
         std::forward<ArgN>(argn)...)
-    , wr_(m_)
+    , rd_(m_)
 {
     m_.clear();
 }
@@ -42,7 +42,7 @@ parser(parser<isRequest, OtherBody, Allocator>&& other,
         Args&&... args)
     : base_type(std::move(other))
     , m_(other.release(), std::forward<Args>(args)...)
-    , wr_(m_)
+    , rd_(m_)
 {
     if(other.rd_inited_)
         BOOST_THROW_EXCEPTION(std::invalid_argument{

--- a/include/boost/beast/http/impl/parser.ipp
+++ b/include/boost/beast/http/impl/parser.ipp
@@ -20,7 +20,26 @@ namespace http {
 template<bool isRequest, class Body, class Allocator>
 parser<isRequest, Body, Allocator>::
 parser()
+    : parser{detail::has_deprecated_body_reader<Body>{}}
+{
+}
+
+template<bool isRequest, class Body, class Allocator>
+parser<isRequest, Body, Allocator>::
+parser(std::true_type)
     : rd_(m_)
+{
+#ifndef BOOST_BEAST_ALLOW_DEPRECATED
+    /* Deprecated BodyWriter Concept (v1.66) */
+    static_assert(sizeof(Body) == 0,
+        BOOST_BEAST_DEPRECATION_STRING);
+#endif // BOOST_BEAST_ALLOW_DEPRECATED
+}
+
+template<bool isRequest, class Body, class Allocator>
+parser<isRequest, Body, Allocator>::
+parser(std::false_type)
+    : rd_(m_.base(), m_.body())
 {
 }
 
@@ -28,9 +47,35 @@ template<bool isRequest, class Body, class Allocator>
 template<class Arg1, class... ArgN, class>
 parser<isRequest, Body, Allocator>::
 parser(Arg1&& arg1, ArgN&&... argn)
+    : parser(std::forward<Arg1>(arg1),
+        detail::has_deprecated_body_reader<Body>{},
+        std::forward<ArgN>(argn)...)
+{
+}
+
+template<bool isRequest, class Body, class Allocator>
+template<class Arg1, class... ArgN, class>
+parser<isRequest, Body, Allocator>::
+parser(Arg1&& arg1, std::true_type, ArgN&&... argn)
     : m_(std::forward<Arg1>(arg1),
         std::forward<ArgN>(argn)...)
     , rd_(m_)
+{
+    m_.clear();
+#ifndef BOOST_BEAST_ALLOW_DEPRECATED
+    /* Deprecated BodyWriter Concept (v1.66) */
+    static_assert(sizeof(Body) == 0,
+        BOOST_BEAST_DEPRECATION_STRING);
+#endif // BOOST_BEAST_ALLOW_DEPRECATED
+}
+
+template<bool isRequest, class Body, class Allocator>
+template<class Arg1, class... ArgN, class>
+parser<isRequest, Body, Allocator>::
+parser(Arg1&& arg1, std::false_type, ArgN&&... argn)
+    : m_(std::forward<Arg1>(arg1),
+        std::forward<ArgN>(argn)...)
+    , rd_(m_.base(), m_.body())
 {
     m_.clear();
 }
@@ -40,9 +85,38 @@ template<class OtherBody, class... Args, class>
 parser<isRequest, Body, Allocator>::
 parser(parser<isRequest, OtherBody, Allocator>&& other,
         Args&&... args)
+    : parser(detail::has_deprecated_body_reader<Body>{}, std::move(other),
+            std::forward<Args>(args)...)
+{
+}
+
+template<bool isRequest, class Body, class Allocator>
+template<class OtherBody, class... Args, class>
+parser<isRequest, Body, Allocator>::
+parser(std::true_type, parser<isRequest, OtherBody, Allocator>&& other,
+        Args&&... args)
     : base_type(std::move(other))
     , m_(other.release(), std::forward<Args>(args)...)
     , rd_(m_)
+{
+    if(other.rd_inited_)
+        BOOST_THROW_EXCEPTION(std::invalid_argument{
+            "moved-from parser has a body"});
+#ifndef BOOST_BEAST_ALLOW_DEPRECATED
+    /* Deprecated BodyWriter Concept (v1.66) */
+    static_assert(sizeof(Body) == 0,
+        BOOST_BEAST_DEPRECATION_STRING);
+#endif // BOOST_BEAST_ALLOW_DEPRECATED
+}
+
+template<bool isRequest, class Body, class Allocator>
+template<class OtherBody, class... Args, class>
+parser<isRequest, Body, Allocator>::
+parser(std::false_type, parser<isRequest, OtherBody, Allocator>&& other,
+        Args&&... args)
+    : base_type(std::move(other))
+    , m_(other.release(), std::forward<Args>(args)...)
+    , rd_(m_.base(), m_.body())
 {
     if(other.rd_inited_)
         BOOST_THROW_EXCEPTION(std::invalid_argument{

--- a/include/boost/beast/http/impl/serializer.ipp
+++ b/include/boost/beast/http/impl/serializer.ipp
@@ -25,18 +25,18 @@ template<
     bool isRequest, class Body, class Fields>
 void
 serializer<isRequest, Body, Fields>::
-frdinit(std::true_type)
+fwrinit(std::true_type)
 {
-    frd_.emplace(m_, m_.version(), m_.method());
+    fwr_.emplace(m_, m_.version(), m_.method());
 }
 
 template<
     bool isRequest, class Body, class Fields>
 void
 serializer<isRequest, Body, Fields>::
-frdinit(std::false_type)
+fwrinit(std::false_type)
 {
-    frd_.emplace(m_, m_.version(), m_.result_int());
+    fwr_.emplace(m_, m_.version(), m_.result_int());
 }
 
 template<
@@ -59,7 +59,7 @@ template<
 serializer<isRequest, Body, Fields>::
 serializer(value_type& m)
     : m_(m)
-    , rd_(m_)
+    , wr_(m_)
 {
 }
 
@@ -75,7 +75,7 @@ next(error_code& ec, Visit&& visit)
     {
     case do_construct:
     {
-        frdinit(std::integral_constant<bool,
+        fwrinit(std::integral_constant<bool,
             isRequest>{});
         if(m_.chunked())
             goto go_init_c;
@@ -85,12 +85,12 @@ next(error_code& ec, Visit&& visit)
 
     case do_init:
     {
-        rd_.init(ec);
+        wr_.init(ec);
         if(ec)
             return;
         if(split_)
             goto go_header_only;
-        auto result = rd_.get(ec);
+        auto result = wr_.get(ec);
         if(ec == error::need_more)
             goto go_header_only;
         if(ec)
@@ -100,7 +100,7 @@ next(error_code& ec, Visit&& visit)
         more_ = result->second;
         v_.template emplace<2>(
             boost::in_place_init,
-            frd_->get(),
+            fwr_->get(),
             result->first);
         s_ = do_header;
         BOOST_BEAST_FALLTHROUGH;
@@ -111,7 +111,7 @@ next(error_code& ec, Visit&& visit)
         break;
 
     go_header_only:
-        v_.template emplace<1>(frd_->get());
+        v_.template emplace<1>(fwr_->get());
         s_ = do_header_only;
         BOOST_BEAST_FALLTHROUGH;
     case do_header_only:
@@ -124,7 +124,7 @@ next(error_code& ec, Visit&& visit)
 
     case do_body + 1:
     {
-        auto result = rd_.get(ec);
+        auto result = wr_.get(ec);
         if(ec)
             return;
         if(! result)
@@ -146,12 +146,12 @@ next(error_code& ec, Visit&& visit)
         BOOST_BEAST_FALLTHROUGH;
     case do_init_c:
     {
-        rd_.init(ec);
+        wr_.init(ec);
         if(ec)
             return;
         if(split_)
             goto go_header_only_c;
-        auto result = rd_.get(ec);
+        auto result = wr_.get(ec);
         if(ec == error::need_more)
             goto go_header_only_c;
         if(ec)
@@ -164,7 +164,7 @@ next(error_code& ec, Visit&& visit)
             // do it all in one buffer
             v_.template emplace<7>(
                 boost::in_place_init,
-                frd_->get(),
+                fwr_->get(),
                 buffer_size(result->first),
                 boost::asio::const_buffer{nullptr, 0},
                 chunk_crlf{},
@@ -177,7 +177,7 @@ next(error_code& ec, Visit&& visit)
         }
         v_.template emplace<4>(
             boost::in_place_init,
-            frd_->get(),
+            fwr_->get(),
             buffer_size(result->first),
             boost::asio::const_buffer{nullptr, 0},
             chunk_crlf{},
@@ -192,7 +192,7 @@ next(error_code& ec, Visit&& visit)
         break;
 
     go_header_only_c:
-        v_.template emplace<1>(frd_->get());
+        v_.template emplace<1>(fwr_->get());
         s_ = do_header_only_c;
     case do_header_only_c:
         do_visit<1>(ec, visit);
@@ -204,7 +204,7 @@ next(error_code& ec, Visit&& visit)
 
     case do_body_c + 1:
     {
-        auto result = rd_.get(ec);
+        auto result = wr_.get(ec);
         if(ec)
             return;
         if(! result)
@@ -309,7 +309,7 @@ consume(std::size_t n)
         v_.template get<1>().consume(n);
         if(buffer_size(v_.template get<1>()) > 0)
             break;
-        frd_ = boost::none;
+        fwr_ = boost::none;
         header_done_ = true;
         if(! split_)
             goto go_complete;
@@ -353,7 +353,7 @@ consume(std::size_t n)
         v_.template get<1>().consume(n);
         if(buffer_size(v_.template get<1>()) > 0)
             break;
-        frd_ = boost::none;
+        fwr_ = boost::none;
         header_done_ = true;
         if(! split_)
         {

--- a/include/boost/beast/http/impl/serializer.ipp
+++ b/include/boost/beast/http/impl/serializer.ipp
@@ -57,9 +57,31 @@ do_visit(error_code& ec, Visit& visit)
 template<
     bool isRequest, class Body, class Fields>
 serializer<isRequest, Body, Fields>::
-serializer(value_type& m)
+serializer(value_type& m, std::true_type)
     : m_(m)
     , wr_(m_)
+{
+#ifndef BOOST_BEAST_ALLOW_DEPRECATED
+    /* Deprecated BodyWriter Concept (v1.66) */
+    static_assert(sizeof(Body) == 0,
+        BOOST_BEAST_DEPRECATION_STRING);
+#endif // BOOST_BEAST_ALLOW_DEPRECATED
+}
+
+template<
+    bool isRequest, class Body, class Fields>
+serializer<isRequest, Body, Fields>::
+serializer(value_type& m, std::false_type)
+    : m_(m)
+    , wr_(m_.base(), m_.body())
+{
+}
+
+template<
+    bool isRequest, class Body, class Fields>
+serializer<isRequest, Body, Fields>::
+serializer(value_type& m)
+    : serializer(m, detail::has_deprecated_body_writer<Body>{})
 {
 }
 

--- a/include/boost/beast/http/parser.hpp
+++ b/include/boost/beast/http/parser.hpp
@@ -63,7 +63,7 @@ class parser
         parser<isRequest, Body, Allocator>>;
 
     message<isRequest, Body, basic_fields<Allocator>> m_;
-    typename Body::reader wr_;
+    typename Body::reader rd_;
     bool rd_inited_ = false;
 
     std::function<void(
@@ -376,7 +376,7 @@ private:
         boost::optional<std::uint64_t> const& content_length,
         error_code& ec)
     {
-        wr_.init(content_length, ec);
+        rd_.init(content_length, ec);
         rd_inited_ = true;
     }
 
@@ -385,7 +385,7 @@ private:
         string_view body,
         error_code& ec)
     {
-        return wr_.put(boost::asio::buffer(
+        return rd_.put(boost::asio::buffer(
             body.data(), body.size()), ec);
     }
 
@@ -408,14 +408,14 @@ private:
     {
         if(cb_b_)
             return cb_b_(remain, body, ec);
-        return wr_.put(boost::asio::buffer(
+        return rd_.put(boost::asio::buffer(
             body.data(), body.size()), ec);
     }
 
     void
     on_finish_impl(error_code& ec)
     {
-        wr_.finish(ec);
+        rd_.finish(ec);
     }
 };
 

--- a/include/boost/beast/http/parser.hpp
+++ b/include/boost/beast/http/parser.hpp
@@ -303,6 +303,37 @@ public:
 private:
     friend class basic_parser<isRequest, parser>;
 
+    parser(std::true_type);
+    parser(std::false_type);
+
+    template <class OtherBody, class... Args,
+        class = typename std::enable_if<
+            ! std::is_same<Body, OtherBody>::value>::type>
+    explicit
+    parser(std::true_type, parser<isRequest, OtherBody, Allocator>&& parser,
+        Args&&... args);
+
+    template <class OtherBody, class... Args,
+        class = typename std::enable_if<
+            ! std::is_same<Body, OtherBody>::value>::type>
+    explicit
+    parser(std::false_type, parser<isRequest, OtherBody, Allocator>&& parser,
+        Args&&... args);
+
+    template<class Arg1, class... ArgN,
+        class = typename std::enable_if<
+            ! detail::is_parser<typename
+                std::decay<Arg1>::type>::value>::type>
+    explicit
+    parser(Arg1&& arg1, std::true_type, ArgN&&... argn);
+
+    template<class Arg1, class... ArgN,
+        class = typename std::enable_if<
+            ! detail::is_parser<typename
+                std::decay<Arg1>::type>::value>::type>
+    explicit
+    parser(Arg1&& arg1, std::false_type, ArgN&&... argn);
+
     void
     on_request_impl(
         verb method,

--- a/include/boost/beast/http/serializer.hpp
+++ b/include/boost/beast/http/serializer.hpp
@@ -104,8 +104,8 @@ private:
         do_complete         = 120
     };
 
-    void frdinit(std::true_type);
-    void frdinit(std::false_type);
+    void fwrinit(std::true_type);
+    void fwrinit(std::false_type);
 
     template<std::size_t, class Visit>
     void
@@ -173,8 +173,8 @@ private:
     using pcb8_t = buffers_prefix_view<cb8_t const&>;
 
     value_type& m_;
-    writer rd_;
-    boost::optional<typename Fields::writer> frd_;
+    writer wr_;
+    boost::optional<typename Fields::writer> fwr_;
     beast::detail::variant<
         cb1_t, cb2_t, cb3_t, cb4_t,
         cb5_t ,cb6_t, cb7_t, cb8_t> v_;
@@ -336,7 +336,7 @@ public:
     void
     consume(std::size_t n);
 
-    /** Provides low-level access to the associated @b BodyWriter
+    /** Provides low-level access to the associated @b BodyWriter (DEPRECATED)
 
         This function provides access to the instance of the writer
         associated with the body and created by the serializer
@@ -349,7 +349,27 @@ public:
     writer&
     reader_impl()
     {
-        return rd_;
+    #if ! BOOST_BEAST_ALLOW_DEPRECATED
+        BOOST_STATIC_ASSERT_MSG(sizeof(Body) == 0,
+            BOOST_BEAST_DEPRECATION_STRING);
+    #endif
+        return wr_;
+    }
+
+    /** Provides low-level access to the associated @b BodyWriter
+
+        This function provides access to the instance of the writer
+        associated with the body and created by the serializer
+        upon construction. The behavior of accessing this object
+        is defined by the specification of the particular writer
+        and its associated body.
+
+        @return A reference to the writer.
+    */
+    writer&
+    writer_impl()
+    {
+        return wr_;
     }
 };
 

--- a/include/boost/beast/http/span_body.hpp
+++ b/include/boost/beast/http/span_body.hpp
@@ -73,9 +73,8 @@ public:
     public:
         template<bool isRequest, class Fields>
         explicit
-        reader(message<isRequest,
-                span_body, Fields>& m)
-            : body_(m.body())
+        reader(header<isRequest, Fields>&, value_type& b)
+            : body_(b)
         {
         }
 
@@ -138,9 +137,8 @@ public:
 
         template<bool isRequest, class Fields>
         explicit
-        writer(message<isRequest,
-                span_body, Fields> const& msg)
-            : body_(msg.body())
+        writer(header<isRequest, Fields> const&, value_type const& b)
+            : body_(b)
         {
         }
 

--- a/include/boost/beast/http/string_body.hpp
+++ b/include/boost/beast/http/string_body.hpp
@@ -81,9 +81,8 @@ public:
     public:
         template<bool isRequest, class Fields>
         explicit
-        reader(message<isRequest,
-                basic_string_body, Fields>& m)
-            : body_(m.body())
+        reader(header<isRequest, Fields>&, value_type& b)
+            : body_(b)
         {
         }
 
@@ -166,9 +165,8 @@ public:
 
         template<bool isRequest, class Fields>
         explicit
-        writer(message<isRequest,
-                basic_string_body, Fields> const& msg)
-            : body_(msg.body())
+        writer(header<isRequest, Fields> const&, value_type const& b)
+            : body_(b)
         {
         }
 

--- a/include/boost/beast/http/type_traits.hpp
+++ b/include/boost/beast/http/type_traits.hpp
@@ -89,11 +89,19 @@ struct is_body_writer<T, beast::detail::void_t<
             std::declval<typename T::writer>().get(std::declval<error_code&>()),
         (void)0)>> : std::integral_constant<bool,
     boost::asio::is_const_buffer_sequence<
-        typename T::writer::const_buffers_type>::value &&
+        typename T::writer::const_buffers_type>::value && (
+    (std::is_constructible<typename T::writer,
+        header<true, detail::fields_model>&,
+        typename T::value_type&>::value &&
     std::is_constructible<typename T::writer,
+        header<false, detail::fields_model>&,
+        typename T::value_type&>::value) ||
+    /* Deprecated BodyWriter Concept (v1.66) */
+    (std::is_constructible<typename T::writer,
         message<true, T, detail::fields_model>&>::value &&
     std::is_constructible<typename T::writer,
-        message<false, T, detail::fields_model>&>::value
+        message<false, T, detail::fields_model>&>::value)
+    )
     > {};
 #endif
 
@@ -136,11 +144,18 @@ struct is_body_reader<T, beast::detail::void_t<decltype(
     std::declval<typename T::reader&>().finish(
         std::declval<error_code&>()),
     (void)0)>> : std::integral_constant<bool,
+        (std::is_constructible<typename T::reader,
+            header<true, detail::fields_model>&,
+                typename T::value_type&>::value &&
         std::is_constructible<typename T::reader,
+            header<false,detail::fields_model>&,
+                typename T::value_type&>::value) ||
+        /* Deprecated BodyReader Concept (v1.66) */
+        (std::is_constructible<typename T::reader,
             message<true, T, detail::fields_model>&>::value &&
         std::is_constructible<typename T::reader,
-            message<false, T, detail::fields_model>&>::value
-            >
+            message<false, T, detail::fields_model>&>::value)
+        >
 {
 };
 #endif

--- a/include/boost/beast/http/vector_body.hpp
+++ b/include/boost/beast/http/vector_body.hpp
@@ -76,9 +76,8 @@ public:
     public:
         template<bool isRequest, class Fields>
         explicit
-        reader(message<isRequest,
-                vector_body, Fields>& m)
-            : body_(m.body())
+        reader(header<isRequest, Fields>&, value_type& b)
+            : body_(b)
         {
         }
 
@@ -155,9 +154,8 @@ public:
 
         template<bool isRequest, class Fields>
         explicit
-        writer(message<isRequest,
-                vector_body, Fields> const& msg)
-            : body_(msg.body())
+        writer(header<isRequest, Fields> const&, value_type const& b)
+            : body_(b)
         {
         }
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -21,6 +21,7 @@ project /boost/beast/test
         cxx11_variadic_templates
     ]
     <include>./extern
+    <define>BOOST_BEAST_ALLOW_DEPRECATED
     ;
 
 path-constant ZLIB_SOURCES :

--- a/test/beast/CMakeLists.txt
+++ b/test/beast/CMakeLists.txt
@@ -7,6 +7,8 @@
 # Official repository: https://github.com/boostorg/beast
 #
 
+add_definitions(BOOST_BEAST_ALLOW_DEPRECATED)
+
 GroupSources(include/boost/beast beast)
 GroupSources(test/extras/include/boost/beast extras)
 GroupSources(subtree/unit_test/include/boost/beast extras)

--- a/test/beast/http/parser.cpp
+++ b/test/beast/http/parser.cpp
@@ -36,6 +36,42 @@ public:
     using parser_type =
         parser<isRequest, string_body>;
 
+    struct deprecated_body
+    {
+        using value_type = std::string;
+
+        class reader
+        {
+        public:
+            template <bool isRequest, class Fields>
+            explicit
+            reader(message<isRequest, deprecated_body, Fields> &)
+            {
+            }
+
+            void
+            init(boost::optional<std::uint64_t> const&, error_code& ec)
+            {
+                ec = {};
+            }
+
+            template<class ConstBufferSequence>
+            std::size_t
+            put(ConstBufferSequence const& buffers, error_code& ec)
+            {
+                ec = {};
+                return boost::asio::buffer_size(buffers);
+            }
+
+            void
+            finish(error_code& ec)
+            {
+                ec = {};
+            }
+        };
+    };
+
+
     static
     boost::asio::const_buffer
     buf(string_view s)
@@ -343,6 +379,12 @@ public:
         BEAST_EXPECT(std::distance(m1.begin(), m1.end()) == 0);
     }
 
+    void testBodyReaderCtor()
+    {
+        request_parser<deprecated_body> p{};
+        boost::ignore_unused(p);
+    }
+
     void
     run() override
     {
@@ -351,6 +393,7 @@ public:
         testNeedMore<multi_buffer>();
         testGotSome();
         testIssue818();
+        testBodyReaderCtor();
     }
 };
 

--- a/test/beast/http/serializer.cpp
+++ b/test/beast/http/serializer.cpp
@@ -20,6 +20,40 @@ namespace http {
 class serializer_test : public beast::unit_test::suite
 {
 public:
+    struct deprecated_body
+    {
+        using value_type = std::string;
+
+        class writer
+        {
+        public:
+            using const_buffers_type =
+                boost::asio::const_buffer;
+
+            value_type const& body_;
+
+            template <bool isRequest, class Fields>
+            explicit
+            writer(message<isRequest, deprecated_body, Fields> const& m):
+                body_{m.body()}
+            {
+            }
+
+            void init(error_code& ec)
+            {
+                ec.assign(0,  ec.category());
+            }
+
+            boost::optional<std::pair<const_buffers_type, bool>>
+            get(error_code& ec)
+            {
+                ec.assign(0, ec.category());
+                return {{const_buffers_type{
+                    body_.data(), body_.size()}, false}};
+            }
+        };
+    };
+
     struct const_body
     {
         struct value_type{};
@@ -30,7 +64,7 @@ public:
                 boost::asio::const_buffer;
 
             template<bool isRequest, class Fields>
-            writer(message<isRequest, const_body, Fields> const&);
+            writer(header<isRequest, Fields> const&, value_type const&);
 
             void
             init(error_code& ec);
@@ -50,7 +84,7 @@ public:
                 boost::asio::const_buffer;
 
             template<bool isRequest, class Fields>
-            writer(message<isRequest, mutable_body, Fields>&);
+            writer(header<isRequest, Fields>&, value_type&);
 
             void
             init(error_code& ec);
@@ -115,10 +149,20 @@ public:
         }
     }
 
+    void testBodyWriterCtor()
+    {
+        response<deprecated_body> resp;
+        request<deprecated_body> req;
+        serializer<false, deprecated_body> sr1{resp};
+        serializer<true, deprecated_body> sr2{req};
+        boost::ignore_unused(sr1, sr2);
+    }
+
     void
     run() override
     {
         testWriteLimit();
+        testBodyWriterCtor();
     }
 };
 

--- a/test/beast/http/span_body.cpp
+++ b/test/beast/http/span_body.cpp
@@ -34,7 +34,7 @@ struct span_body_test
             BEAST_EXPECT(req.body().size() == 3);
             BEAST_EXPECT(B::size(req.body()) == 3);
 
-            B::writer r{req};
+            B::writer r{req, req.body()};
             error_code ec;
             r.init(ec);
             BEAST_EXPECTS(! ec, ec.message());
@@ -50,7 +50,7 @@ struct span_body_test
             using B = span_body<char>;
             request<B> req;
             req.body() = span<char>{buf, sizeof(buf)};
-            B::reader w{req};
+            B::reader w{req, req.body()};
             error_code ec;
             w.init(boost::none, ec);
             BEAST_EXPECTS(! ec, ec.message());

--- a/test/beast/http/write.cpp
+++ b/test/beast/http/write.cpp
@@ -48,9 +48,8 @@ public:
 
             template<bool isRequest, class Fields>
             explicit
-            writer(message<isRequest,
-                    unsized_body, Fields> const& msg)
-                : body_(msg.body())
+            writer(header<isRequest, Fields> const&, value_type const& b)
+                : body_(b)
             {
             }
 
@@ -93,9 +92,8 @@ public:
 
             template<bool isRequest, class Fields>
             explicit
-            writer(message<isRequest,
-                    test_body, Fields> const& msg)
-                : body_(msg.body())
+            writer(header<isRequest, Fields> const&, value_type const& b)
+                : body_(b)
             {
             }
 
@@ -230,9 +228,8 @@ public:
 
             template<bool isRequest, class Fields>
             explicit
-            writer(message<isRequest,
-                    fail_body, Fields> const& msg)
-                : body_(msg.body())
+            writer(header<isRequest, Fields> const&, value_type const& b)
+                : body_(b)
             {
             }
 


### PR DESCRIPTION
This change enables composing bodies into multiple layers e.g. compressed_body<json_body<T>>. Resolves #884.

Actions required:
- change body writer constructor signature to
	writer(header<isRequest, Fields> const&, value_type const&)
- change body reader constructor signature to
	reader(header<isRequest, Fields>&, value_type&)
