### PR TITLE
Version 158

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Version 158:
 * DynamicBuffer input areas are not mutable
 * Tidy up some documentation
 
+API Changes:
+
+* get_lowest_layer is a type alias
+
+Actions required:
+
+* Replace instances of `typename get_lowest_layer<T>::type`
+  with `get_lowest_layer<T>`.
+
+
 --------------------------------------------------------------------------------
 
 Version 157:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 158:
+
+* Tidy up end_of_stream javadoc
+
+--------------------------------------------------------------------------------
+
 Version 157:
 
 * Fix teardown for TIME_WAIT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 158:
 * Examples set reuse_address(true)
 * Advanced servers support clean shutdown via SIGINT or SIGTERM
 * DynamicBuffer input areas are not mutable
+* Tidy up some documentation
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 158:
 
 * Tidy up end_of_stream javadoc
+* Tidy up websocket docs
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 158:
 
 * Tidy up end_of_stream javadoc
 * Tidy up websocket docs
+* Examples set reuse_address(true)
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 158:
 * Tidy up websocket docs
 * Examples set reuse_address(true)
 * Advanced servers support clean shutdown via SIGINT or SIGTERM
+* DynamicBuffer input areas are not mutable
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 158:
 * Tidy up end_of_stream javadoc
 * Tidy up websocket docs
 * Examples set reuse_address(true)
+* Advanced servers support clean shutdown via SIGINT or SIGTERM
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.5.1)
 
-project (Beast VERSION 157)
+project (Beast VERSION 158)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/doc/qbk/00_main.qbk
+++ b/doc/qbk/00_main.qbk
@@ -28,7 +28,7 @@
 
 [template source_file[path] '''<ulink url="../../'''[path]'''">'''[path]'''</ulink>''']
 [template include_file[path][^<'''<ulink url="../../../../'''[path]'''">'''[path]'''</ulink>'''>]]
-[template issue[n] '''(<ulink url="https://github.com/boostorg/beast/issues/'''[n]'''">#'''[n]'''</ulink>)''']
+[template issue[n] '''<ulink url="https://github.com/boostorg/beast/issues/'''[n]'''">#'''[n]'''</ulink>''']
 
 [def __N3747__                  [@http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3747.pdf [*N3747]]]
 [def __NetTS__                  [@http://cplusplus.github.io/networking-ts/draft.pdf [*Networking.TS]]]

--- a/doc/qbk/02_examples.qbk
+++ b/doc/qbk/02_examples.qbk
@@ -180,7 +180,9 @@ and illustrate the implementation of advanced features.
             [HTTP pipelining]
             [Asynchronous timeouts]
             [Dual protocols: HTTP and WebSocket]
-            [WebSocket use idle ping for timeout]]]
+            [WebSocket use idle ping for timeout]
+            [Clean exit via SIGINT (CTRL+C) or SIGTERM (kill)]
+        ]]
         [[example_src example/advanced/server/advanced_server.cpp advanced_server.cpp]]
 ][
         [Advanced, flex (plain + SSL)]
@@ -189,7 +191,9 @@ and illustrate the implementation of advanced features.
             [Asynchronous timeouts]
             [Dual protocols: HTTP and WebSocket]
             [WebSocket use idle ping for timeout]
-            [Flexible ports: plain and SSL on the same port]]]
+            [Flexible ports: plain and SSL on the same port]
+            [Clean exit via SIGINT (CTRL+C) or SIGTERM (kill)]
+        ]]
         [[example_src example/advanced/server-flex/advanced_server_flex.cpp advanced_server_flex.cpp]]
 ]]
 

--- a/doc/qbk/03_core/5_composed.qbk
+++ b/doc/qbk/03_core/5_composed.qbk
@@ -41,24 +41,27 @@ composed operations:
 [[
     [link beast.ref.boost__beast__bind_handler `bind_handler`]
 ][
-    This function returns a new, nullary completion handler which when
-    invoked with no arguments invokes the original completion handler with a
-    list of bound arguments. The invocation is made from the same implicit
-    or explicit strand as that which would be used to invoke the original
-    handler. This works because the returned call wrapper uses the same
-    associated executor and associated allocator as the bound handler.
+    This function creates a new handler which, when invoked, calls
+    the original handler with the list of bound arguments. Any
+    parameters passed in the invocation will be substituted for
+    placeholders present in the list of bound arguments. Parameters
+    which are not matched to placeholders are silently discarded.
+
+    The passed handler and arguments are forwarded into the returned
+    handler, whose associated allocator and associated executor will
+    will be the same as those of the original handler.
 ]]
 [[
     [link beast.ref.boost__beast__handler_ptr `handler_ptr`]
 ][
     This is a smart pointer container used to manage the internal state of a
     composed operation. It is useful when the state is non trivial. For example
-    when the state has non-copyable or expensive to copy types. The container
-    takes ownership of the final completion handler, and provides boilerplate
-    to invoke the final handler in a way that also deletes the internal state.
-    The internal state is allocated using the final completion handler's
-    associated allocator, benefiting from all handler memory management
-    optimizations transparently.
+    when the state has non-movable or contains expensive to move types. The
+    container takes ownership of the final completion handler, and provides
+    boilerplate to invoke the final handler in a way that also deletes the
+    internal state. The internal state is allocated using the final completion
+    handler's associated allocator, benefiting from all handler memory
+    management optimizations transparently.
 ]]
 ]
 

