### PR TITLE
Add field enum entry for "Access-Control-Expose-Headers"

### DIFF
--- a/include/boost/beast/http/field.hpp
+++ b/include/boost/beast/http/field.hpp
@@ -38,6 +38,7 @@ enum class field : unsigned short
     access_control_allow_headers,
     access_control_allow_methods,
     access_control_allow_origin,
+    access_control_expose_headers,
     access_control_max_age,
     access_control_request_headers,
     access_control_request_method,

--- a/test/beast/http/field.cpp
+++ b/test/beast/http/field.cpp
@@ -50,6 +50,7 @@ public:
         match(field::access_control_allow_headers, "Access-Control-Allow-Headers");
         match(field::access_control_allow_methods, "Access-Control-Allow-Methods");
         match(field::access_control_allow_origin, "Access-Control-Allow-Origin");
+        match(field::access_control_expose_headers, "Access-Control-Expose-Headers");
         match(field::access_control_max_age, "Access-Control-Max-Age");
         match(field::access_control_request_headers, "Access-Control-Request-Headers");
         match(field::access_control_request_method, "Access-Control-Request-Method");


### PR DESCRIPTION
This response header is described both in [CORS](https://www.w3.org/TR/cors/) and [Fetch](https://fetch.spec.whatwg.org/) specifications.