### PR TITLE
file_mode::write_new available only on C++17 or later

### DIFF
--- a/include/boost/beast/core/impl/file_stdio.ipp
+++ b/include/boost/beast/core/impl/file_stdio.ipp
@@ -105,6 +105,10 @@ open(char const* path, file_mode mode, error_code& ec)
         return;
     }
 #else
+    #if (__cplusplus <= 201402L)
+        // supported by std::fopen since c++17
+        BOOST_ASSERT(mode != file_mode::write_new);
+    #endif
     f_ = std::fopen(path, s);
     if(! f_)
     {


### PR DESCRIPTION
Fixes issue https://github.com/boostorg/beast/issues/982

Since we don't want to loose the "write_new" option to open files, 
and since this option is only available in std::fopen since c++17 
(apart from the posix and win32 api's)
I suggest to assert that we are dealing with c++17, in case we are using std::fopen.
