### PR TITLE
Most members of std::allocate are deprecated in C++17

### DIFF
--- a/include/boost/beast/experimental/core/impl/flat_stream.ipp
+++ b/include/boost/beast/experimental/core/impl/flat_stream.ipp
@@ -28,8 +28,13 @@ class flat_stream<NextLayer>::write_op
     : public boost::asio::coroutine
 {
     using alloc_type = typename 
+#if defined(BOOST_NO_CXX11_ALLOCATOR)
         boost::asio::associated_allocator_t<Handler>::template
             rebind<char>::other;
+#else
+        std::allocator_traits<boost::asio::associated_allocator_t<Handler>>
+            ::template rebind_alloc<char>;
+#endif
 
     struct deleter
     {

--- a/include/boost/beast/experimental/http/impl/icy_stream.ipp
+++ b/include/boost/beast/experimental/http/impl/icy_stream.ipp
@@ -197,8 +197,13 @@ class icy_stream<NextLayer>::read_op
     : public boost::asio::coroutine
 {
     using alloc_type = typename 
+#if defined(BOOST_NO_CXX11_ALLOCATOR)
         boost::asio::associated_allocator_t<Handler>::template
             rebind<char>::other;
+#else
+        std::allocator_traits<boost::asio::associated_allocator_t<Handler>>
+            ::template rebind_alloc<char>;
+#endif
 
     struct data
     {


### PR DESCRIPTION
Replace them by their cousins from std::allocator_traits. Without that, heaps of deprecation warnings will fall onto humble users when compiling with MSVC 15 in C++17 mode.

Signed-off-by: Daniela Engert <dani@ngrt.de>