--- a/doc/qbk/06_websocket/1_streams.qbk
+++ b/doc/qbk/06_websocket/1_streams.qbk
@@ -78,4 +78,8 @@ accessed by calling
     operations are being performed may result in undefined behavior.
 ]
 
+[heading Non-Blocking Mode]
+
+Please note that websocket streams do not support non-blocking modes.
+
 [endsect]

--- a/doc/qbk/06_websocket/5_messages.qbk
+++ b/doc/qbk/06_websocket/5_messages.qbk
@@ -61,9 +61,9 @@ all of the buffers representing the message are known ahead of time:
 [ws_snippet_15]
 
 [important
-    Calls to [link beast.ref.boost__beast__websocket__stream.set_option `set_option`]
-    must be made from the same implicit or explicit strand as that used
-    to perform other operations.
+    [link beast.ref.boost__beast__websocket__stream `websocket::stream`]
+    is not thread-safe. Calls to stream member functions must
+    all be made from the same implicit or explicit strand.
 ]
 
 [heading Frames]

--- a/doc/qbk/09_releases.qbk
+++ b/doc/qbk/09_releases.qbk
@@ -20,9 +20,9 @@ to update to the latest Boost release.
 
 * Move-only completion handlers are supported throughout the library
 
-* [issue 899] Advanced server examples support idle websocket pings and timeouts
+* ([issue 899]) Advanced server examples support idle websocket pings and timeouts
 
-* [issue 849] WebSocket permessage-deflate support is now a compile-time
+* ([issue 849]) WebSocket permessage-deflate support is now a compile-time
   feature.  This adds an additional `bool` template parameter to
   [link beast.ref.boost__beast__websocket__stream `websocket::stream`]
   When `deflateSupported` is `true`, the stream will be capable of
@@ -34,7 +34,7 @@ to update to the latest Boost release.
   will be excluded from function instantiations. Programs which set
   `deflateSupported` to `false` when instantiating streams will be smaller.
 
-* [issue 949] WebSocket error codes are revised. New
+* ([issue 949]) WebSocket error codes are revised. New
   [link beast.ref.boost__beast__websocket__error error codes]
   are added for more fine-grained failure outcomes. Messages for error
   codes are more verbose to help pinpoint the problem. Error codes are
@@ -56,11 +56,11 @@ to update to the latest Boost release.
 
 [*Improvements]
 
-* [issue 857]
+* ([issue 857])
   [link beast.ref.boost__beast__http__basic_fields `http::basic_fields`]
   uses less storage
 
-* [issue 894]
+* ([issue 894])
   [link beast.ref.boost__beast__http__basic_fields `http::basic_fields`]
   exception specifiers are provided
 
@@ -68,45 +68,47 @@ to update to the latest Boost release.
 
 * Add [include_file boost/beast/websocket/stream_fwd.hpp]
 
-* [issue 955] The asynchronous SSL detector example uses a stackless coroutine
+* ([issue 955]) The asynchronous SSL detector example uses a stackless coroutine
 
 * [link beast.ref.boost__beast__bind_handler `bind_handler`]
   works with boost placeholders
 
 * Examples set `reuse_address(true)`
 
+* ([issue 1026]) Advanced servers support clean shutdown via SIGINT or SIGTERM
+
 [*Fixes]
 
 * Fix "warning: ‘const’ type qualifier on return type has no effect"
 
-* [issue 916] Tidy up `ssl_stream` special members in
+* ([issue 916]) Tidy up `ssl_stream` special members in
   [source_file example/common/ssl_stream.hpp]
 
-* [issue 918] Calls to `<algorithm>` are protected from macros
+* ([issue 918]) Calls to `<algorithm>` are protected from macros
 
-* [issue 954] The control callback is invoked on the proper executor
+* ([issue 954]) The control callback is invoked on the proper executor
 
