### PR TITLE
Version 159

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 159:
 
 * Fix typo in release notes
 * Safe treatment of zero-length string arguments in basic_fields
+* Some basic_fields operations now give the strong exception guarantee
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 159:
 
 * Fix typo in release notes
+* Safe treatment of zero-length string arguments in basic_fields
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 159:
+
+* Fix typo in release notes
+
+--------------------------------------------------------------------------------
+
 Version 158:
 
 * Tidy up end_of_stream javadoc
@@ -15,7 +21,6 @@ Actions required:
 
 * Replace instances of `typename get_lowest_layer<T>::type`
   with `get_lowest_layer<T>`.
-
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.5.1)
 
-project (Beast VERSION 158)
+project (Beast VERSION 159)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/doc/qbk/09_releases.qbk
+++ b/doc/qbk/09_releases.qbk
@@ -110,6 +110,8 @@ to update to the latest Boost release.
 
 * ([issue 1030]) Fix big-endian websocket masking
 
+* Safe treatment of zero-length string arguments in basic_fields
+
 [*API Changes]
 
 * Remove unintended public members of

--- a/doc/qbk/09_releases.qbk
+++ b/doc/qbk/09_releases.qbk
@@ -77,6 +77,8 @@ to update to the latest Boost release.
 
 * ([issue 1026]) Advanced servers support clean shutdown via SIGINT or SIGTERM
 
+* Some basic_fields operations now give the strong exception guarantee
+
 [*Fixes]
 
 * Fix "warning: ‘const’ type qualifier on return type has no effect"

--- a/doc/qbk/09_releases.qbk
+++ b/doc/qbk/09_releases.qbk
@@ -160,7 +160,7 @@ to update to the latest Boost release.
   Actions required: do not attempt to write to input areas of dynamic
   buffers.
 
-* ([\issue 941]) `get_lowest_layer` is now a type alias.
+* ([issue 941]) `get_lowest_layer` is now a type alias.
   Actions required: Replace instances of `typename get_lowest_layer<T>::type`
   with `get_lowest_layer<T>`.
 

--- a/include/boost/beast/http/impl/fields.ipp
+++ b/include/boost/beast/http/impl/fields.ipp
@@ -1219,18 +1219,19 @@ realloc_string(string_view& dest, string_view s)
     auto a = typename beast::detail::allocator_traits<
         Allocator>::template rebind_alloc<
             char>(this->member());
-    if(! dest.empty())
-    {
-        a.deallocate(const_cast<char*>(
-            dest.data()), dest.size());
-        dest = {};
-    }
+    char* p = nullptr;
     if(! s.empty())
     {
-        auto const p = a.allocate(s.size());
+        p = a.allocate(s.size());
         s.copy(p, s.size());
-        dest = {p, s.size()};
     }
+    if(! dest.empty())
+        a.deallocate(const_cast<char*>(
+            dest.data()), dest.size());
+    if(p)
+        dest = {p, s.size()};
+    else
+        dest = {};
 }
 
 template<class Allocator>
@@ -1247,19 +1248,20 @@ realloc_target(
     auto a = typename beast::detail::allocator_traits<
         Allocator>::template rebind_alloc<
             char>(this->member());
-    if(! dest.empty())
-    {
-        a.deallocate(const_cast<char*>(
-            dest.data()), dest.size());
-        dest = {};
-    }
+    char* p = nullptr;
     if(! s.empty())
     {
-        auto const p = a.allocate(1 + s.size());
+        p = a.allocate(1 + s.size());
         p[0] = ' ';
         s.copy(p + 1, s.size());
-        dest = {p, 1 + s.size()};
     }
+    if(! dest.empty())
+        a.deallocate(const_cast<char*>(
+            dest.data()), dest.size());
+    if(p)
+        dest = {p, 1 + s.size()};
+    else
+        dest = {};
 }
 
 template<class Allocator>

--- a/include/boost/beast/http/impl/fields.ipp
+++ b/include/boost/beast/http/impl/fields.ipp
@@ -272,8 +272,10 @@ writer(basic_fields const& f,
 template<class Allocator>
 basic_fields<Allocator>::
 value_type::
-value_type(field name,
-        string_view sname, string_view value)
+value_type(
+    field name,
+    string_view sname,
+    string_view value)
     : off_(static_cast<off_t>(sname.size() + 2))
     , len_(static_cast<off_t>(value.size()))
     , f_(name)
@@ -285,8 +287,8 @@ value_type(field name,
     p[off_-1] = ' ';
     p[off_ + len_] = '\r';
     p[off_ + len_ + 1] = '\n';
-    std::memcpy(p, sname.data(), sname.size());
-    std::memcpy(p + off_, value.data(), value.size());
+    sname.copy(p, sname.size());
+    value.copy(p + off_, value.size());
 }
 
 template<class Allocator>
@@ -1226,7 +1228,7 @@ realloc_string(string_view& dest, string_view s)
     if(! s.empty())
     {
         auto const p = a.allocate(s.size());
-        std::memcpy(p, s.data(), s.size());
+        s.copy(p, s.size());
         dest = {p, s.size()};
     }
 }
@@ -1255,7 +1257,7 @@ realloc_target(
     {
         auto const p = a.allocate(1 + s.size());
         p[0] = ' ';
-        std::memcpy(p + 1, s.data(), s.size());
+        s.copy(p + 1, s.size());
         dest = {p, 1 + s.size()};
     }
 }

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 158
+#define BOOST_BEAST_VERSION 159
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 


### PR DESCRIPTION
* Fix typo in release notes
* Safe treatment of zero-length string arguments in basic_fields
* Some basic_fields operations now give the strong exception guarantee
