### PR TITLE
Fix Contributing Link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Branch      | Linux/OSX | Windows | Coverage | Documentation | Matrix
 - [Usage](#usage)
 - [License](#license)
 - [Contact](#contact)
-- [Contributing](#Contributing)
+- [Contributing](#contributing-we-need-your-help)
 
 ## Introduction
 


### PR DESCRIPTION
All of your contributors missed this one apparently. :stuck_out_tongue: 