-* [issue 994] Fix iterator version of
+* ([issue 994]) Fix iterator version of
   [link beast.ref.boost__beast__http__basic_fields.erase.overload1 `http::basic_fields::erase`]
 
-* [issue 992] Fix use-after-move in example request handlers
+* ([issue 992]) Fix use-after-move in example request handlers
 
-* [issue 988] Type check completion handlers
+* ([issue 988]) Type check completion handlers
 
-* [issue 985] Tidy up
+* ([issue 985]) Tidy up
   [link beast.ref.boost__beast__bind_handler `bind_handler`]
   doc
 
 * Fix memory leak in advanced server examples
 
-* [issue 1000] Fix soft-mutex assert in websocket stream.
+* ([issue 1000]) Fix soft-mutex assert in websocket stream.
   This resolves the assert `"ws_.wr_block_ == tok_"`.
 
-* [issue 1019] Fix fallthrough warnings
+* ([issue 1019]) Fix fallthrough warnings
 
-* [issue 1024] Fix teardown for TIME_WAIT
+* ([issue 1024]) Fix teardown for TIME_WAIT
 
-* [issue 1030] Fix big-endian websocket masking
+* ([issue 1030]) Fix big-endian websocket masking
 
 [*API Changes]
 
@@ -126,19 +128,19 @@ to update to the latest Boost release.
   constructor signature for state objects used with `handler_ptr`
   to receive a `const` reference to the handler.
 
-* [issue 896]
+* ([issue 896])
   [link beast.ref.boost__beast__http__basic_fields `http::basic_fields`]
   does not support fancy pointers
 
 * [link beast.ref.boost__beast__http__parser `http::parser`]
   is no longer [*MoveConstructible]
 
-* [issue 930] `http::serializer::reader_impl` is deprecated and will
+* ([issue 930]) `http::serializer::reader_impl` is deprecated and will
   be removed in the next release. Actions required: Call
   [link beast.ref.boost__beast__http__serializer.writer_impl `http::serializer::writer_impl`]
   instead of `serializer::reader_impl`.
 
-* [issue 884] The __BodyReader__ and __BodyWriter__ concept constructor
+* ([issue 884]) The __BodyReader__ and __BodyWriter__ concept constructor
   requirements have changed. They now require the header and body
   elements to be passed as distinct
   [link beast.ref.boost__beast__http__header `http::header`]

--- a/doc/qbk/09_releases.qbk
+++ b/doc/qbk/09_releases.qbk
@@ -160,7 +160,9 @@ to update to the latest Boost release.
   Actions required: do not attempt to write to input areas of dynamic
   buffers.
 
-
+* ([\issue 941]) `get_lowest_layer` is now a type alias.
+  Actions required: Replace instances of `typename get_lowest_layer<T>::type`
+  with `get_lowest_layer<T>`.
 
 [heading Boost 1.66]
 

--- a/doc/qbk/09_releases.qbk
+++ b/doc/qbk/09_releases.qbk
@@ -73,6 +73,7 @@ to update to the latest Boost release.
 * [link beast.ref.boost__beast__bind_handler `bind_handler`]
   works with boost placeholders
 
+* Examples set `reuse_address(true)`
 
 [*Fixes]
 

--- a/doc/qbk/09_releases.qbk
+++ b/doc/qbk/09_releases.qbk
@@ -156,7 +156,9 @@ to update to the latest Boost release.
 * [link beast.ref.boost__beast__websocket__stream.control_callback `websocket::stream::control_callback`]
   now copies or moves the function object.
 
-
+* ([issue 1014]) DynamicBuffer input areas are not mutable.
+  Actions required: do not attempt to write to input areas of dynamic
+  buffers.
 
 
 

--- a/example/advanced/server-flex/advanced_server_flex.cpp
+++ b/example/advanced/server-flex/advanced_server_flex.cpp
@@ -23,6 +23,7 @@
 #include <boost/beast/version.hpp>
 #include <boost/asio/bind_executor.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/signal_set.hpp>
 #include <boost/asio/ssl/stream.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/asio/steady_timer.hpp>
@@ -1272,6 +1273,17 @@ int main(int argc, char* argv[])
         tcp::endpoint{address, port},
         doc_root)->run();
 
+    // Capture SIGINT and SIGTERM to perform a clean shutdown
+    boost::asio::signal_set signals(ioc, SIGINT, SIGTERM);
+    signals.async_wait(
+        [&](boost::system::error_code const&, int)
+        {
+            // Stop the `io_context`. This will cause `run()`
+            // to return immediately, eventually destroying the
+            // `io_context` and all of the sockets in it.
+            ioc.stop();
+        });
+
     // Run the I/O service on the requested number of threads
     std::vector<std::thread> v;
     v.reserve(threads - 1);
