### PR TITLE
Change filler value for temp buffer to pass valid() check

### DIFF
--- a/include/boost/beast/websocket/detail/utf8_checker.hpp
+++ b/include/boost/beast/websocket/detail/utf8_checker.hpp
@@ -153,13 +153,13 @@ write(std::uint8_t const* in, std::size_t size)
                 BOOST_ASSERT(false);
                 BOOST_FALLTHROUGH;
             case 1:
-                cp_[1] = 0x81;
+                cp_[1] = 0xA0;
                 BOOST_FALLTHROUGH;
             case 2:
-                cp_[2] = 0x81;
+                cp_[2] = 0xA0;
                 BOOST_FALLTHROUGH;
             case 3:
-                cp_[3] = 0x81;
+                cp_[3] = 0xA0;
                 break;
             }
             std::uint8_t const* p = cp_;

--- a/include/boost/beast/websocket/detail/utf8_checker.hpp
+++ b/include/boost/beast/websocket/detail/utf8_checker.hpp
@@ -112,7 +112,7 @@ write(std::uint8_t const* in, std::size_t size)
             if((p[0] & 0xe0) == 0xc0)
             {
                 if( (p[1] & 0xc0) != 0x80 ||
-                    (p[0] & 0xfe) == 0xc0)  // overlong
+                    (p[0] & 0x1e) == 0)  // overlong
                     return false;
                 p += 2;
                 return true;
