### PR TITLE
Don't copy the handler in websocket write_some_op

### DIFF
--- a/include/boost/beast/websocket/impl/write.ipp
+++ b/include/boost/beast/websocket/impl/write.ipp
@@ -561,7 +561,7 @@ operator()(
         if(! cont_)
             return boost::asio::post(
                 ws_.stream_.get_executor(),
-                bind_handler(h_, ec, bytes_transferred_));
+                bind_handler(std::move(h_), ec, bytes_transferred_));
         h_(ec, bytes_transferred_);
     }
 }


### PR DESCRIPTION
While experimenting with the latest version of Beast I think I spotted a small omission from the revamp in https://github.com/boostorg/beast/commit/200e898f7e287d33863990ccf7af0f07bfa1a1a6

This ~10 character commit is my attempt to fix this issue :smile:

Some stray observations: 

- a recursive `grep` for the phrase `Copies will be made of the handler as required` turns up a lot of results in the documentation for various read/write ops. I guess these lines should all be removed?
- I think the issue in this PR could have been caught by a compile time unit test in the form of a static assert. Maybe an approach with `boost::callable_traits::is_invocable` and a move-only function object could be used to test a wide variety of operations to make sure they don't require handler copying.

I think maybe both those points are outside the scope of this PR, but if you think they are worth an issue or PR of their own I would be happy to contribute or help.
