### PR TITLE
fix memory leak in advanced server examples

### DIFF
--- a/example/advanced/server-flex/advanced_server_flex.cpp
+++ b/example/advanced/server-flex/advanced_server_flex.cpp
@@ -26,6 +26,7 @@
 #include <boost/asio/ssl/stream.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/asio/steady_timer.hpp>
+#include <boost/make_unique.hpp>
 #include <boost/config.hpp>
 #include <algorithm>
 #include <cstdlib>
@@ -745,15 +746,8 @@ class http_session
             };
 
             // Allocate and store the work
-#ifdef __cpp_lib_make_unique
-            // C++14
             items_.push_back(
-                std::make_unique<work_impl>(self_, std::move(msg)));
-#else
-            // C++11
-            items_.push_back(nullptr); // might throw
-            items_.back().reset(new work_impl(self_, std::move(msg)));
-#endif
+                boost::make_unique<work_impl>(self_, std::move(msg)));
 
             // If there was no previous work, start this one
             if(items_.size() == 1)

--- a/example/advanced/server-flex/advanced_server_flex.cpp
+++ b/example/advanced/server-flex/advanced_server_flex.cpp
@@ -745,7 +745,15 @@ class http_session
             };
 
             // Allocate and store the work
-            items_.emplace_back(new work_impl(self_, std::move(msg)));
+#ifdef __cpp_lib_make_unique
+            // C++14
+            items_.push_back(
+                std::make_unique<work_impl>(self_, std::move(msg)));
+#else
+            // C++11
+            items_.push_back(nullptr); // might throw
+            items_.back().reset(new work_impl(self_, std::move(msg)));
+#endif
 
             // If there was no previous work, start this one
             if(items_.size() == 1)

--- a/example/advanced/server/advanced_server.cpp
+++ b/example/advanced/server/advanced_server.cpp
@@ -21,6 +21,7 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/asio/steady_timer.hpp>
+#include <boost/make_unique.hpp>
 #include <boost/config.hpp>
 #include <algorithm>
 #include <cstdlib>
@@ -539,15 +540,8 @@ class http_session : public std::enable_shared_from_this<http_session>
             };
 
             // Allocate and store the work
-#ifdef __cpp_lib_make_unique
-            // C++14
             items_.push_back(
-                std::make_unique<work_impl>(self_, std::move(msg)));
-#else
-            // C++11
-            items_.push_back(nullptr); // might throw
-            items_.back().reset(new work_impl(self_, std::move(msg)));
-#endif
+                boost::make_unique<work_impl>(self_, std::move(msg)));
 
             // If there was no previous work, start this one
             if(items_.size() == 1)

--- a/example/advanced/server/advanced_server.cpp
+++ b/example/advanced/server/advanced_server.cpp
@@ -539,7 +539,15 @@ class http_session : public std::enable_shared_from_this<http_session>
             };
 
             // Allocate and store the work
-            items_.emplace_back(new work_impl(self_, std::move(msg)));
+#ifdef __cpp_lib_make_unique
+            // C++14
+            items_.push_back(
+                std::make_unique<work_impl>(self_, std::move(msg)));
+#else
+            // C++11
+            items_.push_back(nullptr); // might throw
+            items_.back().reset(new work_impl(self_, std::move(msg)));
+#endif
 
             // If there was no previous work, start this one
             if(items_.size() == 1)


### PR DESCRIPTION
emplace_back may throw and at this time the pointer created with new is a raw unmanaged pointer that will never be deleted.

Beast is C++11, unfortunately the simple solution make_unique is introduced by C++14.