@@ -121,8 +121,8 @@ write(std::uint8_t const* in, std::size_t size)
             {
                 if(    (p[1] & 0xc0) != 0x80
                     || (p[2] & 0xc0) != 0x80
-                    || (p[0] == 0xe0 && (p[1] & 0xe0) == 0x80) // overlong
-                    || (p[0] == 0xed && (p[1] & 0xe0) == 0xa0) // surrogate
+                    || (p[0] == 0xe0 && (p[1] & 0x20) == 0) // overlong
+                    || (p[0] == 0xed && (p[1] & 0x3C) >= 0x3C) // surrogate
                     //|| (p[0] == 0xef && p[1] == 0xbf && (p[2] & 0xfe) == 0xbe) // U+FFFE or U+FFFF
                     )
                     return false;
@@ -134,7 +134,7 @@ write(std::uint8_t const* in, std::size_t size)
                 if(    (p[1] & 0xc0) != 0x80
                     || (p[2] & 0xc0) != 0x80
                     || (p[3] & 0xc0) != 0x80
-                    || (p[0] == 0xf0 && (p[1] & 0xf0) == 0x80) // overlong
+                    || (p[0] == 0xf0 && (p[1] & 0x30) == 0) // overlong
                     || (p[0] == 0xf4 && p[1] > 0x8f) || p[0] > 0xf4 // > U+10FFFF
                     )
                     return false;
@@ -153,7 +153,7 @@ write(std::uint8_t const* in, std::size_t size)
                 BOOST_ASSERT(false);
                 BOOST_FALLTHROUGH;
             case 1:
-                cp_[1] = 0xA0;
+                cp_[1] =((cp_[0] & 0xF8) == 0xF0)? 0x81 : 0xA0;
                 BOOST_FALLTHROUGH;
             case 2:
                 cp_[2] = 0xA0;

--- a/include/boost/beast/websocket/detail/utf8_checker.hpp
+++ b/include/boost/beast/websocket/detail/utf8_checker.hpp
@@ -122,7 +122,7 @@ write(std::uint8_t const* in, std::size_t size)
                 if(    (p[1] & 0xc0) != 0x80
                     || (p[2] & 0xc0) != 0x80
                     || (p[0] == 0xe0 && (p[1] & 0x20) == 0) // overlong
-                    || (p[0] == 0xed && (p[1] & 0x3C) >= 0x3C) // surrogate
+                    || (p[0] == 0xed && (p[1] & 0x20) == 0x20) // surrogate
                     //|| (p[0] == 0xef && p[1] == 0xbf && (p[2] & 0xfe) == 0xbe) // U+FFFE or U+FFFF
                     )
                     return false;
@@ -131,7 +131,8 @@ write(std::uint8_t const* in, std::size_t size)
             }
             if((p[0] & 0xf8) == 0xf0)
             {
-                if(    (p[1] & 0xc0) != 0x80
+                if(    (p[0] & 0x07) >= 0x05 // invalid F5...FF characters 
+                    || (p[1] & 0xc0) != 0x80
                     || (p[2] & 0xc0) != 0x80
                     || (p[3] & 0xc0) != 0x80
                     || (p[0] == 0xf0 && (p[1] & 0x30) == 0) // overlong
@@ -146,24 +147,74 @@ write(std::uint8_t const* in, std::size_t size)
     auto const fail_fast =
         [&]()
         {
-            auto const n = p_ - cp_;
-            switch(n)
+            if(cp_[0] < 128)
             {
-            default:
-                BOOST_ASSERT(false);
-                BOOST_FALLTHROUGH;
-            case 1:
-                cp_[1] =((cp_[0] & 0xF8) == 0xF0)? 0x81 : 0xA0;
-                BOOST_FALLTHROUGH;
-            case 2:
-                cp_[2] = 0xA0;
-                BOOST_FALLTHROUGH;
-            case 3:
-                cp_[3] = 0xA0;
-                break;
+                return false;
             }
-            std::uint8_t const* p = cp_;
-            return ! valid(p);
+
+            const auto& p = cp_; // alias, only to keep this code similar to valid() above
+            const auto known_only = p_ - cp_;
+            if (known_only == 1) 
+            {
+                if((p[0] & 0xe0) == 0xc0)
+                {
+                    return ((p[0] & 0x1e) == 0);  // overlong
+                }
+                if((p[0] & 0xf0) == 0xe0)
+                {
+                    return false;
+                }
+                if((p[0] & 0xf8) == 0xf0)
+                {
+                    return ((p[0] & 0x07) >= 0x05);  // invalid F5...FF characters
+                }
+            }
+            else if (known_only == 2)
+            {
+                if((p[0] & 0xe0) == 0xc0)
+                {
+                    return ((p[1] & 0xc0) != 0x80 ||
+                            (p[0] & 0x1e) == 0);  // overlong
+                }
+                if((p[0] & 0xf0) == 0xe0)
+                {
+                    return (  (p[1] & 0xc0) != 0x80
+                           || (p[0] == 0xe0 && (p[1] & 0x20) == 0) // overlong
+                           || (p[0] == 0xed && (p[1] & 0x20) == 0x20)); // surrogate
+                }
+                if((p[0] & 0xf8) == 0xf0)
+                {
+                    return (  (p[0] & 0x07) >= 0x05 // invalid F5...FF characters 
+                           || (p[1] & 0xc0) != 0x80
+                           || (p[0] == 0xf0 && (p[1] & 0x30) == 0) // overlong
+                           || (p[0] == 0xf4 && p[1] > 0x8f) || p[0] > 0xf4); // > U+10FFFF
+                }
+            }
+            else if (known_only == 3)
+            {
+                if((p[0] & 0xe0) == 0xc0)
+                {
+                    return (  (p[1] & 0xc0) != 0x80
+                           || (p[0] & 0x1e) == 0);  // overlong
+                }
+                if((p[0] & 0xf0) == 0xe0)
+                {
+                    return (  (p[1] & 0xc0) != 0x80
+                           || (p[2] & 0xc0) != 0x80
+                           || (p[0] == 0xe0 && (p[1] & 0x20) == 0) // overlong
+                           || (p[0] == 0xed && (p[1] & 0x20) == 0x20)); // surrogate
+                           //|| (p[0] == 0xef && p[1] == 0xbf && (p[2] & 0xfe) == 0xbe) // U+FFFE or U+FFFF
+                }
+                if((p[0] & 0xf8) == 0xf0)
+                {
+                    return (  (p[0] & 0x07) >= 0x05 // invalid F5...FF characters 
+                           || (p[1] & 0xc0) != 0x80
+                           || (p[2] & 0xc0) != 0x80
+                           || (p[0] == 0xf0 && (p[1] & 0x30) == 0) // overlong
+                           || (p[0] == 0xf4 && p[1] > 0x8f) || p[0] > 0xf4); // > U+10FFFF
+                }
+            }
+            return true;
         };
     auto const needed =
         [](std::uint8_t const v)

--- a/test/beast/websocket/utf8_checker.cpp
+++ b/test/beast/websocket/utf8_checker.cpp
@@ -68,13 +68,8 @@ public:
         {
             // fail fast
             utf8_checker u;
-            if (c == 240)
-                BEAST_EXPECT(! u.write(&c, 1));
-            else
-            {
-                BEAST_EXPECT(u.write(&c, 1));
-                BEAST_EXPECT(! u.finish());
-            }
+            BEAST_EXPECT(u.write(&c, 1));
+            BEAST_EXPECT(! u.finish());
         }
 
         // invalid lead bytes
@@ -310,13 +305,8 @@ public:
                         BEAST_EXPECT(u.write(buf, 4));
                         BEAST_EXPECT(u.finish());
                         // Segmented sequence
-                        if (i == 240)
-                            BEAST_EXPECT(! u.write(buf, 1));
-                        else
-                        {
-                            BEAST_EXPECT(u.write(buf, 1));
-                            BEAST_EXPECT(u.write(&buf[1], 3));
-                        }
+                        BEAST_EXPECT(u.write(buf, 1));
+                        BEAST_EXPECT(u.write(&buf[1], 3));
                         u.reset();
                         // Segmented sequence
                         BEAST_EXPECT(u.write(buf, 2));
@@ -423,13 +413,9 @@ public:
             }
 
             // Segmented sequence second byte invalid
-            if (i == 240)
-                BEAST_EXPECT(! u.write(buf, 1));
-            else
-            {
-                BEAST_EXPECT(u.write(buf, 1));
-                BEAST_EXPECT(! u.write(&buf[1], 1));
-            }
+            BEAST_EXPECT(u.write(buf, 1));
+            BEAST_EXPECT(! u.write(&buf[1], 1));
+
             u.reset();
         }
 

--- a/test/beast/websocket/utf8_checker.cpp
+++ b/test/beast/websocket/utf8_checker.cpp
@@ -58,15 +58,9 @@ public:
         // three byte sequences
         for(unsigned char c = 224; c < 240; ++c)
         {
-            // fail fast
             utf8_checker u;
-            if (c == 224)
-                BEAST_EXPECT(! u.write(&c, 1));
-            else
-            {
-                BEAST_EXPECT(u.write(&c, 1));
-                BEAST_EXPECT(! u.finish());
-            }
+            BEAST_EXPECT(u.write(&c, 1));
+            BEAST_EXPECT(! u.finish());
         }
 
         // four byte sequences
@@ -167,8 +161,11 @@ public:
                     BEAST_EXPECT(u.write(buf, 3));
                     BEAST_EXPECT(u.finish());
                     // Segmented sequence
-                    if (i == 224)
-                        BEAST_EXPECT(! u.write(buf, 1));
+                    if (i == 224) 
+                    {
+                        BEAST_EXPECT(u.write(buf, 1));
+                        BEAST_EXPECT(!u.finish());
+                    }
                     else
                     {
                         BEAST_EXPECT(u.write(buf, 1));
@@ -270,8 +267,10 @@ public:
             }
 
             // Segmented sequence second byte invalid
-            if (i == 224)
-                BEAST_EXPECT(! u.write(buf, 1));
+            if (i == 224) {
+                BEAST_EXPECT(u.write(buf, 1));
+                BEAST_EXPECT(!u.finish());
+            }
             else
             {
                 BEAST_EXPECT(u.write(buf, 1));
@@ -534,6 +533,53 @@ public:
         }
     }
 