@@ -1282,6 +1294,12 @@ int main(int argc, char* argv[])
             ioc.run();
         });
     ioc.run();
+
+    // (If we get here, it means we got a SIGINT or SIGTERM)
+
+    // Block until all the threads exit
+    for(auto& t : v)
+        t.join();
 
     return EXIT_SUCCESS;
 }

--- a/example/advanced/server-flex/advanced_server_flex.cpp
+++ b/example/advanced/server-flex/advanced_server_flex.cpp
@@ -1171,6 +1171,14 @@ public:
             return;
         }
 
+        // Allow address reuse
+        acceptor_.set_option(boost::asio::socket_base::reuse_address(true));
+        if(ec)
+        {
+            fail(ec, "set_option");
+            return;
+        }
+
         // Bind to the server address
         acceptor_.bind(endpoint, ec);
         if(ec)

--- a/example/advanced/server/advanced_server.cpp
+++ b/example/advanced/server/advanced_server.cpp
@@ -722,6 +722,14 @@ public:
             return;
         }
 
+        // Allow address reuse
+        acceptor_.set_option(boost::asio::socket_base::reuse_address(true));
+        if(ec)
+        {
+            fail(ec, "set_option");
+            return;
+        }
+
         // Bind to the server address
         acceptor_.bind(endpoint, ec);
         if(ec)

--- a/example/http/server/async-ssl/http_server_async_ssl.cpp
+++ b/example/http/server/async-ssl/http_server_async_ssl.cpp
@@ -419,6 +419,14 @@ public:
             return;
         }
 
+        // Allow address reuse
+        acceptor_.set_option(boost::asio::socket_base::reuse_address(true));
+        if(ec)
+        {
+            fail(ec, "set_option");
+            return;
+        }
+
         // Bind to the server address
         acceptor_.bind(endpoint, ec);
         if(ec)

--- a/example/http/server/async/http_server_async.cpp
+++ b/example/http/server/async/http_server_async.cpp
@@ -380,6 +380,14 @@ public:
             return;
         }
 
+        // Allow address reuse
+        acceptor_.set_option(boost::asio::socket_base::reuse_address(true));
+        if(ec)
+        {
+            fail(ec, "set_option");
+            return;
+        }
+
         // Bind to the server address
         acceptor_.bind(endpoint, ec);
         if(ec)

--- a/example/http/server/coro-ssl/http_server_coro_ssl.cpp
+++ b/example/http/server/coro-ssl/http_server_coro_ssl.cpp
@@ -325,6 +325,11 @@ do_listen(
     if(ec)
         return fail(ec, "open");
 
+    // Allow address reuse
+    acceptor.set_option(boost::asio::socket_base::reuse_address(true));
+    if(ec)
+        return fail(ec, "set_option");
+
     // Bind to the server address
     acceptor.bind(endpoint, ec);
     if(ec)

--- a/example/http/server/coro/http_server_coro.cpp
+++ b/example/http/server/coro/http_server_coro.cpp
@@ -309,6 +309,11 @@ do_listen(
     if(ec)
         return fail(ec, "open");
 
+    // Allow address reuse
+    acceptor.set_option(boost::asio::socket_base::reuse_address(true));
+    if(ec)
+        return fail(ec, "set_option");
+
     // Bind to the server address
     acceptor.bind(endpoint, ec);
     if(ec)

--- a/example/http/server/flex/http_server_flex.cpp
+++ b/example/http/server/flex/http_server_flex.cpp
@@ -591,6 +591,14 @@ public:
             return;
         }
 
+        // Allow address reuse
+        acceptor_.set_option(boost::asio::socket_base::reuse_address(true));
+        if(ec)
+        {
+            fail(ec, "set_option");
+            return;
+        }
+
         // Bind to the server address
         acceptor_.bind(endpoint, ec);
         if(ec)

--- a/example/http/server/stackless-ssl/http_server_stackless_ssl.cpp
+++ b/example/http/server/stackless-ssl/http_server_stackless_ssl.cpp
@@ -405,6 +405,14 @@ public:
             return;
         }
 
+        // Allow address reuse
+        acceptor_.set_option(boost::asio::socket_base::reuse_address(true));
+        if(ec)
+        {
+            fail(ec, "set_option");
+            return;
+        }
+
         // Bind to the server address
         acceptor_.bind(endpoint, ec);
         if(ec)

--- a/example/http/server/stackless/http_server_stackless.cpp
+++ b/example/http/server/stackless/http_server_stackless.cpp
@@ -372,6 +372,14 @@ public:
             return;
         }
 
