### PR TITLE
Provide the type trait alias get_lowest_layer_t

### DIFF
--- a/include/boost/beast/core/type_traits.hpp
+++ b/include/boost/beast/core/type_traits.hpp
@@ -167,6 +167,15 @@ struct get_lowest_layer<T, detail::void_t<
 };
 #endif
 
+/**
+ * Convenience type alias for
+ * @code
+ * typename get_lowest_layer<T>::type
+ * @endcode
+ */
+template<class T>
+using get_lowest_layer_t = typename get_lowest_layer<T>::type;
+
 /** Determine if `T` meets the requirements of @b AsyncReadStream.
 
     Metafunctions are used to perform compile time checking of template


### PR DESCRIPTION
Added a C++14-style type alias (get_lowest_layer_t<T>) for the type trait get_lowest_layer<T>.

Resolves: #941

Signed-off-by: Damian Jarek <damian.jarek93@gmail.com>