+    void 
+    AutodeskTests() 
+    {
+        std::vector<std::vector<std::uint8_t>> const data{
+            { 's','t','a','r','t', 0xE0 },
+            { 0xA6, 0x81, 'e','n','d' } };
+        utf8_checker u;
+        for(auto const& s : data)
+        {
+            std::size_t n = s.size();
+            buffers_suffix<boost::asio::const_buffer> cb{boost::asio::const_buffer(s.data(), n)};
+            multi_buffer b;
+            while(n)
+            {
+                auto const amount = (std::min)(n, std::size_t(3)/*size*/);
+                b.commit(boost::asio::buffer_copy(b.prepare(amount), cb));
+                cb.consume(amount);
+                n -= amount;
+            }
+            BEAST_EXPECT(u.write(b.data()));
+        }
+        BEAST_EXPECT(u.finish());
+    }
+
+    void 
+    AutobahnTest(std::vector<std::vector<std::uint8_t>>&& data, std::vector<bool> result) 
+    {
+        BEAST_EXPECT(data.size() == result.size());
+        utf8_checker u;
+        for(std::size_t i = 0; i < data.size(); ++i)
+        {
+            auto const& s = data[i];
+
+            std::size_t n = s.size();
+            buffers_suffix<boost::asio::const_buffer> cb{boost::asio::const_buffer(s.data(), n)};
+            multi_buffer b;
+            while(n)
+            {
+                auto const amount = (std::min)(n, std::size_t(3)/*size*/);
+                b.commit(boost::asio::buffer_copy(b.prepare(amount), cb));
+                cb.consume(amount);
+                n -= amount;
+            }
+            BEAST_EXPECT(u.write(b.data()) == result[i]);
+        }
+    }
+
     void
     run() override
     {
@@ -543,6 +589,17 @@ public:
         testFourByteSequence();
         testWithStreamBuffer();
         testBranches();
+        AutodeskTests();
+        // 6.4.2
+        t.AutobahnTest(std::vector<std::vector<std::uint8_t>>{
+            { 0xCE, 0xBA, 0xE1, 0xBD, 0xB9, 0xCF, 0x83, 0xCE, 0xBC, 0xCE, 0xB5, 0xF4 },
+            { 0x90 }, { 0x80, 0x80, 0x65, 0x64, 0x69, 0x74, 0x65, 0x64 } },
+            { true, false, false});
+        // 6.4.4
+        t.AutobahnTest(std::vector<std::vector<std::uint8_t>>{
+            { 0xCE, 0xBA, 0xE1, 0xBD, 0xB9, 0xCF, 0x83, 0xCE, 0xBC, 0xCE, 0xB5, 0xF4 },
+            { 0x90 } },
+            { true, false });
     }
 };
 

