### PR TITLE
Version 168

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,24 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 30
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - API Change
+  - Bug
+  - Design
+  - Doc
+  - Example
+  - Feature
+  - Talk
+# Label to use when marking an issue as stale
+staleLabel: Stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been open for a while with no activity, has it
+  been resolved?
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  It looks like this issue has either been abandoned or resolved so
+  I will go ahead and close it. Feel free to re-open this issue if
+  you feel it needs attention, or open new issues as needed. Thanks!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 168:
+
+* Use executor_work_guard in composed operations
+
+--------------------------------------------------------------------------------
+
 Version 167:
 
 * Revert: Tidy up calls to post()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 168:
 
 * Use executor_work_guard in composed operations
 * Revert verb.ipp change which caused spurious warnings
+* Fix race in advanced server examples
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 168:
 
 * Use executor_work_guard in composed operations
+* Revert verb.ipp change which caused spurious warnings
 
 --------------------------------------------------------------------------------
 
@@ -19,7 +20,6 @@ Version 166:
 Version 165:
 
 * Fix BOOST_NO_CXX11_ALLOCATOR check
-* Tidy up a warning
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.5.1)
 
-project (Beast VERSION 167)
+project (Beast VERSION 168)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/doc/qbk/03_core/5_composed.qbk
+++ b/doc/qbk/03_core/5_composed.qbk
@@ -146,6 +146,9 @@ composed operations:
   __io_context__, the underlying stream may be accessed in a fashion
   that violates safety guarantees.
 
+* Forgetting to create an object of type __executor_work_guard__ with the
+  type of executor returned by the stream's `get_executor` member function.
+
 * For operations which complete immediately (i.e. without calling an
   intermediate initiating function), forgetting to use __post__ to
   invoke the final handler. This breaks the following initiating

