### PR TITLE
Version 166

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 166:
+
+* Use boost::is_convertible as a workaround
+
+--------------------------------------------------------------------------------
+
 Version 165:
 
 * Fix BOOST_NO_CXX11_ALLOCATOR check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.5.1)
 
-project (Beast VERSION 165)
+project (Beast VERSION 166)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/include/boost/beast/core/detail/type_traits.hpp
+++ b/include/boost/beast/core/detail/type_traits.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/beast/core/error.hpp>
 #include <boost/asio/buffer.hpp>
+#include <boost/type_traits.hpp>
 #include <iterator>
 #include <tuple>
 #include <type_traits>
@@ -309,7 +310,7 @@ template<class... Bn>
 struct common_buffers_type
 {
     using type = typename std::conditional<
-        std::is_convertible<std::tuple<Bn...>,
+        boost::is_convertible<std::tuple<Bn...>,
             typename repeat_tuple<sizeof...(Bn),
                 boost::asio::mutable_buffer>::type>::value,
                     boost::asio::mutable_buffer,
@@ -341,7 +342,7 @@ class buffers_range_adaptor
 
 public:
     using value_type = typename std::conditional<
-        std::is_convertible<
+        boost::is_convertible<
             typename std::iterator_traits<
                 typename buffer_sequence_iterator<
                     Buffers>::type>::value_type,

--- a/include/boost/beast/core/impl/buffers_prefix.ipp
+++ b/include/boost/beast/core/impl/buffers_prefix.ipp
@@ -53,7 +53,7 @@ class buffers_prefix_view<BufferSequence>::const_iterator
 
 public:
     using value_type = typename std::conditional<
-        std::is_convertible<typename
+        boost::is_convertible<typename
             std::iterator_traits<iter_type>::value_type,
                 boost::asio::mutable_buffer>::value,
                     boost::asio::mutable_buffer,

--- a/include/boost/beast/core/impl/buffers_suffix.ipp
+++ b/include/boost/beast/core/impl/buffers_suffix.ipp
@@ -11,6 +11,7 @@
 #define BOOST_BEAST_IMPL_BUFFERS_SUFFIX_IPP
 
 #include <boost/beast/core/type_traits.hpp>
+#include <boost/type_traits.hpp>
 #include <algorithm>
 #include <cstdint>
 #include <iterator>
@@ -33,7 +34,7 @@ class buffers_suffix<Buffers>::const_iterator
 
 public:
     using value_type = typename std::conditional<
-        std::is_convertible<typename
+        boost::is_convertible<typename
             std::iterator_traits<iter_type>::value_type,
                 boost::asio::mutable_buffer>::value,
                     boost::asio::mutable_buffer,

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 165
+#define BOOST_BEAST_VERSION 166
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 


### PR DESCRIPTION
This could fix a compile error on a particular configuration:
http://www.boost.org/development/tests/master/developer/output/teeks99-02-mc3-5-14-Docker-64on64-boost-bin-v2-libs-beast-test-beast-core-buffers_cat-test-clang-linux-3-5~c++14-debug-threadapi-pthread-threading-multi.html