### PR TITLE
Fix parse_dec algorithm

### DIFF
--- a/include/boost/beast/http/detail/basic_parser.hpp
+++ b/include/boost/beast/http/detail/basic_parser.hpp
@@ -299,25 +299,28 @@ protected:
         return p;
     }
 
-    template<class Iter, class Unsigned>
+    template<class Iter, class T>
     static
-    bool
-    parse_dec(Iter it, Iter last, Unsigned& v)
+    typename std::enable_if<
+        std::numeric_limits<T>::is_integer
+        && !std::numeric_limits<T>::is_signed, bool>::type
+    parse_dec(Iter it, Iter last, T& v)
     {
-        if(! is_digit(*it))
+        if(it == last)
             return false;
-        v = *it - '0';
-        for(;;)
-        {
-            if(! is_digit(*++it))
-                break;
-            auto const d = *it - '0';
-            if(v > ((std::numeric_limits<
-                    Unsigned>::max)() - 10) / 10)
+        T tmp = 0;
+        do {
+            if((! is_digit(*it)) ||
+                tmp > (std::numeric_limits<T>::max)() / 10)
                 return false;
-            v = 10 * v + d;
-        }
-        return it == last;
+            tmp *= 10;
+            T const d = *it - '0';
+            if((std::numeric_limits<T>::max)() - tmp < d)
+                return false;
+            tmp += d;
+        } while(++it != last);
+        v = tmp;
+        return true;
     }
 
     template<class Iter, class Unsigned>


### PR DESCRIPTION
Current `parse_dec` implementation is wrong in general. Iterating over `[it, last)` range implies that you shouldn't dereference an iterator pointing to `last`. However parsing actually stops when `*last` is not a digit. Also function unable to parse a number close to `numeric_limis<T>::max()` (for example 6553x for `unsigned short` argument).