### PR TITLE
Version 151

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,6 +153,7 @@ install:
   - git submodule update --init libs/chrono
   - git submodule update --init libs/concept_check
   - git submodule update --init libs/container
+  - git submodule update --init libs/container_hash
   - git submodule update --init libs/context
   - git submodule update --init libs/conversion
   - git submodule update --init libs/coroutine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ WebSocket:
 
 * Control callback is invoked on the execution context
 * Add stream_fwd.hpp
+* Remove unnecessary include
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ WebSocket:
 * Add stream_fwd.hpp
 * Remove unnecessary include
 
+API Changes:
+
+* http::parser is not MoveConstructible
+
 --------------------------------------------------------------------------------
 
 Version 150:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 151:
+
+* Sanitizer failures are errors
+
+--------------------------------------------------------------------------------
+
 Version 150:
 
 * handler_ptr tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 151:
 
 * Sanitizer failures are errors
 * Depend on container_hash
+* Fix high-ASCII in source file
 
 WebSocket:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+--------------------------------------------------------------------------------
+
 Version 151:
 
 * Sanitizer failures are errors
@@ -13,6 +15,7 @@ WebSocket:
 API Changes:
 
 * http::parser is not MoveConstructible
+* permessage-deflate is a compile-time feature
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 151:
 WebSocket:
 
 * Control callback is invoked on the execution context
+* Add stream_fwd.hpp
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Version 151:
 
 * Sanitizer failures are errors
 
+WebSocket:
+
+* Control callback is invoked on the execution context
+
 --------------------------------------------------------------------------------
 
 Version 150:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 151:
 
 * Sanitizer failures are errors
+* Depend on container_hash
 
 WebSocket:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.5.1)
 
-project (Beast VERSION 150)
+project (Beast VERSION 151)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,8 +150,8 @@ elseif ("${VARIANT}" STREQUAL "ubasan")
     else()
         set (CMAKE_BUILD_TYPE RELWITHDEBINFO)
         set (CMAKE_CXX_FLAGS
-          "${CMAKE_CXX_FLAGS} -DBOOST_BEAST_NO_SLOW_TESTS=1 -msse4.2 -funsigned-char -fno-omit-frame-pointer -fsanitize=address,undefined -fsanitize-blacklist=${PROJECT_SOURCE_DIR}/tools/blacklist.supp")
-        set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address,undefined")
+          "${CMAKE_CXX_FLAGS} -DBOOST_BEAST_NO_SLOW_TESTS=1 -msse4.2 -funsigned-char -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined -fsanitize-blacklist=${PROJECT_SOURCE_DIR}/tools/blacklist.supp")
+        set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address,undefined -fno-sanitize-recover=address,undefined")
     endif()
 
 elseif ("${VARIANT}" STREQUAL "debug")

--- a/Jamfile
+++ b/Jamfile
@@ -62,7 +62,7 @@ variant valgrind
 
 variant ubasan
   : release
-  : <cxxflags>"-msse4.2 -funsigned-char -fno-omit-frame-pointer -fsanitize=address,undefined -fsanitize-blacklist=libs/beast/tools/blacklist.supp"
+  : <cxxflags>"-msse4.2 -funsigned-char -fno-omit-frame-pointer -fsanitize=address,undefined -fno-sanitize-recover=address,undefined -fsanitize-blacklist=libs/beast/tools/blacklist.supp"
     <linkflags>"-fsanitize=address,undefined"
     <define>BOOST_USE_ASAN=1
   ;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,6 +47,7 @@ install:
   - git submodule update --init libs/chrono
   - git submodule update --init libs/concept_check
   - git submodule update --init libs/container
+  - git submodule update --init libs/container_hash
   - git submodule update --init libs/context
   - git submodule update --init libs/conversion
   - git submodule update --init libs/coroutine

--- a/doc/qbk/06_websocket/1_streams.qbk
+++ b/doc/qbk/06_websocket/1_streams.qbk
@@ -10,13 +10,27 @@
 [section Creating Streams]
 
 The interface to the WebSocket implementation is a single template class