--- a/example/advanced/server-flex/advanced_server_flex.cpp
+++ b/example/advanced/server-flex/advanced_server_flex.cpp
@@ -924,6 +924,15 @@ public:
     void
     run()
     {
+        // Make sure we run on the strand
+        if(! strand_.running_in_this_thread())
+            return boost::asio::post(
+                boost::asio::bind_executor(
+                    strand_,
+                    std::bind(
+                        &plain_http_session::run,
+                        shared_from_this())));
+
         // Run the timer. The timer is operated
         // continuously, this simplifies the code.
         on_timer({});
@@ -996,6 +1005,15 @@ public:
     void
     run()
     {
+        // Make sure we run on the strand
+        if(! strand_.running_in_this_thread())
+            return boost::asio::post(
+                boost::asio::bind_executor(
+                    strand_,
+                    std::bind(
+                        &ssl_http_session::run,
+                        shared_from_this())));
+
         // Run the timer. The timer is operated
         // continuously, this simplifies the code.
         on_timer({});

--- a/example/advanced/server/advanced_server.cpp
+++ b/example/advanced/server/advanced_server.cpp
@@ -578,6 +578,15 @@ public:
     void
     run()
     {
+        // Make sure we run on the strand
+        if(! strand_.running_in_this_thread())
+            return boost::asio::post(
+                boost::asio::bind_executor(
+                    strand_,
+                    std::bind(
+                        &http_session::run,
+                        shared_from_this())));
+
         // Run the timer. The timer is operated
         // continuously, this simplifies the code.
         on_timer({});

--- a/example/echo-op/echo_op.cpp
+++ b/example/echo-op/echo_op.cpp
@@ -88,6 +88,13 @@ class echo_op
         // The stream to read and write to
         AsyncStream& stream;
 
+        // Boost.Asio and the Networking TS require an object of
+        // type executor_work_guard<T>, where T is the type of
+        // executor returned by the stream's get_executor function,
+        // to persist for the duration of the asynchronous operation.
+        boost::asio::executor_work_guard<
+            decltype(std::declval<AsyncStream&>().get_executor())> work;
+
         // Indicates what step in the operation's state machine
         // to perform next, starting from zero.
         int step = 0;
@@ -109,6 +116,7 @@ class echo_op
         //
         explicit state(Handler const& handler, AsyncStream& stream_)
             : stream(stream_)
+            , work(stream.get_executor())
             , buffer((std::numeric_limits<std::size_t>::max)(),
                 boost::asio::get_associated_allocator(handler))
         {
@@ -215,7 +223,6 @@ operator()(boost::beast::error_code ec, std::size_t bytes_transferred)
             p.buffer.consume(bytes_transferred);
             break;
     }
-
     // Invoke the final handler. The implementation of `handler_ptr`
     // will deallocate the storage for the state before the handler
     // is invoked. This is necessary to provide the
@@ -226,6 +233,10 @@ operator()(boost::beast::error_code ec, std::size_t bytes_transferred)
     // from the `state`, they would have to be moved to the stack
     // first or else undefined behavior results.
     //
+    // The work guard is moved to the stack first, otherwise it would
+    // be destroyed before the handler is invoked.
+    //
+    auto work = std::move(p.work);
     p_.invoke(ec);
     return;
 }

--- a/include/boost/beast/core/impl/buffered_read_stream.ipp
+++ b/include/boost/beast/core/impl/buffered_read_stream.ipp
@@ -18,6 +18,7 @@
 #include <boost/beast/core/detail/config.hpp>
 #include <boost/asio/associated_allocator.hpp>
 #include <boost/asio/associated_executor.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/handler_continuation_hook.hpp>
 #include <boost/asio/handler_invoke_hook.hpp>
 #include <boost/asio/post.hpp>
@@ -31,10 +32,12 @@ template<class MutableBufferSequence, class Handler>
 class buffered_read_stream<
     Stream, DynamicBuffer>::read_some_op
 {
-    int step_ = 0;
     buffered_read_stream& s_;
+    boost::asio::executor_work_guard<decltype(
+        std::declval<Stream&>().get_executor())> wg_;
     MutableBufferSequence b_;
     Handler h_;
+    int step_ = 0;
 
 public:
     read_some_op(read_some_op&&) = default;
@@ -45,6 +48,7 @@ public:
         buffered_read_stream& s,
             MutableBufferSequence const& b)
         : s_(s)
+        , wg_(s_.get_executor())
         , b_(b)
         , h_(std::forward<DeducedHandler>(h))
     {

--- a/include/boost/beast/http/impl/file_body_win32.ipp
+++ b/include/boost/beast/http/impl/file_body_win32.ipp
@@ -20,6 +20,7 @@
 #include <boost/asio/associated_executor.hpp>
 #include <boost/asio/async_result.hpp>
 #include <boost/asio/basic_stream_socket.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/handler_continuation_hook.hpp>
 #include <boost/asio/handler_invoke_hook.hpp>
 #include <boost/asio/windows/overlapped_ptr.hpp>
@@ -337,6 +338,8 @@ template<
 class write_some_win32_op
 {
     boost::asio::basic_stream_socket<Protocol>& sock_;
+    boost::asio::executor_work_guard<decltype(std::declval<
+        boost::asio::basic_stream_socket<Protocol>&>().get_executor())> wg_;
     serializer<isRequest,
         basic_file_body<file_win32>, Fields>& sr_;
     std::size_t bytes_transferred_ = 0;
@@ -354,6 +357,7 @@ public:
         serializer<isRequest,
             basic_file_body<file_win32>,Fields>& sr)
         : sock_(s)
+        , wg_(sock_.get_executor())
         , sr_(sr)
         , h_(std::forward<DeducedHandler>(h))
     {

--- a/include/boost/beast/http/impl/verb.ipp
+++ b/include/boost/beast/http/impl/verb.ipp
@@ -72,10 +72,6 @@ verb_to_string(verb v)
     }
 
     BOOST_THROW_EXCEPTION(std::invalid_argument{"unknown verb"});
-
-    // Help some compilers which don't know the next line is
-    // unreachable, otherwise spurious warnings are generated.
-    return "<unknown>";
 }
 
 template<class = void>

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 167
+#define BOOST_BEAST_VERSION 168
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/impl/accept.ipp
+++ b/include/boost/beast/websocket/impl/accept.ipp
@@ -22,6 +22,7 @@
 #include <boost/asio/coroutine.hpp>
 #include <boost/asio/associated_allocator.hpp>
 #include <boost/asio/associated_executor.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/handler_continuation_hook.hpp>
 #include <boost/asio/handler_invoke_hook.hpp>
 #include <boost/asio/post.hpp>
@@ -43,6 +44,8 @@ class stream<NextLayer, deflateSupported>::response_op
     struct data
     {
         stream<NextLayer, deflateSupported>& ws;
+        boost::asio::executor_work_guard<decltype(std::declval<
+            stream<NextLayer, deflateSupported>&>().get_executor())> wg;
         error_code result;
         response_type res;
 
@@ -54,6 +57,7 @@ class stream<NextLayer, deflateSupported>::response_op
                 http::basic_fields<Allocator>> const& req,
             Decorator const& decorator)
             : ws(ws_)
+            , wg(ws.get_executor())
             , res(ws_.build_response(req, decorator, result))
         {
         }
@@ -137,7 +141,10 @@ operator()(
             d.ws.do_pmd_config(d.res, is_deflate_supported{});
             d.ws.open(role_type::server);
         }
-        d_.invoke(ec);
+        {
+            auto wg = std::move(d.wg);
+            d_.invoke(ec);
+        }
     }
 }
 
