### PR TITLE
Replace boost string_view with std string_view if macro is set.

### DIFF
--- a/include/boost/beast/core/string.hpp
+++ b/include/boost/beast/core/string.hpp
@@ -12,19 +12,35 @@
 
 #include <boost/beast/core/detail/config.hpp>
 #include <boost/version.hpp>
+
+#if defined(BOOST_BEAST_USE_STD_STRING_VIEW)
+#include <string_view>
+#else
 #include <boost/utility/string_view.hpp>
+#endif
+
 #include <algorithm>
 
 namespace boost {
 namespace beast {
 
-/// The type of string view used by the library
-using string_view = boost::string_view;
+#if defined(BOOST_BEAST_USE_STD_STRING_VIEW)
+  /// The type of string view used by the library
+  using string_view = std::string_view;
 
-/// The type of basic string view used by the library
-template<class CharT, class Traits>
-using basic_string_view =
-    boost::basic_string_view<CharT, Traits>;
+  /// The type of basic string view used by the library
+  template<class CharT, class Traits>
+  using basic_string_view =
+      std::basic_string_view<CharT, Traits>;
+#else
+  /// The type of string view used by the library
+  using string_view = boost::string_view;
+
+  /// The type of basic string view used by the library
+  template<class CharT, class Traits>
+  using basic_string_view =
+      boost::basic_string_view<CharT, Traits>;
+#endif
 
 namespace detail {
 

--- a/include/boost/beast/http/detail/basic_parsed_list.hpp
+++ b/include/boost/beast/http/detail/basic_parsed_list.hpp
@@ -111,7 +111,7 @@ public:
             basic_parsed_list const& list, bool at_end)
             : list_(&list)
             , it_(at_end ? nullptr :
-                list.s_.begin())
+                list.s_.data())
         {
             if(! at_end)
                 increment();

--- a/include/boost/beast/http/detail/rfc7230.hpp
+++ b/include/boost/beast/http/detail/rfc7230.hpp
@@ -429,11 +429,11 @@ struct opt_token_list_policy
         char const*& it, string_view s) const
     {
         v = {};
-        auto need_comma = it != s.begin();
+        auto need_comma = it != s.data();
         for(;;)
         {
-            detail::skip_ows(it, s.end());
-            if(it == s.end())
+            detail::skip_ows(it, (s.data() + s.size()));
+            if(it == (s.data() + s.size()))
             {
                 it = nullptr;
                 return true;
@@ -447,12 +447,12 @@ struct opt_token_list_policy
                 for(;;)
                 {
                     ++it;
-                    if(it == s.end())
+                    if(it == (s.data() + s.size()))
                         break;
                     if(! detail::is_token_char(*it))
                         break;
                 }
-                v = string_view{&*p0,
+                v = string_view{p0,
                     static_cast<std::size_t>(it - p0)};
                 return true;
             }

--- a/include/boost/beast/http/impl/field.ipp
+++ b/include/boost/beast/http/impl/field.ipp
@@ -51,7 +51,7 @@ struct field_table
         {
             auto p1 = lhs.data();
             auto p2 = rhs.data();
-            auto pend = lhs.end();
+            auto pend = p1 + lhs.size();
             char a, b;
             while(p1 < pend)
             {

--- a/include/boost/beast/http/impl/verb.ipp
+++ b/include/boost/beast/http/impl/verb.ipp
@@ -127,7 +127,7 @@ string_to_verb(string_view v)
                 ++s;
                 ++p;
                 if(! *s)
-                    return p == sv.end();
+                    return p == (sv.data() + sv.size());
             }
         };
     auto c = v[0];


### PR DESCRIPTION
Closes #1133 

The solution uses a naive approach of expecting the user knows whether compiler implements std::string_view (not using/defining any compatibility check macros)  and also ignoring the <experimental/string_view> version.