+        // Allow address reuse
+        acceptor_.set_option(boost::asio::socket_base::reuse_address(true));
+        if(ec)
+        {
+            fail(ec, "set_option");
+            return;
+        }
+
         // Bind to the server address
         acceptor_.bind(endpoint, ec);
         if(ec)

--- a/example/websocket/server/async-ssl/websocket_server_async_ssl.cpp
+++ b/example/websocket/server/async-ssl/websocket_server_async_ssl.cpp
@@ -191,6 +191,14 @@ public:
             return;
         }
 
+        // Allow address reuse
+        acceptor_.set_option(boost::asio::socket_base::reuse_address(true));
+        if(ec)
+        {
+            fail(ec, "set_option");
+            return;
+        }
+
         // Bind to the server address
         acceptor_.bind(endpoint, ec);
         if(ec)

--- a/example/websocket/server/async/websocket_server_async.cpp
+++ b/example/websocket/server/async/websocket_server_async.cpp
@@ -165,6 +165,14 @@ public:
             return;
         }
 
+        // Allow address reuse
+        acceptor_.set_option(boost::asio::socket_base::reuse_address(true));
+        if(ec)
+        {
+            fail(ec, "set_option");
+            return;
+        }
+
         // Bind to the server address
         acceptor_.bind(endpoint, ec);
         if(ec)

--- a/example/websocket/server/coro-ssl/websocket_server_coro_ssl.cpp
+++ b/example/websocket/server/coro-ssl/websocket_server_coro_ssl.cpp
@@ -106,6 +106,11 @@ do_listen(
     if(ec)
         return fail(ec, "open");
 
+    // Allow address reuse
+    acceptor.set_option(boost::asio::socket_base::reuse_address(true));
+    if(ec)
+        return fail(ec, "set_option");
+
     // Bind to the server address
     acceptor.bind(endpoint, ec);
     if(ec)

--- a/example/websocket/server/coro/websocket_server_coro.cpp
+++ b/example/websocket/server/coro/websocket_server_coro.cpp
@@ -92,6 +92,11 @@ do_listen(
     if(ec)
         return fail(ec, "open");
 
+    // Allow address reuse
+    acceptor.set_option(boost::asio::socket_base::reuse_address(true));
+    if(ec)
+        return fail(ec, "set_option");
+
     // Bind to the server address
     acceptor.bind(endpoint, ec);
     if(ec)

--- a/example/websocket/server/fast/websocket_server_fast.cpp
+++ b/example/websocket/server/fast/websocket_server_fast.cpp
@@ -268,6 +268,14 @@ public:
             return;
         }
 
+        // Allow address reuse
+        acceptor_.set_option(boost::asio::socket_base::reuse_address(true));
+        if(ec)
+        {
+            fail(ec, "set_option");
+            return;
+        }
+
         // Bind to the server address
         acceptor_.bind(endpoint, ec);
         if(ec)
@@ -375,6 +383,10 @@ do_coro_listen(
     acceptor.open(endpoint.protocol(), ec);
     if(ec)
         return fail(ec, "open");
+
+    acceptor.set_option(boost::asio::socket_base::reuse_address(true));
+    if(ec)
+        return fail(ec, "set_option");
 
     acceptor.bind(endpoint, ec);
     if(ec)

--- a/example/websocket/server/stackless-ssl/websocket_server_stackless_ssl.cpp
+++ b/example/websocket/server/stackless-ssl/websocket_server_stackless_ssl.cpp
@@ -179,6 +179,14 @@ public:
             return;
         }
 
+        // Allow address reuse
+        acceptor_.set_option(boost::asio::socket_base::reuse_address(true));
+        if(ec)
+        {
+            fail(ec, "set_option");
+            return;
+        }
+
         // Bind to the server address
         acceptor_.bind(endpoint, ec);
         if(ec)

--- a/example/websocket/server/stackless/websocket_server_stackless.cpp
+++ b/example/websocket/server/stackless/websocket_server_stackless.cpp
@@ -156,6 +156,14 @@ public:
             return;
         }
 
+        // Allow address reuse
+        acceptor_.set_option(boost::asio::socket_base::reuse_address(true));
+        if(ec)
+        {
+            fail(ec, "set_option");
+            return;
+        }
+
         // Bind to the server address
         acceptor_.bind(endpoint, ec);
         if(ec)