@@ -153,6 +160,8 @@ class stream<NextLayer, deflateSupported>::accept_op
     struct data
     {
         stream<NextLayer, deflateSupported>& ws;
+        boost::asio::executor_work_guard<decltype(std::declval<
+            stream<NextLayer, deflateSupported>&>().get_executor())> wg;
         Decorator decorator;
         http::request_parser<http::empty_body> p;
         data(
@@ -160,6 +169,7 @@ class stream<NextLayer, deflateSupported>::accept_op
             stream<NextLayer, deflateSupported>& ws_,
             Decorator const& decorator_)
             : ws(ws_)
+            , wg(ws.get_executor())
             , decorator(decorator_)
         {
         }
@@ -284,6 +294,7 @@ operator()(error_code ec, std::size_t)
                 auto& ws = d.ws;
                 auto const req = d.p.release();
                 auto const decorator = d.decorator;
+                auto wg = std::move(d.wg);
             #if 1
                 return response_op<Handler>{
                     d_.release_handler(),
@@ -297,7 +308,10 @@ operator()(error_code ec, std::size_t)
             #endif
             }
         }
-        d_.invoke(ec);
+        {
+            auto wg = std::move(d.wg);
+            d_.invoke(ec);
+        }
     }
 }
 

--- a/include/boost/beast/websocket/impl/ping.ipp
+++ b/include/boost/beast/websocket/impl/ping.ipp
@@ -18,6 +18,7 @@
 #include <boost/asio/associated_allocator.hpp>
 #include <boost/asio/associated_executor.hpp>
 #include <boost/asio/coroutine.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/handler_continuation_hook.hpp>
 #include <boost/asio/handler_invoke_hook.hpp>
 #include <boost/asio/post.hpp>
@@ -41,6 +42,8 @@ class stream<NextLayer, deflateSupported>::ping_op
     struct state
     {
         stream<NextLayer, deflateSupported>& ws;
+        boost::asio::executor_work_guard<decltype(std::declval<
+            stream<NextLayer, deflateSupported>&>().get_executor())> wg;
         detail::frame_buffer fb;
 
         state(
@@ -49,6 +52,7 @@ class stream<NextLayer, deflateSupported>::ping_op
             detail::opcode op,
             ping_data const& payload)
             : ws(ws_)
+            , wg(ws.get_executor())
         {
             // Serialize the control frame
             ws.template write_ping<
@@ -172,7 +176,10 @@ operator()(error_code ec, std::size_t)
         d.ws.paused_close_.maybe_invoke() ||
             d.ws.paused_rd_.maybe_invoke() ||
             d.ws.paused_wr_.maybe_invoke();
-        d_.invoke(ec);
+        {
+            auto wg = std::move(d.wg);
+            d_.invoke(ec);
+        }
     }
 }
 