-[link beast.ref.boost__beast__websocket__stream `stream`]
-which wraps an existing network transport object or other type of
-octet oriented stream. The wrapped object is called the "next layer"
-and must meet the requirements of __SyncStream__ if synchronous
-operations are performed, __AsyncStream__ if asynchronous operations
-are performed, or both. Any arguments supplied during construction of
-the stream wrapper are passed to next layer's constructor.
+[link beast.ref.boost__beast__websocket__stream `stream`]:
+
+[ws_snippet_26]
+
+An instance of the stream wraps an existing network transport object
+or other type of octet oriented stream. The wrapped object is called
+the "next layer" and must meet the requirements of __SyncStream__ if
+synchronous operations are performed, __AsyncStream__ if asynchronous
+operations are performed, or both. Any arguments supplied during
+construction of the stream wrapper are passed to next layer's constructor.
+
+The value of `deflateSupported` determines if the stream will support
+(but not require) the permessage-deflate extension
+([@https://tools.ietf.org/html/rfc7692 rfc7692])
+negotiation during handshaking. This extension allows messages to be
+optionally automatically compressed using the deflate algorithm prior
+to transmission. When this boolean value is `false`, the extension is
+disabled. Applications which do not intend to use the permessage-deflate
+extension may set the value to `false` to enjoy a reduction in the size
+of the compiled output, as the necessary compression code (included with
+Beast) will not be compiled in.
 
 Here we declare a websocket stream over a TCP/IP socket with ownership
 of the socket. The `io_context` argument is forwarded to the wrapped

--- a/example/websocket/client/sync-ssl/websocket_client_sync_ssl.cpp
+++ b/example/websocket/client/sync-ssl/websocket_client_sync_ssl.cpp
@@ -26,7 +26,7 @@
 #include <string>
 
 using tcp = boost::asio::ip::tcp;               // from <boost/asio/ip/tcp.hpp>
-namespace ssl = boost::asio::ssl;       // from <boost/asio/ssl.hpp>
+namespace ssl = boost::asio::ssl;               // from <boost/asio/ssl.hpp>
 namespace websocket = boost::beast::websocket;  // from <boost/beast/websocket.hpp>
 
 // Sends a WebSocket message and prints the response

--- a/include/boost/beast/core/detail/base64.hpp
+++ b/include/boost/beast/core/detail/base64.hpp
@@ -13,7 +13,7 @@
 
    base64.cpp and base64.h
 
-   Copyright (C) 2004-2008 René Nyffenegger
+   Copyright (C) 2004-2008 Rene Nyffenegger
 
    This source code is provided 'as-is', without any express or implied
    warranty. In no event will the author be held liable for any damages
@@ -33,7 +33,7 @@
 
    3. This notice may not be removed or altered from any source distribution.
 
-   René Nyffenegger rene.nyffenegger@adp-gmbh.ch
+   Rene Nyffenegger rene.nyffenegger@adp-gmbh.ch
 
 */
 

--- a/include/boost/beast/http/parser.hpp
+++ b/include/boost/beast/http/parser.hpp
@@ -84,21 +84,17 @@ public:
     /// Destructor
     ~parser() = default;
 
-    /// Constructor
-    parser();
-
-    /// Constructor
+    /// Constructor (disallowed)
     parser(parser const&) = delete;
 
-    /// Assignment
+    /// Assignment (disallowed)
     parser& operator=(parser const&) = delete;
 
-    /** Constructor
+    /// Constructor (disallowed)
+    parser(parser&& other) = delete;
 
-        After the move, the only valid operation
-        on the moved-from object is destruction.
-    */
-    parser(parser&& other) = default;
+    /// Constructor
+    parser();
 
     /** Constructor
 

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 150
+#define BOOST_BEAST_VERSION 151
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/detail/frame.hpp
+++ b/include/boost/beast/websocket/detail/frame.hpp
@@ -75,7 +75,7 @@ native_to_little_uint32(std::uint32_t v, void* buf)
     p[3] = (v >> 24) & 0xff;
 }
 
-/** WebSocket frame header opcodes. */
+// frame header opcodes
 enum class opcode : std::uint8_t
 {
     cont    = 0,
@@ -110,8 +110,7 @@ struct frame_header
 };
 
 // holds the largest possible frame header
-using fh_buffer =
-    flat_static_buffer<14>;
+using fh_buffer = flat_static_buffer<14>;
 
 // holds the largest possible control frame
 using frame_buffer =

--- a/include/boost/beast/websocket/detail/stream_base.hpp
+++ b/include/boost/beast/websocket/detail/stream_base.hpp
@@ -1,0 +1,141 @@
+//
+// Copyright (c) 2016-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_WEBSOCKET_STREAM_BASE_HPP
+#define BOOST_BEAST_WEBSOCKET_STREAM_BASE_HPP
+
+#include <boost/beast/websocket/option.hpp>
+#include <boost/beast/websocket/detail/pmd_extension.hpp>
+#include <boost/beast/zlib/deflate_stream.hpp>
+#include <boost/beast/zlib/inflate_stream.hpp>
+#include <boost/beast/core/buffers_suffix.hpp>
+#include <boost/beast/core/error.hpp>
+#include <boost/asio/buffer.hpp>
+#include <cstdint>
+#include <memory>
+
+namespace boost {
+namespace beast {
+namespace websocket {
+namespace detail {
+
+template<bool deflateSupported>
+struct stream_base
+{
+    // State information for the permessage-deflate extension
+    struct pmd_type
+    {
+        // `true` if current read message is compressed
+        bool rd_set = false;
+
+        zlib::deflate_stream zo;
+        zlib::inflate_stream zi;
+    };
+
+    std::unique_ptr<pmd_type>   pmd_;           // pmd settings or nullptr
+    permessage_deflate          pmd_opts_;      // local pmd options
+    detail::pmd_offer           pmd_config_;    // offer (client) or negotiation (server)
+
+    // return `true` if current message is deflated
+    bool
+    rd_deflated() const
+    {
+        return pmd_ && pmd_->rd_set;
+    }
+
+    // set whether current message is deflated
+    // returns `false` on protocol violation
+    bool
+    rd_deflated(bool rsv1)
+    {
+        if(pmd_)
+        {
+            pmd_->rd_set = rsv1;
+            return true;
+        }
+        return ! rsv1; // pmd not negotiated
+    }
+
+    template<class ConstBufferSequence>
+    bool
+    deflate(
+        boost::asio::mutable_buffer& out,
+        buffers_suffix<ConstBufferSequence>& cb,
+        bool fin,
+        std::size_t& total_in,
+        error_code& ec);
+
+    void
+    do_context_takeover_write(role_type role);
+
+    void
+    inflate(
+        zlib::z_params& zs,
+        zlib::Flush flush,
+        error_code& ec);
+
+    void
+    do_context_takeover_read(role_type role);
+};
+
+template<>
+struct stream_base<false>
+{
+    // These stubs are for avoiding linking in the zlib
+    // code when permessage-deflate is not enabled.
+
+    bool
+    rd_deflated() const
+    {
+        return false;
+    }
+
+    bool
+    rd_deflated(bool rsv1)
+    {
+        return ! rsv1;
+    }
+
+    template<class ConstBufferSequence>
+    bool
+    deflate(
+        boost::asio::mutable_buffer&,
+        buffers_suffix<ConstBufferSequence>&,
+        bool,
+        std::size_t&,
+        error_code&)
+    {
+        return false;
+    }
+
+    void
+    do_context_takeover_write(role_type)
+    {
+    }
+
+    void
+    inflate(
+        zlib::z_params&,
+        zlib::Flush,
+        error_code&)
+    {
+    }
+
+    void
+    do_context_takeover_read(role_type)
+    {
+    }
+};
+
+} // detail
+} // websocket
+} // beast
+} // boost
+
+#endif

--- a/include/boost/beast/websocket/detail/type_traits.hpp
+++ b/include/boost/beast/websocket/detail/type_traits.hpp
@@ -19,12 +19,12 @@ namespace websocket {
 namespace detail {
 
 template<class F>
-using is_RequestDecorator =
+using is_request_decorator =
     typename beast::detail::is_invocable<F,
         void(request_type&)>::type;
 
 template<class F>
-using is_ResponseDecorator =
+using is_response_decorator =
     typename beast::detail::is_invocable<F,
         void(response_type&)>::type;
 

--- a/include/boost/beast/websocket/impl/ping.ipp
+++ b/include/boost/beast/websocket/impl/ping.ipp
@@ -32,20 +32,20 @@ namespace websocket {
     It only sends the frames it does not make attempts to read
     any frame data.
 */
-template<class NextLayer>
+template<class NextLayer, bool deflateSupported>
 template<class Handler>
-class stream<NextLayer>::ping_op
+class stream<NextLayer, deflateSupported>::ping_op
     : public boost::asio::coroutine
 {
     struct state
     {
-        stream<NextLayer>& ws;
+        stream<NextLayer, deflateSupported>& ws;
         detail::frame_buffer fb;
         token tok;
 
         state(
             Handler const&,
-            stream<NextLayer>& ws_,
+            stream<NextLayer, deflateSupported>& ws_,
             detail::opcode op,
             ping_data const& payload)
             : ws(ws_)
@@ -67,7 +67,7 @@ public:
     template<class DeducedHandler>
     ping_op(
         DeducedHandler&& h,
-        stream<NextLayer>& ws,
+        stream<NextLayer, deflateSupported>& ws,
         detail::opcode op,
         ping_data const& payload)
         : d_(std::forward<DeducedHandler>(h),
@@ -85,7 +85,7 @@ public:
     }
 
     using executor_type = boost::asio::associated_executor_t<
-        Handler, decltype(std::declval<stream<NextLayer>&>().get_executor())>;
+        Handler, decltype(std::declval<stream<NextLayer, deflateSupported>&>().get_executor())>;
 
     executor_type
     get_executor() const noexcept
@@ -107,10 +107,10 @@ public:
     }
 };
 
-template<class NextLayer>
+template<class NextLayer, bool deflateSupported>
 template<class Handler>
 void
-stream<NextLayer>::
+stream<NextLayer, deflateSupported>::
 ping_op<Handler>::
 operator()(error_code ec, std::size_t)
 {
@@ -174,9 +174,9 @@ operator()(error_code ec, std::size_t)
 
 //------------------------------------------------------------------------------
 
-template<class NextLayer>
+template<class NextLayer, bool deflateSupported>
 void
-stream<NextLayer>::
+stream<NextLayer, deflateSupported>::
 ping(ping_data const& payload)
 {
     error_code ec;
@@ -185,9 +185,9 @@ ping(ping_data const& payload)
         BOOST_THROW_EXCEPTION(system_error{ec});
 }
 
-template<class NextLayer>
+template<class NextLayer, bool deflateSupported>
 void
-stream<NextLayer>::
+stream<NextLayer, deflateSupported>::
 ping(ping_data const& payload, error_code& ec)
 {
     // Make sure the stream is open
@@ -201,9 +201,9 @@ ping(ping_data const& payload, error_code& ec)
         return;
 }
 
-template<class NextLayer>
+template<class NextLayer, bool deflateSupported>
 void
-stream<NextLayer>::
+stream<NextLayer, deflateSupported>::
 pong(ping_data const& payload)
 {
     error_code ec;
@@ -212,9 +212,9 @@ pong(ping_data const& payload)
         BOOST_THROW_EXCEPTION(system_error{ec});
 }
 
-template<class NextLayer>
+template<class NextLayer, bool deflateSupported>
 void
-stream<NextLayer>::
+stream<NextLayer, deflateSupported>::
 pong(ping_data const& payload, error_code& ec)
 {
     // Make sure the stream is open
@@ -228,11 +228,11 @@ pong(ping_data const& payload, error_code& ec)
         return;
 }
 
-template<class NextLayer>
+template<class NextLayer, bool deflateSupported>
 template<class WriteHandler>
 BOOST_ASIO_INITFN_RESULT_TYPE(
     WriteHandler, void(error_code))
-stream<NextLayer>::
+stream<NextLayer, deflateSupported>::
 async_ping(ping_data const& payload, WriteHandler&& handler)
 {
     static_assert(is_async_stream<next_layer_type>::value,
@@ -246,11 +246,11 @@ async_ping(ping_data const& payload, WriteHandler&& handler)
     return init.result.get();
 }
 
-template<class NextLayer>
+template<class NextLayer, bool deflateSupported>
 template<class WriteHandler>
 BOOST_ASIO_INITFN_RESULT_TYPE(
     WriteHandler, void(error_code))
-stream<NextLayer>::
+stream<NextLayer, deflateSupported>::
 async_pong(ping_data const& payload, WriteHandler&& handler)
 {
     static_assert(is_async_stream<next_layer_type>::value,

--- a/include/boost/beast/websocket/stream.hpp
+++ b/include/boost/beast/websocket/stream.hpp
@@ -39,15 +39,9 @@
 #include <limits>
 #include <type_traits>
 
-#include <boost/asio/io_context.hpp> // DEPRECATED
-
 namespace boost {
 namespace beast {
 namespace websocket {
-
-namespace detail {
-class frame_test;
-}
 
 /// The type of object holding HTTP Upgrade requests
 using request_type = http::request<http::empty_body>;
@@ -71,6 +65,10 @@ enum class frame_type
     /// A pong frame was received
     pong
 };
+
+namespace detail {
+class frame_test;
+} // detail
 
 //--------------------------------------------------------------------
 

--- a/include/boost/beast/websocket/stream.hpp
+++ b/include/boost/beast/websocket/stream.hpp
@@ -15,6 +15,7 @@
 #include <boost/beast/websocket/option.hpp>
 #include <boost/beast/websocket/role.hpp>
 #include <boost/beast/websocket/rfc6455.hpp>
+#include <boost/beast/websocket/stream_fwd.hpp>
 #include <boost/beast/websocket/detail/frame.hpp>
 #include <boost/beast/websocket/detail/hybi13.hpp>
 #include <boost/beast/websocket/detail/mask.hpp>

--- a/include/boost/beast/websocket/stream.hpp
+++ b/include/boost/beast/websocket/stream.hpp
@@ -21,6 +21,7 @@
 #include <boost/beast/websocket/detail/mask.hpp>
 #include <boost/beast/websocket/detail/pausation.hpp>
 #include <boost/beast/websocket/detail/pmd_extension.hpp>
+#include <boost/beast/websocket/detail/stream_base.hpp>
 #include <boost/beast/websocket/detail/utf8_checker.hpp>
 #include <boost/beast/core/static_buffer.hpp>
 #include <boost/beast/core/string.hpp>
@@ -29,8 +30,6 @@
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/http/string_body.hpp>
 #include <boost/beast/http/detail/type_traits.hpp>
-#include <boost/beast/zlib/deflate_stream.hpp>
-#include <boost/beast/zlib/inflate_stream.hpp>
 #include <boost/asio/async_result.hpp>
 #include <boost/asio/error.hpp>
 #include <algorithm>
@@ -108,6 +107,12 @@ class frame_test;
     For asynchronous operations, the type must support the
     @b AsyncStream concept.
 
+    @tparam deflateSupported A `bool` indicating whether or not the
+    stream will be capable of negotiating the permessage-deflate websocket
+    extension. Note that even if this is set to `true`, the permessage
+    deflate options (set by the caller at runtime) must still have the
+    feature enabled for a successful negotiation to occur.
+
     @note A stream object must not be moved or destroyed while there
     are pending asynchronous operations associated with it.
 
@@ -116,8 +121,13 @@ class frame_test;
         @b DynamicBuffer,
         @b SyncStream
 */
-template<class NextLayer>
+template<
+    class NextLayer,
+    bool deflateSupported>
 class stream
+#ifndef BOOST_BEAST_DOXYGEN
+    : private detail::stream_base<deflateSupported>
+#endif
 {
     friend class close_test;
     friend class frame_test;
@@ -126,15 +136,13 @@ class stream
     friend class read2_test;
     friend class stream_test;
     friend class write_test;
-
+    
     /*  The read buffer has to be at least as large
         as the largest possible control frame including
         the frame header.
     */
     static std::size_t constexpr max_control_frame_size = 2 + 8 + 4 + 125;
     static std::size_t constexpr tcp_frame_size = 1536;
-
-    struct op {};
 
     using control_cb_type =
         std::function<void(frame_type, string_view)>;
@@ -152,16 +160,6 @@ class stream
         bool operator!=(token const& t) { return id_ != t.id_; }
         token unique() { token t{id_++}; if(id_ == 0) ++id_; return t; }
         void reset() { id_ = 0; }
-    };
-
-    // State information for the permessage-deflate extension
-    struct pmd_t
-    {
-        // `true` if current read message is compressed
-        bool rd_set = false;
-
-        zlib::deflate_stream zo;
-        zlib::inflate_stream zi;
     };
 
     enum class status
@@ -231,14 +229,14 @@ class stream
     detail::pausation       paused_wr_;     // paused write op
     detail::pausation       paused_ping_;   // paused ping op
     detail::pausation       paused_close_;  // paused close op
-    detail::pausation       paused_r_rd_;   // paused read op (read)
-    detail::pausation       paused_r_close_;// paused close op (read)
-
-    std::unique_ptr<pmd_t>  pmd_;           // pmd settings or nullptr
-    permessage_deflate      pmd_opts_;      // local pmd options
-    detail::pmd_offer       pmd_config_;    // offer (client) or negotiation (server)
+    detail::pausation       paused_r_rd_;   // paused read op (async read)
+    detail::pausation       paused_r_close_;// paused close op (async read)
 
 public:
+    /// Indicates if the permessage-deflate extension is supported
+    using is_deflate_supported =
+        std::integral_constant<bool, deflateSupported>;
+
     /// The type of the next layer.
     using next_layer_type =
         typename std::remove_reference<NextLayer>::type;
@@ -444,7 +442,11 @@ public:
     */
     std::size_t
     read_size_hint(
-        std::size_t initial_size = +tcp_frame_size) const;
+        std::size_t initial_size = +tcp_frame_size) const
+    {
+        return read_size_hint(initial_size,
+            is_deflate_supported{});
+    }
 
     /** Returns a suggested maximum buffer size for the next call to read.
 
@@ -475,15 +477,22 @@ public:
     //
     //--------------------------------------------------------------------------
 
-    /// Set the permessage-deflate extension options
+    /** Set the permessage-deflate extension options
+
+        @throws invalid_argument if `deflateSupported == false`, and either
+        `client_enable` or `server_enable` is `true`.
+    */
     void
-    set_option(permessage_deflate const& o);
+    set_option(permessage_deflate const& o)
+    {
+        set_option(o, is_deflate_supported{});
+    }
 
     /// Get the permessage-deflate extension options
     void
     get_option(permessage_deflate& o)
     {
-        o = pmd_opts_;
+        get_option(o, is_deflate_supported{});
     }
 
     /** Set the automatic fragmentation option.
@@ -2353,8 +2362,8 @@ public:
         next layer's `async_write_some` functions, and is known as a
         <em>composed operation</em>. The program must ensure that the
         stream performs no other write operations (such as @ref async_ping,
-        @ref stream::async_write, @ref stream::async_write_some, or
-        @ref stream::async_close) until this operation completes.
+        @ref async_write, @ref async_write_some, or @ref async_close)
+        until this operation completes.
 
         If the close reason specifies a close code other than
         @ref beast::websocket::close_code::none, the close frame is
@@ -3172,8 +3181,8 @@ public:
         to the next layer's `async_write_some` functions, and is known
         as a <em>composed operation</em>. The program must ensure that
         the stream performs no other write operations (such as
-        stream::async_write, stream::async_write_some, or
-        stream::async_close).
+        @ref async_write, @ref async_write_some, or
+        @ref async_close).
 
         The current setting of the @ref binary option controls
         whether the message opcode is set to text or binary. If the
@@ -3301,8 +3310,8 @@ public:
         as a <em>composed operation</em>. The actual payload sent
         may be transformed as per the WebSocket protocol settings. The
         program must ensure that the stream performs no other write
-        operations (such as stream::async_write, stream::async_write_some,
-        or stream::async_close).
+        operations (such as @ref async_write, @ref async_write_some,
+        or @ref async_close).
 
         If this is the beginning of a new message, the message opcode
         will be set to text or binary as per the current setting of
@@ -3351,10 +3360,65 @@ private:
     static void default_decorate_req(request_type&) {}
     static void default_decorate_res(response_type&) {}
 
+    void
+    set_option(permessage_deflate const& o, std::true_type);
+
+    void
+    set_option(permessage_deflate const&, std::false_type);
+
+    void
+    get_option(permessage_deflate& o, std::true_type)
+    {
+        o = this->pmd_opts_;
+    }
+
+    void
+    get_option(permessage_deflate& o, std::false_type)
+    {
+        o = {};
+        o.client_enable = false;
+        o.server_enable = false;
+    }
+
     void open(role_type role);
+
+    void open_pmd(std::true_type);
+
+    void open_pmd(std::false_type)
+    {
+    }
+
     void close();
+
+    void close_pmd(std::true_type)
+    {
+        this->pmd_.reset();
+    }
+
+    void close_pmd(std::false_type)
+    {
+    }
+    
     void reset();
-    void begin_msg();
+
+    void begin_msg()
+    {
+        begin_msg(is_deflate_supported{});
+    }
+
+    void begin_msg(std::true_type);
+
+    void begin_msg(std::false_type);
+
+    std::size_t
+    read_size_hint(
+        std::size_t initial_size,
+        std::true_type) const;
+
+    std::size_t
+    read_size_hint(
+        std::size_t initial_size,
+        std::false_type) const;
 
     bool
     check_open(error_code& ec)
@@ -3394,6 +3458,10 @@ private:
     write_ping(DynamicBuffer& b,
         detail::opcode op, ping_data const& data);
 
+    //
+    // upgrade
+    //
+
     template<class Decorator>
     request_type
     build_request(detail::sec_ws_key_type& key,
@@ -3401,28 +3469,94 @@ private:
             string_view target,
                 Decorator const& decorator);
 
-    template<class Body,
-        class Allocator, class Decorator>
-    response_type
-    build_response(http::request<Body,
-        http::basic_fields<Allocator>> const& req,
-            Decorator const& decorator);
+    void
+    build_request_pmd(request_type& req, std::true_type);
 
     void
-    on_response(response_type const& resp,
-        detail::sec_ws_key_type const& key, error_code& ec);
+    build_request_pmd(request_type&, std::false_type)
+    {
+    }
+
+    template<
+        class Body, class Allocator, class Decorator>
+    response_type
+    build_response(
+        http::request<Body,
+            http::basic_fields<Allocator>> const& req,
+        Decorator const& decorator);
+
+    template<class Body, class Allocator>
+    void
+    build_response_pmd(
+        response_type& res,
+        http::request<Body,
+            http::basic_fields<Allocator>> const& req,
+        std::true_type);
+
+    template<class Body, class Allocator>
+    void
+    build_response_pmd(
+        response_type&,
+        http::request<Body,
+            http::basic_fields<Allocator>> const&,
+        std::false_type)
+    {
+    }
+
+    void
+    on_response(
+        response_type const& res,
+        detail::sec_ws_key_type const& key,
+        error_code& ec);
+
+    void
+    on_response_pmd(
+        response_type const& res,
+        std::true_type);
+
+    void
+    on_response_pmd(
+        response_type const&,
+        std::false_type)
+    {
+    }
+
+    //
+    // accept / handshake
+    //
+
+    template<class Allocator>
+    void
+    do_pmd_config(
+        http::basic_fields<Allocator> const& h,
+        std::true_type)
+    {
+        pmd_read(this->pmd_config_, h);
+    }
+
+    template<class Allocator>
+    void
+    do_pmd_config(
+        http::basic_fields<Allocator> const&,
+        std::false_type)
+    {
+    }
 
     template<class Decorator>
     void
-    do_accept(Decorator const& decorator,
+    do_accept(
+        Decorator const& decorator,
         error_code& ec);
 
-    template<class Body, class Allocator,
+    template<
+        class Body, class Allocator,
         class Decorator>
     void
-    do_accept(http::request<Body,
-        http::basic_fields<Allocator>> const& req,
-            Decorator const& decorator, error_code& ec);
+    do_accept(
+        http::request<Body,
+            http::basic_fields<Allocator>> const& req,
+        Decorator const& decorator,
+        error_code& ec);
 
     template<class RequestDecorator>
     void
@@ -3430,6 +3564,10 @@ private:
         string_view host, string_view target,
             RequestDecorator const& decorator,
                 error_code& ec);
+
+    //
+    // fail
+    //
 
     void
     do_fail(

--- a/include/boost/beast/websocket/stream_fwd.hpp
+++ b/include/boost/beast/websocket/stream_fwd.hpp
@@ -17,7 +17,8 @@ namespace beast {
 namespace websocket {
 
 template<
-    class NextLayer>
+    class NextLayer,
+    bool deflateSupported = true>
 class stream;
 
 } // websocket

--- a/include/boost/beast/websocket/stream_fwd.hpp
+++ b/include/boost/beast/websocket/stream_fwd.hpp
@@ -7,16 +7,21 @@
 // Official repository: https://github.com/boostorg/beast
 //
 
-#ifndef BOOST_BEAST_WEBSOCKET_HPP
-#define BOOST_BEAST_WEBSOCKET_HPP
+#ifndef BOOST_BEAST_WEBSOCKET_STREAM_FWD_HPP
+#define BOOST_BEAST_WEBSOCKET_STREAM_FWD_HPP
 
 #include <boost/beast/core/detail/config.hpp>
 
-#include <boost/beast/websocket/error.hpp>
-#include <boost/beast/websocket/option.hpp>
-#include <boost/beast/websocket/rfc6455.hpp>
-#include <boost/beast/websocket/stream.hpp>
-#include <boost/beast/websocket/stream_fwd.hpp>
-#include <boost/beast/websocket/teardown.hpp>
+namespace boost {
+namespace beast {
+namespace websocket {
+
+template<
+    class NextLayer>
+class stream;
+
+} // websocket
+} // beast
+} // boost
 
 #endif

--- a/test/beast/websocket/CMakeLists.txt
+++ b/test/beast/websocket/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable (tests-beast-websocket
     rfc6455.cpp
     role.cpp
     stream.cpp
+    stream_fwd.cpp
     teardown.cpp
     utf8_checker.cpp
     write.cpp

--- a/test/beast/websocket/Jamfile
+++ b/test/beast/websocket/Jamfile
@@ -21,6 +21,7 @@ local SOURCES =
     rfc6455.cpp
     role.cpp
     stream.cpp
+    stream_fwd.cpp
     teardown.cpp
     utf8_checker.cpp
     write.cpp

--- a/test/beast/websocket/stream.cpp
+++ b/test/beast/websocket/stream.cpp
@@ -122,6 +122,8 @@ public:
         BOOST_STATIC_ASSERT(! std::is_move_assignable<
             stream<test::stream&>>::value);
 
+        log << "sizeof(websocket::stream_base<true>) == " <<
+            sizeof(websocket::detail::stream_base<true>) << std::endl;
         log << "sizeof(websocket::stream) == " <<
             sizeof(websocket::stream<test::stream&>) << std::endl;
 

--- a/test/beast/websocket/stream_fwd.cpp
+++ b/test/beast/websocket/stream_fwd.cpp
@@ -1,0 +1,11 @@
+//
+// Copyright (w) 2016-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+// Test that header file is self-contained.
+#include <boost/beast/websocket/stream_fwd.hpp>

--- a/test/beast/websocket/test.hpp
+++ b/test/beast/websocket/test.hpp
@@ -35,6 +35,10 @@ class websocket_test_suite
     , public test::enable_yield_to
 {
 public:
+    template<bool deflateSupported>
+    using ws_type_t =
+        websocket::stream<test::stream&, deflateSupported>;
+
     using ws_type =
         websocket::stream<test::stream&>;
 
@@ -303,7 +307,7 @@ public:
             , limit);
     }
 
-    template<class Test>
+    template<bool deflateSupported = true, class Test>
     void
     doTest(
         permessage_deflate const& pmd,
@@ -320,7 +324,7 @@ public:
             {
                 test::fail_counter fc{n};
                 test::stream ts{ioc_, fc};
-                ws_type ws{ts};
+                ws_type_t<deflateSupported> ws{ts};
                 ws.set_option(pmd);
 
                 echo_server es{log, i==1 ?
@@ -481,146 +485,171 @@ public:
 
     struct SyncClient
     {
-        template<class NextLayer>
+        template<class NextLayer, bool deflateSupported>
         void
-        accept(stream<NextLayer>& ws) const
+        accept(
+            stream<NextLayer, deflateSupported>& ws) const
         {
             ws.accept();
         }
 
-        template<class NextLayer, class Buffers>
+        template<
+            class NextLayer, bool deflateSupported,
+            class Buffers>
         typename std::enable_if<
             ! http::detail::is_header<Buffers>::value>::type
-        accept(stream<NextLayer>& ws,
+        accept(stream<NextLayer, deflateSupported>& ws,
             Buffers const& buffers) const
         {
             ws.accept(buffers);
         }
 
-        template<class NextLayer>
+        template<class NextLayer, bool deflateSupported>
         void
-        accept(stream<NextLayer>& ws,
+        accept(
+            stream<NextLayer, deflateSupported>& ws,
             http::request<http::empty_body> const& req) const
         {
             ws.accept(req);
         }
 
-        template<class NextLayer, class Decorator>
+        template<
+            class NextLayer, bool deflateSupported,
+            class Decorator>
         void
-        accept_ex(stream<NextLayer>& ws,
+        accept_ex(
+            stream<NextLayer, deflateSupported>& ws,
             Decorator const& d) const
         {
             ws.accept_ex(d);
         }
 
-        template<class NextLayer,
+        template<
+            class NextLayer, bool deflateSupported,
             class Buffers, class Decorator>
         typename std::enable_if<
             ! http::detail::is_header<Buffers>::value>::type
-        accept_ex(stream<NextLayer>& ws,
+        accept_ex(
+            stream<NextLayer, deflateSupported>& ws,
             Buffers const& buffers,
-                Decorator const& d) const
+            Decorator const& d) const
         {
             ws.accept_ex(buffers, d);
         }
 
-        template<class NextLayer, class Decorator>
+        template<
+            class NextLayer, bool deflateSupported,
+            class Decorator>
         void
-        accept_ex(stream<NextLayer>& ws,
+        accept_ex(
+            stream<NextLayer, deflateSupported>& ws,
             http::request<http::empty_body> const& req,
-                Decorator const& d) const
+            Decorator const& d) const
         {
             ws.accept_ex(req, d);
         }
 
-        template<class NextLayer,
+        template<
+            class NextLayer, bool deflateSupported,
             class Buffers, class Decorator>
         void
-        accept_ex(stream<NextLayer>& ws,
+        accept_ex(
+            stream<NextLayer, deflateSupported>& ws,
             http::request<http::empty_body> const& req,
-                Buffers const& buffers,
-                    Decorator const& d) const
+            Buffers const& buffers,
+            Decorator const& d) const
         {
             ws.accept_ex(req, buffers, d);
         }
 
-        template<class NextLayer>
+        template<class NextLayer, bool deflateSupported>
         void
-        handshake(stream<NextLayer>& ws,
+        handshake(
+            stream<NextLayer, deflateSupported>& ws,
             string_view uri,
-                string_view path) const
+            string_view path) const
         {
             ws.handshake(uri, path);
         }
 
-        template<class NextLayer>
+        template<class NextLayer, bool deflateSupported>
         void
-        handshake(stream<NextLayer>& ws,
+        handshake(
+            stream<NextLayer, deflateSupported>& ws,
             response_type& res,
-                string_view uri,
-                    string_view path) const
+            string_view uri,
+            string_view path) const
         {
             ws.handshake(res, uri, path);
         }
 
-        template<class NextLayer, class Decorator>
+        template<
+            class NextLayer, bool deflateSupported,
+            class Decorator>
         void
-        handshake_ex(stream<NextLayer>& ws,
+        handshake_ex(
+            stream<NextLayer, deflateSupported>& ws,
             string_view uri,
-                string_view path,
-                    Decorator const& d) const
+            string_view path,
+            Decorator const& d) const
         {
             ws.handshake_ex(uri, path, d);
         }
 
-        template<class NextLayer, class Decorator>
+        template<
+            class NextLayer, bool deflateSupported,
+            class Decorator>
         void
-        handshake_ex(stream<NextLayer>& ws,
+        handshake_ex(
+            stream<NextLayer, deflateSupported>& ws,
             response_type& res,
-                string_view uri,
-                    string_view path,
-                        Decorator const& d) const
+            string_view uri,
+            string_view path,
+            Decorator const& d) const
         {
             ws.handshake_ex(res, uri, path, d);
         }
 
-        template<class NextLayer>
+        template<class NextLayer, bool deflateSupported>
         void
-        ping(stream<NextLayer>& ws,
+        ping(stream<NextLayer, deflateSupported>& ws,
             ping_data const& payload) const
         {
             ws.ping(payload);
         }
 
-        template<class NextLayer>
+        template<class NextLayer, bool deflateSupported>
         void
-        pong(stream<NextLayer>& ws,
+        pong(stream<NextLayer, deflateSupported>& ws,
             ping_data const& payload) const
         {
             ws.pong(payload);
         }
 
-        template<class NextLayer>
+        template<class NextLayer, bool deflateSupported>
         void
-        close(stream<NextLayer>& ws,
+        close(stream<NextLayer, deflateSupported>& ws,
             close_reason const& cr) const
         {
             ws.close(cr);
         }
 
         template<
-            class NextLayer, class DynamicBuffer>
+            class NextLayer, bool deflateSupported,
+            class DynamicBuffer>
         std::size_t
-        read(stream<NextLayer>& ws,
+        read(stream<NextLayer, deflateSupported>& ws,
             DynamicBuffer& buffer) const
         {
             return ws.read(buffer);
         }
 
         template<
-            class NextLayer, class DynamicBuffer>
+            class NextLayer, bool deflateSupported,
+            class DynamicBuffer>
         std::size_t
-        read_some(stream<NextLayer>& ws,
+        read_some(
+            stream<NextLayer, deflateSupported>& ws,
             std::size_t limit,
             DynamicBuffer& buffer) const
         {
@@ -628,36 +657,45 @@ public:
         }
 
         template<
-            class NextLayer, class MutableBufferSequence>
+            class NextLayer, bool deflateSupported,
+            class MutableBufferSequence>
         std::size_t
-        read_some(stream<NextLayer>& ws,
+        read_some(
+            stream<NextLayer, deflateSupported>& ws,
             MutableBufferSequence const& buffers) const
         {
             return ws.read_some(buffers);
         }
 
         template<
-            class NextLayer, class ConstBufferSequence>
+            class NextLayer, bool deflateSupported,
+            class ConstBufferSequence>
         std::size_t
-        write(stream<NextLayer>& ws,
+        write(
+            stream<NextLayer, deflateSupported>& ws,
             ConstBufferSequence const& buffers) const
         {
             return ws.write(buffers);
         }
 
         template<
-            class NextLayer, class ConstBufferSequence>
+            class NextLayer, bool deflateSupported,
+            class ConstBufferSequence>
         std::size_t
-        write_some(stream<NextLayer>& ws, bool fin,
+        write_some(
+            stream<NextLayer, deflateSupported>& ws,
+            bool fin,
             ConstBufferSequence const& buffers) const
         {
             return ws.write_some(fin, buffers);
         }
 
         template<
-            class NextLayer, class ConstBufferSequence>
+            class NextLayer, bool deflateSupported,
+            class ConstBufferSequence>
         std::size_t
-        write_raw(stream<NextLayer>& ws,
+        write_raw(
+            stream<NextLayer, deflateSupported>& ws,
             ConstBufferSequence const& buffers) const
         {
             return boost::asio::write(
@@ -678,9 +716,9 @@ public:
         {
         }
 
-        template<class NextLayer>
+        template<class NextLayer, bool deflateSupported>
         void
-        accept(stream<NextLayer>& ws) const
+        accept(stream<NextLayer, deflateSupported>& ws) const
         {
             error_code ec;
             ws.async_accept(yield_[ec]);
@@ -688,10 +726,13 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer, class Buffers>
+        template<
+            class NextLayer, bool deflateSupported,
+            class Buffers>
         typename std::enable_if<
             ! http::detail::is_header<Buffers>::value>::type
-        accept(stream<NextLayer>& ws,
+        accept(
+            stream<NextLayer, deflateSupported>& ws,
             Buffers const& buffers) const
         {
             error_code ec;
@@ -700,9 +741,10 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer>
+        template<class NextLayer, bool deflateSupported>
         void
-        accept(stream<NextLayer>& ws,
+        accept(
+            stream<NextLayer, deflateSupported>& ws,
             http::request<http::empty_body> const& req) const
         {
             error_code ec;
@@ -711,10 +753,12 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer,
+        template<
+            class NextLayer, bool deflateSupported,
             class Decorator>
         void
-        accept_ex(stream<NextLayer>& ws,
+        accept_ex(
+            stream<NextLayer, deflateSupported>& ws,
             Decorator const& d) const
         {
             error_code ec;
@@ -723,13 +767,15 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer,
+        template<
+            class NextLayer, bool deflateSupported,
             class Buffers, class Decorator>
         typename std::enable_if<
             ! http::detail::is_header<Buffers>::value>::type
-        accept_ex(stream<NextLayer>& ws,
+        accept_ex(
+            stream<NextLayer, deflateSupported>& ws,
             Buffers const& buffers,
-                Decorator const& d) const
+            Decorator const& d) const
         {
             error_code ec;
             ws.async_accept_ex(buffers, d, yield_[ec]);
@@ -737,11 +783,14 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer, class Decorator>
+        template<
+            class NextLayer, bool deflateSupported,
+            class Decorator>
         void
-        accept_ex(stream<NextLayer>& ws,
+        accept_ex(
+            stream<NextLayer, deflateSupported>& ws,
             http::request<http::empty_body> const& req,
-                Decorator const& d) const
+            Decorator const& d) const
         {
             error_code ec;
             ws.async_accept_ex(req, d, yield_[ec]);
@@ -749,13 +798,15 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer,
+        template<
+            class NextLayer, bool deflateSupported,
             class Buffers, class Decorator>
         void
-        accept_ex(stream<NextLayer>& ws,
+        accept_ex(
+            stream<NextLayer, deflateSupported>& ws,
             http::request<http::empty_body> const& req,
-                Buffers const& buffers,
-                    Decorator const& d) const
+            Buffers const& buffers,
+            Decorator const& d) const
         {
             error_code ec;
             ws.async_accept_ex(
@@ -764,11 +815,13 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer>
+        template<
+            class NextLayer, bool deflateSupported>
         void
-        handshake(stream<NextLayer>& ws,
+        handshake(
+            stream<NextLayer, deflateSupported>& ws,
             string_view uri,
-                string_view path) const
+            string_view path) const
         {
             error_code ec;
             ws.async_handshake(
@@ -777,12 +830,13 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer>
+        template<class NextLayer, bool deflateSupported>
         void
-        handshake(stream<NextLayer>& ws,
+        handshake(
+            stream<NextLayer, deflateSupported>& ws,
             response_type& res,
-                string_view uri,
-                    string_view path) const
+            string_view uri,
+            string_view path) const
         {
             error_code ec;
             ws.async_handshake(
@@ -791,12 +845,15 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer, class Decorator>
+        template<
+            class NextLayer, bool deflateSupported,
+            class Decorator>
         void
-        handshake_ex(stream<NextLayer>& ws,
+        handshake_ex(
+            stream<NextLayer, deflateSupported>& ws,
             string_view uri,
-                string_view path,
-                    Decorator const &d) const
+            string_view path,
+            Decorator const &d) const
         {
             error_code ec;
             ws.async_handshake_ex(
@@ -805,13 +862,16 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer, class Decorator>
+        template<
+            class NextLayer, bool deflateSupported,
+            class Decorator>
         void
-        handshake_ex(stream<NextLayer>& ws,
+        handshake_ex(
+            stream<NextLayer, deflateSupported>& ws,
             response_type& res,
-                string_view uri,
-                    string_view path,
-                        Decorator const &d) const
+            string_view uri,
+            string_view path,
+            Decorator const &d) const
         {
             error_code ec;
             ws.async_handshake_ex(
@@ -820,9 +880,10 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer>
+        template<class NextLayer, bool deflateSupported>
         void
-        ping(stream<NextLayer>& ws,
+        ping(
+            stream<NextLayer, deflateSupported>& ws,
             ping_data const& payload) const
         {
             error_code ec;
@@ -831,9 +892,10 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer>
+        template<class NextLayer, bool deflateSupported>
         void
-        pong(stream<NextLayer>& ws,
+        pong(
+            stream<NextLayer, deflateSupported>& ws,
             ping_data const& payload) const
         {
             error_code ec;
@@ -842,9 +904,10 @@ public:
                 throw system_error{ec};
         }
 
-        template<class NextLayer>
+        template<class NextLayer, bool deflateSupported>
         void
-        close(stream<NextLayer>& ws,
+        close(
+            stream<NextLayer, deflateSupported>& ws,
             close_reason const& cr) const
         {
             error_code ec;
@@ -854,9 +917,11 @@ public:
         }
 
         template<
-            class NextLayer, class DynamicBuffer>
+            class NextLayer, bool deflateSupported,
+            class DynamicBuffer>
         std::size_t
-        read(stream<NextLayer>& ws,
+        read(
+            stream<NextLayer, deflateSupported>& ws,
             DynamicBuffer& buffer) const
         {
             error_code ec;
@@ -868,9 +933,11 @@ public:
         }
 
         template<
-            class NextLayer, class DynamicBuffer>
+            class NextLayer, bool deflateSupported,
+            class DynamicBuffer>
         std::size_t
-        read_some(stream<NextLayer>& ws,
+        read_some(
+            stream<NextLayer, deflateSupported>& ws,
             std::size_t limit,
             DynamicBuffer& buffer) const
         {
@@ -883,9 +950,11 @@ public:
         }
 
         template<
-            class NextLayer, class MutableBufferSequence>
+            class NextLayer, bool deflateSupported,
+            class MutableBufferSequence>
         std::size_t
-        read_some(stream<NextLayer>& ws,
+        read_some(
+            stream<NextLayer, deflateSupported>& ws,
             MutableBufferSequence const& buffers) const
         {
             error_code ec;
@@ -897,9 +966,11 @@ public:
         }
 
         template<
-            class NextLayer, class ConstBufferSequence>
+            class NextLayer, bool deflateSupported,
+            class ConstBufferSequence>
         std::size_t
-        write(stream<NextLayer>& ws,
+        write(
+            stream<NextLayer, deflateSupported>& ws,
             ConstBufferSequence const& buffers) const
         {
             error_code ec;
@@ -911,9 +982,12 @@ public:
         }
 
         template<
-            class NextLayer, class ConstBufferSequence>
+            class NextLayer, bool deflateSupported,
+            class ConstBufferSequence>
         std::size_t
-        write_some(stream<NextLayer>& ws, bool fin,
+        write_some(
+            stream<NextLayer, deflateSupported>& ws,
+            bool fin,
             ConstBufferSequence const& buffers) const
         {
             error_code ec;
@@ -925,9 +999,11 @@ public:
         }
 
         template<
-            class NextLayer, class ConstBufferSequence>
+            class NextLayer, bool deflateSupported,
+            class ConstBufferSequence>
         std::size_t
-        write_raw(stream<NextLayer>& ws,
+        write_raw(
+            stream<NextLayer, deflateSupported>& ws,
             ConstBufferSequence const& buffers) const
         {
             error_code ec;

--- a/test/doc/websocket_snippets.cpp
+++ b/test/doc/websocket_snippets.cpp
@@ -57,7 +57,7 @@ boost::asio::ip::tcp::socket sock{ioc};
 
 {
 //[ws_snippet_6
-    std::string const host = "mywebapp.com";
+    std::string const host = "example.com";
     boost::asio::ip::tcp::resolver r{ioc};
     stream<boost::asio::ip::tcp::socket> ws{ioc};
     auto const results = r.resolve(host, "ws");
@@ -307,6 +307,16 @@ struct custom_wrapper
         async_teardown(role, stream.next_layer, std::forward<TeardownHandler>(handler));
     }
 };
+
+//]
+
+//[ws_snippet_26
+
+// A WebSocket stream
+template<
+    class NextLayer,
+    bool deflateSupported = true>
+class stream;
 
 //]
 


### PR DESCRIPTION
* Sanitizer failures are errors
* Depend on container_hash
* Fix high-ASCII in source file

WebSocket:

* Control callback is invoked on the execution context
* Add stream_fwd.hpp
* Remove unnecessary include

API Changes:

* http::parser is not MoveConstructible
* permessage-deflate is a compile-time feature
