### PR TITLE
Pointer-like observers for handler_ptr

### DIFF
--- a/include/boost/beast/core/handler_ptr.hpp
+++ b/include/boost/beast/core/handler_ptr.hpp
@@ -131,6 +131,18 @@ public:
         return *reinterpret_cast<Handler*>(&h_);
     }
 
+    /// Checks whether *this owns an object. Equivalent to get() != nullptr.
+    bool has_handler() const noexcept
+    {
+        return get() != nullptr;
+    }
+
+    /// Checks whether *this owns an object. Equivalent to get() != nullptr.
+    explicit operator bool() const noexcept
+    {
+        return has_handler();
+    }
+
     /** Returns a pointer to the owned object.
     */
     T*


### PR DESCRIPTION
Add observer functions to handler_ptr to enable convenient checking of whether the handler_ptr is active or not.