### PR TITLE
Remove redundant static_assert

### DIFF
--- a/include/boost/beast/core/handler_ptr.hpp
+++ b/include/boost/beast/core/handler_ptr.hpp
@@ -58,9 +58,6 @@ class handler_ptr
     void clear();
 
 public:
-    static_assert(std::is_nothrow_destructible<T>::value,
-        "T must be nothrow destructible");
-
     /// The type of element stored
     using element_type = T;
 


### PR DESCRIPTION
The standard library doesn't handle types that throw from destructors, so the check is redundant.