--- a/include/boost/beast/core/bind_handler.hpp
+++ b/include/boost/beast/core/bind_handler.hpp
@@ -31,11 +31,6 @@ namespace beast {
     handler, whose associated allocator and associated executor will
     will be the same as those of the original handler.
 
-    Unlike `boost::asio::io_context::wrap`, the returned handler can
-    be used in a subsequent call to `boost::asio::post` instead of
-    `boost::asio::dispatch`, to ensure that the handler will not be
-    invoked immediately by the calling function.
-
     Example:
 
     @code

--- a/include/boost/beast/core/buffered_read_stream.hpp
+++ b/include/boost/beast/core/buffered_read_stream.hpp
@@ -111,8 +111,7 @@ public:
         typename std::remove_reference<Stream>::type;
 
     /// The type of the lowest layer.
-    using lowest_layer_type =
-        typename get_lowest_layer<next_layer_type>::type;
+    using lowest_layer_type = get_lowest_layer<next_layer_type>;
 
     /** Move constructor.
 

--- a/include/boost/beast/core/detail/type_traits.hpp
+++ b/include/boost/beast/core/detail/type_traits.hpp
@@ -255,6 +255,21 @@ max_all(U0 u0, U1 u1, UN... un)
 
 //------------------------------------------------------------------------------
 
+template<class T, class = void>
+struct get_lowest_layer_helper
+{
+    using type = T;
+};
+
+template<class T>
+struct get_lowest_layer_helper<T,
+    void_t<typename T::lowest_layer_type>>
+{
+    using type = typename T::lowest_layer_type;
+};
+
+//------------------------------------------------------------------------------
+
 //
 // buffer concepts
 //

--- a/include/boost/beast/core/flat_buffer.hpp
+++ b/include/boost/beast/core/flat_buffer.hpp
@@ -84,7 +84,7 @@ public:
     using allocator_type = Allocator;
 
     /// The type used to represent the input sequence as a list of buffers.
-    using const_buffers_type = boost::asio::mutable_buffer;
+    using const_buffers_type = boost::asio::const_buffer;
 
     /// The type used to represent the output sequence as a list of buffers.
     using mutable_buffers_type = boost::asio::mutable_buffer;

--- a/include/boost/beast/core/flat_static_buffer.hpp
+++ b/include/boost/beast/core/flat_static_buffer.hpp
@@ -52,7 +52,7 @@ public:
 
         This buffer sequence is guaranteed to have length 1.
     */
-    using const_buffers_type = boost::asio::mutable_buffer;
+    using const_buffers_type = boost::asio::const_buffer;
 
     /** The type used to represent the output sequence as a list of buffers.
 

--- a/include/boost/beast/core/impl/multi_buffer.ipp
+++ b/include/boost/beast/core/impl/multi_buffer.ipp
@@ -132,7 +132,7 @@ class basic_multi_buffer<Allocator>::const_buffers_type
     const_buffers_type(basic_multi_buffer const& b);
 
 public:
-    using value_type = boost::asio::mutable_buffer;
+    using value_type = boost::asio::const_buffer;
 
     class const_iterator;
 

--- a/include/boost/beast/core/impl/static_buffer.ipp
+++ b/include/boost/beast/core/impl/static_buffer.ipp
@@ -35,8 +35,29 @@ static_buffer_base::
 data() const ->
     const_buffers_type
 {
-    using boost::asio::mutable_buffer;
+    using boost::asio::const_buffer;
     const_buffers_type result;
+    if(in_off_ + in_size_ <= capacity_)
+    {
+        result[0] = const_buffer{begin_ + in_off_, in_size_};
+        result[1] = const_buffer{begin_, 0};
+    }
+    else
+    {
+        result[0] = const_buffer{begin_ + in_off_, capacity_ - in_off_};
+        result[1] = const_buffer{begin_, in_size_ - (capacity_ - in_off_)};
+    }
+    return result;
+}
+
+inline
+auto
+static_buffer_base::
+mutable_data() ->
+    mutable_buffers_type
+{
+    using boost::asio::mutable_buffer;
+    mutable_buffers_type result;
     if(in_off_ + in_size_ <= capacity_)
     {
         result[0] = mutable_buffer{begin_ + in_off_, in_size_};

--- a/include/boost/beast/core/static_buffer.hpp
+++ b/include/boost/beast/core/static_buffer.hpp
@@ -52,7 +52,7 @@ class static_buffer_base
 public:
     /// The type used to represent the input sequence as a list of buffers.
     using const_buffers_type =
-        std::array<boost::asio::mutable_buffer, 2>;
+        std::array<boost::asio::const_buffer, 2>;
 
     /// The type used to represent the output sequence as a list of buffers.
     using mutable_buffers_type =
@@ -93,6 +93,11 @@ public:
     */
     const_buffers_type
     data() const;
+
+    /** Get a mutable list of buffers that represent the input sequence.
+    */
+    mutable_buffers_type
+    mutable_data();
 
     /** Get a list of buffers that represent the output sequence, with the given size.
 

--- a/include/boost/beast/core/type_traits.hpp
+++ b/include/boost/beast/core/type_traits.hpp
@@ -122,10 +122,10 @@ struct has_get_executor<T, beast::detail::void_t<decltype(
     (void)0)>> : std::true_type {};
 #endif
 
-/** Returns `T::lowest_layer_type` if it exists, else `T`
+/** Alias for `T::lowest_layer_type` if it exists, else `T`
 
-    This will contain a nested `type` equal to `T::lowest_layer_type`
-    if it exists, else `type` will be equal to `T`.
+    This will be a type alias for `T::lowest_layer_type`
+    if it exists, else it will be an alias for `T`.
 
     @par Example
 
@@ -136,7 +136,7 @@ struct has_get_executor<T, beast::detail::void_t<decltype(
     struct stream_wrapper
     {
         using next_layer_type = typename std::remove_reference<Stream>::type;
-        using lowest_layer_type = typename get_lowest_layer<stream_type>::type;
+        using lowest_layer_type = get_lowest_layer<stream_type>;
     };
     @endcode
 
@@ -146,25 +146,15 @@ struct has_get_executor<T, beast::detail::void_t<decltype(
     /// Alias for `std::true_type` if `T` wraps another stream
     template<class T>
     using is_stream_wrapper : std::integral_constant<bool,
-        ! std::is_same<T, typename get_lowest_layer<T>::type>::value> {};
+        ! std::is_same<T, get_lowest_layer<T>>::value> {};
     @endcode
 */
 #if BOOST_BEAST_DOXYGEN
 template<class T>
 struct get_lowest_layer;
 #else
-template<class T, class = void>
-struct get_lowest_layer
-{
-    using type = T;
-};
-
 template<class T>
-struct get_lowest_layer<T, detail::void_t<
-    typename T::lowest_layer_type>>
-{
-    using type = typename T::lowest_layer_type;
-};
+using get_lowest_layer = typename detail::get_lowest_layer_helper<T>::type;
 #endif
 
 /** Determine if `T` meets the requirements of @b AsyncReadStream.

--- a/include/boost/beast/http/error.hpp
+++ b/include/boost/beast/http/error.hpp
@@ -22,15 +22,10 @@ enum class error
 {
     /** The end of the stream was reached.
 
-        This error is returned under the following conditions:
-
-        @li When attempting to read HTTP data from a stream and the stream
-        read returns the error `boost::asio::error::eof` before any new octets
-        have been received.
-
-        @li When sending a complete HTTP message at once and the semantics of
-        the message are that the connection should be closed to indicate the
-        end of the message.
+        This error is returned when attempting to read HTTP data,
+        and the stream returns the error `boost::asio::error::eof`
+        before any octets corresponding to a new HTTP message have
+        been received.
     */
     end_of_stream = 1,
 

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 157
+#define BOOST_BEAST_VERSION 158
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/impl/close.ipp
+++ b/include/boost/beast/websocket/impl/close.ipp
@@ -228,7 +228,7 @@ operator()(
                     d.ws.rd_close_ = true;
                     auto const mb = buffers_prefix(
                         clamp(d.ws.rd_fh_.len),
-                        d.ws.rd_buf_.data());
+                        d.ws.rd_buf_.mutable_data());
                     if(d.ws.rd_fh_.len > 0 && d.ws.rd_fh_.mask)
                         detail::mask_inplace(mb, d.ws.rd_key_);
                     detail::read_close(d.ws.cr_, mb, d.ev);
@@ -370,7 +370,7 @@ close(close_reason const& cr, error_code& ec)
                 rd_close_ = true;
                 auto const mb = buffers_prefix(
                     clamp(rd_fh_.len),
-                    rd_buf_.data());
+                    rd_buf_.mutable_data());
                 if(rd_fh_.len > 0 && rd_fh_.mask)
                     detail::mask_inplace(mb, rd_key_);
                 detail::read_close(cr_, mb, result);