--- a/test/beast/websocket/utf8_checker.cpp
+++ b/test/beast/websocket/utf8_checker.cpp
@@ -577,12 +577,12 @@ public:
         testBranches();
         AutodeskTests();
         // 6.4.2
-        t.AutobahnTest(std::vector<std::vector<std::uint8_t>>{
+        AutobahnTest(std::vector<std::vector<std::uint8_t>>{
             { 0xCE, 0xBA, 0xE1, 0xBD, 0xB9, 0xCF, 0x83, 0xCE, 0xBC, 0xCE, 0xB5, 0xF4 },
             { 0x90 }, { 0x80, 0x80, 0x65, 0x64, 0x69, 0x74, 0x65, 0x64 } },
             { true, false, false});
         // 6.4.4
-        t.AutobahnTest(std::vector<std::vector<std::uint8_t>>{
+        AutobahnTest(std::vector<std::vector<std::uint8_t>>{
             { 0xCE, 0xBA, 0xE1, 0xBD, 0xB9, 0xCF, 0x83, 0xCE, 0xBC, 0xCE, 0xB5, 0xF4 },
             { 0x90 } },
             { true, false });


### PR DESCRIPTION
This is fix for issue https://github.com/boostorg/beast/issues/1245.

The problem happened when read_some buffer ends in the middle of 3-byte symbol (e.g. Bengali). In my example, the first `read_some()` call read 1532 characters, which included the 1st character of the 3-byte sequence, `0xE0`, as the last byte read.  Then, `fail_fast()` was called and filled the last 3 bytes of  `utf8_checker_t::cp_` with `0x81` values, then called `valid()`. Since `{0xE0, 0x81, 0x81, 0x81}` sequence doesn't pass the _overlong_ check for 3-byte values
```
(p[0] == 0xe0 && (p[1] & 0xe0) == 0x80) // overlong
```
`valid()` returned false and an error was thrown.

Changing the filler values from `0x81` to `0xA0` allows all checks to pass, for 2-, 3-, and probably 4-byte code points (I haven't tested the 4-byte ones, but believe they'll work too).