### PR TITLE
[Test] Remove few unused variables

### DIFF
--- a/test/beast/http/write.cpp
+++ b/test/beast/http/write.cpp
@@ -757,7 +757,6 @@ public:
             }
             {
                 auto m = m0;
-                error_code ec;
                 response_serializer<Body, fields> sr{m};
                 sr.split(true);
                 for(;;)
@@ -771,7 +770,6 @@ public:
             }
             {
                 auto m = m0;
-                error_code ec;
                 response_serializer<Body, fields> sr{m};
                 sr.split(true);
                 for(;;)
@@ -804,7 +802,6 @@ public:
             }
             {
                 auto m = m0;
-                error_code ec;
                 response_serializer<Body, fields> sr{m};
                 sr.split(true);
                 for(;;)
@@ -818,7 +815,6 @@ public:
             }
             {
                 auto m = m0;
-                error_code ec;
                 response_serializer<Body, fields> sr{m};
                 sr.split(true);
                 for(;;)
@@ -895,7 +891,7 @@ public:
     struct const_body_writer
     {
         struct value_type{};
-            
+
         struct writer
         {
             using const_buffers_type =
@@ -926,7 +922,7 @@ public:
     struct mutable_body_writer
     {
         struct value_type{};
-            
+
         struct writer
         {
             using const_buffers_type =

--- a/test/beast/websocket/read1.cpp
+++ b/test/beast/websocket/read1.cpp
@@ -394,7 +394,6 @@ public:
                 w.handshake(ws, "localhost", "/");
                 ws.next_layer().append(s);
                 static_buffer<1> b;
-                error_code ec;
                 try
                 {
                     w.read(ws, b);

--- a/test/beast/websocket/read2.cpp
+++ b/test/beast/websocket/read2.cpp
@@ -237,7 +237,7 @@ public:
                 ws.read(b, ec);
                 BEAST_EXPECT(ec);
             };
-        
+
         // chopped frame header
         {
             echo_server es{log};
@@ -249,7 +249,6 @@ public:
                 "\x81\x7e\x01");
             std::size_t count = 0;
             std::string const s(257, '*');
-            error_code ec;
             multi_buffer b;
             ws.async_read(b,
                 [&](error_code ec, std::size_t)
@@ -324,7 +323,6 @@ public:
             ws.next_layer().append(
                 "\x89\x02*");
             std::size_t count = 0;
-            error_code ec;
             multi_buffer b;
             ws.async_read(b,
                 [&](error_code ec, std::size_t)
@@ -354,7 +352,7 @@ public:
             {
                 void operator()(error_code, std::size_t) {}
             };
-        
+
             char buf[32];
             stream<test::stream> ws{ioc_};
             stream<test::stream>::read_some_op<
@@ -371,7 +369,7 @@ public:
             {
                 void operator()(error_code, std::size_t) {}
             };
-        
+
             multi_buffer b;
             stream<test::stream> ws{ioc_};
             stream<test::stream>::read_op<

--- a/test/beast/websocket/write.cpp
+++ b/test/beast/websocket/write.cpp
@@ -452,7 +452,6 @@ public:
         doFailLoop([&](test::fail_count& fc)
         {
             echo_server es{log};
-            error_code ec;
             boost::asio::io_context ioc;
             stream<test::stream> ws{ioc, fc};
             ws.next_layer().connect(es.stream());
@@ -485,7 +484,6 @@ public:
         doFailLoop([&](test::fail_count& fc)
         {
             echo_server es{log};
-            error_code ec;
             boost::asio::io_context ioc;
             stream<test::stream> ws{ioc, fc};
             ws.next_layer().connect(es.stream());
@@ -622,7 +620,7 @@ public:
         {
             void operator()(error_code) {}
         };
-        
+
         char buf[32];
         stream<test::stream> ws{ioc_};
         stream<test::stream>::write_some_op<


### PR DESCRIPTION
Problem:
- There are a few unused instances of `std::error_code` in some tests.

Solution:
- Remove the unused instances to silence the unused variable warnings I am getting during builds.
- Fix some extra whitespace issues in those files I touched with leading whitespace.