--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -253,7 +253,7 @@ operator()(
             if(ws_.rd_fh_.len > 0 && ws_.rd_fh_.mask)
                 detail::mask_inplace(buffers_prefix(
                     clamp(ws_.rd_fh_.len),
-                        ws_.rd_buf_.data()),
+                        ws_.rd_buf_.mutable_data()),
                             ws_.rd_key_);
             if(detail::is_control(ws_.rd_fh_.op))
             {
@@ -440,7 +440,7 @@ operator()(
                     ws_.rd_buf_.commit(bytes_transferred);
                     if(ws_.rd_fh_.mask)
                         detail::mask_inplace(buffers_prefix(clamp(
-                            ws_.rd_remain_), ws_.rd_buf_.data()),
+                            ws_.rd_remain_), ws_.rd_buf_.mutable_data()),
                                 ws_.rd_key_);
                 }
                 if(ws_.rd_buf_.size() > 0)
@@ -528,7 +528,7 @@ operator()(
                     if(ws_.rd_fh_.mask)
                         detail::mask_inplace(
                             buffers_prefix(clamp(ws_.rd_remain_),
-                                ws_.rd_buf_.data()), ws_.rd_key_);
+                                ws_.rd_buf_.mutable_data()), ws_.rd_key_);
                     did_read_ = true;
                 }
                 zlib::z_params zs;