--- a/include/boost/beast/websocket/impl/teardown.ipp
+++ b/include/boost/beast/websocket/impl/teardown.ipp
@@ -15,6 +15,7 @@
 #include <boost/asio/associated_allocator.hpp>
 #include <boost/asio/associated_executor.hpp>
 #include <boost/asio/coroutine.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/handler_continuation_hook.hpp>
 #include <boost/asio/handler_invoke_hook.hpp>
 #include <boost/asio/post.hpp>
@@ -34,6 +35,8 @@ class teardown_tcp_op : public boost::asio::coroutine
 
     Handler h_;
     socket_type& s_;
+    boost::asio::executor_work_guard<decltype(std::declval<
+        socket_type&>().get_executor())> wg_;
     role_type role_;
     bool nb_;
 
@@ -48,6 +51,7 @@ public:
         role_type role)
         : h_(std::forward<DeducedHandler>(h))
         , s_(s)
+        , wg_(s_.get_executor())
         , role_(role)
     {
     }

--- a/test/beast/websocket/test.hpp
+++ b/test/beast/websocket/test.hpp
@@ -17,6 +17,7 @@
 #include <boost/beast/test/stream.hpp>
 #include <boost/beast/test/yield_to.hpp>
 #include <boost/beast/unit_test/suite.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/optional.hpp>
@@ -71,9 +72,8 @@ public:
 
         std::ostream& log_;
         boost::asio::io_context ioc_;
-        boost::optional<
-            boost::asio::executor_work_guard<
-                boost::asio::io_context::executor_type>> work_;
+        boost::asio::executor_work_guard<
+            boost::asio::io_context::executor_type> work_;
         static_buffer<buf_size> buffer_;
         test::stream ts_;
         std::thread t_;
@@ -115,7 +115,7 @@ public:
 
         ~echo_server()
         {
-            work_ = boost::none;
+            work_.reset();
             t_.join();
         }
 

--- a/test/extras/include/boost/beast/test/stream.hpp
+++ b/test/extras/include/boost/beast/test/stream.hpp
@@ -19,6 +19,7 @@
 #include <boost/beast/test/fail_counter.hpp>
 #include <boost/asio/async_result.hpp>
 #include <boost/asio/buffer.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/assert.hpp>
@@ -697,9 +698,8 @@ class stream::read_op_impl : public stream::read_op
         state& s_;
         Buffers b_;
         Handler h_;
-        boost::optional<
-            boost::asio::executor_work_guard<
-                boost::asio::io_context::executor_type>> work_;
+        boost::asio::executor_work_guard<
+            boost::asio::io_context::executor_type> work_;
 
     public:
         lambda(lambda&&) = default;
@@ -720,7 +720,7 @@ class stream::read_op_impl : public stream::read_op
             boost::asio::post(
                 s_.ioc.get_executor(),
                 std::move(*this));
-            work_ = boost::none;
+            work_.reset();
         }
 
         void

--- a/test/extras/include/boost/beast/test/yield_to.hpp
+++ b/test/extras/include/boost/beast/test/yield_to.hpp
@@ -10,9 +10,9 @@
 #ifndef BOOST_BEAST_TEST_YIELD_TO_HPP
 #define BOOST_BEAST_TEST_YIELD_TO_HPP
 
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/spawn.hpp>
-#include <boost/optional.hpp>
 #include <condition_variable>
 #include <functional>
 #include <mutex>
@@ -35,9 +35,8 @@ protected:
     boost::asio::io_context ioc_;
 
 private:
-    boost::optional<
-        boost::asio::executor_work_guard<
-            boost::asio::io_context::executor_type>> work_;
+    boost::asio::executor_work_guard<
+        boost::asio::io_context::executor_type> work_;
     std::vector<std::thread> threads_;
     std::mutex m_;
     std::condition_variable cv_;
@@ -60,7 +59,7 @@ public:
 
     ~enable_yield_to()
     {
-        work_ = boost::none;
+        work_.reset();
         for(auto& t : threads_)
             t.join();
     }


### PR DESCRIPTION
* Use executor_work_guard in composed operations
* Revert verb.ipp change which caused spurious warnings
* Fix race in advanced server examples
