### PR TITLE
Fix iterator version of basic_fields::erase

### DIFF
--- a/include/boost/beast/http/impl/fields.ipp
+++ b/include/boost/beast/http/impl/fields.ipp
@@ -609,11 +609,11 @@ basic_fields<Allocator>::
 erase(const_iterator pos) ->
     const_iterator
 {
-    auto next = pos.iter();
+    auto next = pos;
     auto& e = *next++;
     set_.erase(e);
-    list_.erase(e);
-    delete_element(e);
+    list_.erase(pos);
+    delete_element(const_cast<value_type&>(e));
     return next;
 }
 

--- a/test/beast/http/fields.cpp
+++ b/test/beast/http/fields.cpp
@@ -388,6 +388,20 @@ public:
         BEAST_EXPECT(size(f) == 2);
     }
 
+    void testIteratorErase()
+    {
+        f_t f;
+        f.insert("a", "x");
+        f.insert("b", "y");
+        f.insert("c", "z");
+        BEAST_EXPECT(size(f) == 3);
+        f_t::const_iterator i = std::next(f.begin());
+        f.erase(i);
+        BEAST_EXPECT(size(f) == 2);
+        BEAST_EXPECT(std::next(f.begin(), 0)->name_string() == "a");
+        BEAST_EXPECT(std::next(f.begin(), 1)->name_string() == "c");
+    }
+
     void
     testContainer()
     {
@@ -980,6 +994,7 @@ public:
         testHeaders();
         testRFC2616();
         testErase();
+        testIteratorErase();
         testContainer();
         testPreparePayload();
 


### PR DESCRIPTION
When used, was causing compile errors.

Not sure whether const_casting here is the best approach,
please let me know if you can think of a better solution and I'll
change it.