@@ -1049,7 +1049,7 @@ loop:
         // of the buffer holding payload data.
         if(rd_fh_.len > 0 && rd_fh_.mask)
             detail::mask_inplace(buffers_prefix(
-                clamp(rd_fh_.len), rd_buf_.data()),
+                clamp(rd_fh_.len), rd_buf_.mutable_data()),
                     rd_key_);
         if(detail::is_control(rd_fh_.op))
         {
@@ -1151,7 +1151,7 @@ loop:
                 if(rd_fh_.mask)
                     detail::mask_inplace(
                         buffers_prefix(clamp(rd_remain_),
-                            rd_buf_.data()), rd_key_);
+                            rd_buf_.mutable_data()), rd_key_);
             }
             if(rd_buf_.size() > 0)
             {
@@ -1258,7 +1258,7 @@ loop:
                     if(rd_fh_.mask)
                         detail::mask_inplace(
                             buffers_prefix(clamp(rd_remain_),
-                                rd_buf_.data()), rd_key_);
+                                rd_buf_.mutable_data()), rd_key_);
                     auto const in = buffers_prefix(
                         clamp(rd_remain_), buffers_front(
                             rd_buf_.data()));

--- a/include/boost/beast/websocket/stream.hpp
+++ b/include/boost/beast/websocket/stream.hpp
@@ -225,8 +225,7 @@ public:
         typename std::remove_reference<NextLayer>::type;
 
     /// The type of the lowest layer.
-    using lowest_layer_type =
-        typename get_lowest_layer<next_layer_type>::type;
+    using lowest_layer_type = get_lowest_layer<next_layer_type>;
 
     /// The type of the executor associated with the object.
     using executor_type = typename next_layer_type::executor_type;

--- a/test/beast/core/type_traits.cpp
+++ b/test/beast/core/type_traits.cpp
@@ -71,8 +71,7 @@ struct F3
     using next_layer_type =
         typename std::remove_reference<F>::type;
 
-    using lowest_layer_type = typename
-        get_lowest_layer<next_layer_type>::type;
+    using lowest_layer_type = get_lowest_layer<next_layer_type>;
 };
 
 template<class F>
@@ -81,18 +80,18 @@ struct F4
     using next_layer_type =
         typename std::remove_reference<F>::type;
 
-    using lowest_layer_type = typename
-        get_lowest_layer<next_layer_type>::type;
+    using lowest_layer_type =
+        get_lowest_layer<next_layer_type>;
 };
 
-BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F1>::type, F1>::value);
-BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F2>::type, F2>::value);
-BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F3<F1>>::type, F1>::value);
-BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F3<F2>>::type, F2>::value);
-BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F4<F1>>::type, F1>::value);
-BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F4<F2>>::type, F2>::value);
-BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F4<F3<F1>>>::type, F1>::value);
-BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F4<F3<F2>>>::type, F2>::value);
+BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F1>, F1>::value);
+BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F2>, F2>::value);
+BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F3<F1>>, F1>::value);
+BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F3<F2>>, F2>::value);
+BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F4<F1>>, F1>::value);
+BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F4<F2>>, F2>::value);
+BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F4<F3<F1>>>, F1>::value);
+BOOST_STATIC_ASSERT(std::is_same<get_lowest_layer<F4<F3<F2>>>, F2>::value);
 
 //
 // min_all, max_all


### PR DESCRIPTION
* Tidy up end_of_stream javadoc
* Tidy up websocket docs
* Examples set reuse_address(true)
* Advanced servers support clean shutdown via SIGINT or SIGTERM
* DynamicBuffer input areas are not mutable
* Tidy up some documentation

API Changes:

* get_lowest_layer is a type alias

Actions required:

* Replace instances of `typename get_lowest_layer<T>::type`
  with `get_lowest_layer<T>`.
