### PR TITLE
File error code consistency

### DIFF
--- a/include/boost/beast/core/impl/file_posix.ipp
+++ b/include/boost/beast/core/impl/file_posix.ipp
@@ -224,7 +224,7 @@ size(error_code& ec) const
 {
     if(fd_ == -1)
     {
-        ec.assign(errc::invalid_argument, generic_category());
+        ec = make_error_code(errc::invalid_argument);
         return 0;
     }
     struct stat st;
@@ -244,7 +244,7 @@ pos(error_code& ec) const
 {
     if(fd_ == -1)
     {
-        ec.assign(errc::invalid_argument, generic_category());
+        ec = make_error_code(errc::invalid_argument);
         return 0;
     }
     auto const result = ::lseek(fd_, 0, SEEK_CUR);
@@ -264,7 +264,7 @@ seek(std::uint64_t offset, error_code& ec)
 {
     if(fd_ == -1)
     {
-        ec.assign(errc::invalid_argument, generic_category());
+        ec = make_error_code(errc::invalid_argument);
         return;
     }
     auto const result = ::lseek(fd_, offset, SEEK_SET);
@@ -283,7 +283,7 @@ read(void* buffer, std::size_t n, error_code& ec) const
 {
     if(fd_ == -1)
     {
-        ec.assign(errc::invalid_argument, generic_category());
+        ec = make_error_code(errc::invalid_argument);
         return 0;
     }
     std::size_t nread = 0;
@@ -319,7 +319,7 @@ write(void const* buffer, std::size_t n, error_code& ec)
 {
     if(fd_ == -1)
     {
-        ec.assign(errc::invalid_argument, generic_category());
+        ec = make_error_code(errc::invalid_argument);
         return 0;
     }
     std::size_t nwritten = 0;

--- a/include/boost/beast/core/impl/file_stdio.ipp
+++ b/include/boost/beast/core/impl/file_stdio.ipp
@@ -122,7 +122,7 @@ size(error_code& ec) const
 {
     if(! f_)
     {
-        ec.assign(errc::invalid_argument, generic_category());
+        ec = make_error_code(errc::invalid_argument);
         return 0;
     }
     long pos = std::ftell(f_);
@@ -159,7 +159,7 @@ pos(error_code& ec) const
 {
     if(! f_)
     {
-        ec.assign(errc::invalid_argument, generic_category());
+        ec = make_error_code(errc::invalid_argument);
         return 0;
     }
     long pos = std::ftell(f_);
@@ -179,7 +179,7 @@ seek(std::uint64_t offset, error_code& ec)
 {
     if(! f_)
     {
-        ec.assign(errc::invalid_argument, generic_category());
+        ec = make_error_code(errc::invalid_argument);
         return;
     }
     if(offset > (std::numeric_limits<long>::max)())
@@ -202,7 +202,7 @@ read(void* buffer, std::size_t n, error_code& ec) const
 {
     if(! f_)
     {
-        ec.assign(errc::invalid_argument, generic_category());
+        ec = make_error_code(errc::invalid_argument);
         return 0;
     }
     auto nread = std::fread(buffer, 1, n, f_);
@@ -221,7 +221,7 @@ write(void const* buffer, std::size_t n, error_code& ec)
 {
     if(! f_)
     {
-        ec.assign(errc::invalid_argument, generic_category());
+        ec = make_error_code(errc::invalid_argument);
         return 0;
     }
     auto nwritten = std::fwrite(buffer, 1, n, f_);

--- a/include/boost/beast/core/impl/file_win32.ipp
+++ b/include/boost/beast/core/impl/file_win32.ipp
@@ -216,7 +216,7 @@ size(error_code& ec) const
 {
     if(h_ == boost::winapi::INVALID_HANDLE_VALUE_)
     {
-        ec.assign(errc::invalid_argument, generic_category());
+        ec = make_error_code(errc::invalid_argument);
         return 0;
     }
     boost::winapi::LARGE_INTEGER_ fileSize;
@@ -237,7 +237,7 @@ pos(error_code& ec)
 {
     if(h_ == boost::winapi::INVALID_HANDLE_VALUE_)
     {
-        ec.assign(errc::invalid_argument, generic_category());
+        ec = make_error_code(errc::invalid_argument);
         return 0;
     }
     boost::winapi::LARGE_INTEGER_ in;
@@ -261,7 +261,7 @@ seek(std::uint64_t offset, error_code& ec)
 {
     if(h_ == boost::winapi::INVALID_HANDLE_VALUE_)
     {
-        ec.assign(errc::invalid_argument, generic_category());
+        ec = make_error_code(errc::invalid_argument);
         return;
     }
     boost::winapi::LARGE_INTEGER_ in;
@@ -283,7 +283,7 @@ read(void* buffer, std::size_t n, error_code& ec)
 {
     if(h_ == boost::winapi::INVALID_HANDLE_VALUE_)
     {
-        ec.assign(errc::invalid_argument, generic_category());
+        ec = make_error_code(errc::invalid_argument);
         return 0;
     }
     std::size_t nread = 0;
@@ -324,7 +324,7 @@ write(void const* buffer, std::size_t n, error_code& ec)
 {
     if(h_ == boost::winapi::INVALID_HANDLE_VALUE_)
     {
-        ec.assign(errc::invalid_argument, generic_category());
+        ec = make_error_code(errc::invalid_argument);
         return 0;
     }
     std::size_t nwritten = 0;

--- a/include/boost/beast/core/impl/file_win32.ipp
+++ b/include/boost/beast/core/impl/file_win32.ipp
@@ -300,9 +300,9 @@ read(void* buffer, std::size_t n, error_code& ec)
         boost::winapi::DWORD_ bytesRead;
         if(! ::ReadFile(h_, buffer, amount, &bytesRead, 0))
         {
-            auto const dwError = ::GetLastError();
+            auto const dwError = boost::winapi::GetLastError();
             if(dwError != boost::winapi::ERROR_HANDLE_EOF_)
-                ec.assign(::GetLastError(), system_category());
+                ec.assign(dwError, system_category());
             else
                 ec.assign(0, ec.category());
             return nread;
@@ -341,9 +341,9 @@ write(void const* buffer, std::size_t n, error_code& ec)
         boost::winapi::DWORD_ bytesWritten;
         if(! ::WriteFile(h_, buffer, amount, &bytesWritten, 0))
         {
-            auto const dwError = ::GetLastError();
+            auto const dwError = boost::winapi::GetLastError();
             if(dwError != boost::winapi::ERROR_HANDLE_EOF_)
-                ec.assign(::GetLastError(), system_category());
+                ec.assign(dwError, system_category());
             else
                 ec.assign(0, ec.category());
             return nwritten;

--- a/include/boost/beast/http/impl/file_body_win32.ipp
+++ b/include/boost/beast/http/impl/file_body_win32.ipp
@@ -25,6 +25,7 @@
 #include <boost/make_unique.hpp>
 #include <boost/smart_ptr/make_shared_array.hpp>
 #include <boost/winapi/basic_types.hpp>
+#include <boost/winapi/get_last_error.hpp>
 #include <algorithm>
 #include <cstring>
 
@@ -436,14 +437,13 @@ operator()()
         overlapped.get(),
         nullptr,
         0);
-    auto const dwError = ::GetLastError();
+    auto const dwError = boost::winapi::GetLastError();
     if(! bSuccess && dwError !=
         boost::winapi::ERROR_IO_PENDING_)
     {
         // VFALCO This needs review, is 0 the right number?
         // completed immediately (with error?)
-        overlapped.complete(error_code{static_cast<int>(
-            boost::winapi::GetLastError()),
+        overlapped.complete(error_code{static_cast<int>(dwError),
                 system_category()}, 0);
         return;
     }


### PR DESCRIPTION
While playing with `std::error_code`, I found a couple of places using a `boost::system::error_code` API that doesn't work with `std::error_code`, and replaced them with a cross-compatible approach.

I also replaced in-passing a couple of places that were directly calling `::GetLastError()` instead of `boost::winapi::GetLastError()`. I was hoping to get rid of the `static_cast<int>` in a few places, but that's built-in to the way `error_code` has been defined, sadly.