### PR TITLE
Enable explicit instantiation of websocket::stream

### DIFF
--- a/include/boost/beast/websocket/detail/stream_base.hpp
+++ b/include/boost/beast/websocket/detail/stream_base.hpp
@@ -10,6 +10,9 @@
 #ifndef BOOST_BEAST_WEBSOCKET_STREAM_BASE_HPP
 #define BOOST_BEAST_WEBSOCKET_STREAM_BASE_HPP
 
+#include <boost/beast/http/empty_body.hpp>
+#include <boost/beast/http/message.hpp>
+#include <boost/beast/http/string_body.hpp>
 #include <boost/beast/websocket/option.hpp>
 #include <boost/beast/websocket/detail/pmd_extension.hpp>
 #include <boost/beast/zlib/deflate_stream.hpp>
@@ -17,6 +20,7 @@
 #include <boost/beast/core/buffers_suffix.hpp>
 #include <boost/beast/core/error.hpp>
 #include <boost/beast/core/detail/chacha.hpp>
+#include <boost/beast/core/detail/clamp.hpp>
 #include <boost/beast/core/detail/integer_sequence.hpp>
 #include <boost/align/aligned_alloc.hpp>
 #include <boost/asio/buffer.hpp>
@@ -354,6 +358,165 @@ struct stream_base : stream_prng
 
     void
     do_context_takeover_read(role_type role);
+
+    template<class Body, class Allocator>
+    void
+    build_response_pmd(
+        http::response<http::string_body>& res,
+        http::request<Body,
+            http::basic_fields<Allocator>> const& req)
+    {
+        detail::pmd_offer offer;
+        detail::pmd_offer unused;
+        detail::pmd_read(offer, req);
+        detail::pmd_negotiate(res, unused, offer, pmd_opts_);
+    }
+
+    void
+    on_response_pmd(http::response<http::string_body> const& res)
+    {
+        detail::pmd_offer offer;
+        detail::pmd_read(offer, res);
+        // VFALCO see if offer satisfies pmd_config_,
+        //        return an error if not.
+        pmd_config_ = offer; // overwrite for now
+    }
+
+    template<class Allocator>
+    void
+    do_pmd_config(
+        http::basic_fields<Allocator> const& h)
+    {
+        detail::pmd_read(pmd_config_, h);
+    }
+
+    void
+    set_option_pmd(permessage_deflate const& o)
+    {
+        if( o.server_max_window_bits > 15 ||
+            o.server_max_window_bits < 9)
+            BOOST_THROW_EXCEPTION(std::invalid_argument{
+                "invalid server_max_window_bits"});
+        if( o.client_max_window_bits > 15 ||
+            o.client_max_window_bits < 9)
+            BOOST_THROW_EXCEPTION(std::invalid_argument{
+                "invalid client_max_window_bits"});
+        if( o.compLevel < 0 ||
+            o.compLevel > 9)
+            BOOST_THROW_EXCEPTION(std::invalid_argument{
+                "invalid compLevel"});
+        if( o.memLevel < 1 ||
+            o.memLevel > 9)
+            BOOST_THROW_EXCEPTION(std::invalid_argument{
+                "invalid memLevel"});
+        pmd_opts_ = o;
+    }
+
+    void
+    get_option_pmd(permessage_deflate& o)
+    {
+        o = pmd_opts_;
+    }
+
+
+    void
+    build_request_pmd(http::request<http::empty_body>& req)
+    {
+        if(pmd_opts_.client_enable)
+        {
+            detail::pmd_offer config;
+            config.accept = true;
+            config.server_max_window_bits =
+                pmd_opts_.server_max_window_bits;
+            config.client_max_window_bits =
+                pmd_opts_.client_max_window_bits;
+            config.server_no_context_takeover =
+                pmd_opts_.server_no_context_takeover;
+            config.client_no_context_takeover =
+                pmd_opts_.client_no_context_takeover;
+            detail::pmd_write(req, config);
+        }
+    }
+
+    void
+    open_pmd(role_type role)
+    {
+        if(((role == role_type::client &&
+                pmd_opts_.client_enable) ||
+            (role == role_type::server &&
+                pmd_opts_.server_enable)) &&
+            pmd_config_.accept)
+        {
+            detail::pmd_normalize(pmd_config_);
+            pmd_.reset(new typename
+                detail::stream_base<deflateSupported>::pmd_type);
+            if(role == role_type::client)
+            {
+                pmd_->zi.reset(
+                    pmd_config_.server_max_window_bits);
+                pmd_->zo.reset(
+                    pmd_opts_.compLevel,
+                    pmd_config_.client_max_window_bits,
+                    pmd_opts_.memLevel,
+                    zlib::Strategy::normal);
+            }
+            else
+            {
+                pmd_->zi.reset(
+                    pmd_config_.client_max_window_bits);
+                pmd_->zo.reset(
+                    pmd_opts_.compLevel,
+                    pmd_config_.server_max_window_bits,
+                    pmd_opts_.memLevel,
+                    zlib::Strategy::normal);
+            }
+        }
+    }
+
+    void close_pmd()
+    {
+        pmd_.reset();
+    }
+
+    bool pmd_enabled() const
+    {
+        return pmd_ != nullptr;
+    }
+
+    std::size_t
+    read_size_hint_pmd(
+        std::size_t initial_size,
+        bool rd_done,
+        std::uint64_t rd_remain,
+        detail::frame_header const& rd_fh) const
+    {
+        using beast::detail::clamp;
+        std::size_t result;
+        BOOST_ASSERT(initial_size > 0);
+        if(! pmd_ || (! rd_done && ! pmd_->rd_set))
+        {
+            // current message is uncompressed
+
+            if(rd_done)
+            {
+                // first message frame
+                result = initial_size;
+                goto done;
+            }
+            else if(rd_fh.fin)
+            {
+                // last message frame
+                BOOST_ASSERT(rd_remain > 0);
+                result = clamp(rd_remain);
+                goto done;
+            }
+        }
+        result = (std::max)(
+            initial_size, clamp(rd_remain));
+    done:
+        BOOST_ASSERT(result != 0);
+        return result;
+    }
 };
 
 template<>
@@ -402,6 +565,97 @@ struct stream_base<false> : stream_prng
     void
     do_context_takeover_read(role_type)
     {
+    }
+
+    template<class Body, class Allocator>
+    void
+    build_response_pmd(
+        http::response<http::string_body>&,
+        http::request<Body,
+            http::basic_fields<Allocator>> const&)
+    {
+    }
+
+    void
+    on_response_pmd(
+        http::response<http::string_body> const&)
+    {
+    }
+
+    template<class Allocator>
+    void
+    do_pmd_config(http::basic_fields<Allocator> const&)
+    {
+    }
+
+    void
+    set_option_pmd(permessage_deflate const& o)
+    {
+        if(o.client_enable || o.server_enable)
+        {
+            // Can't enable permessage-deflate
+            // when deflateSupported == false.
+            //
+            BOOST_THROW_EXCEPTION(std::invalid_argument{
+                "deflateSupported == false"});
+        }
+    }
+
+    void
+    get_option_pmd(permessage_deflate& o)
+    {
+        o = {};
+        o.client_enable = false;
+        o.server_enable = false;
+    }
+
+    void
+    build_request_pmd(http::request<http::empty_body>& req)
+    {
+    }
+
+    void open_pmd(role_type)
+    {
+    }
+
+    void close_pmd()
+    {
+    }
+
+    bool pmd_enabled() const
+    {
+        return false;
+    }
+
+    std::size_t
+    read_size_hint_pmd(
+        std::size_t initial_size,
+        bool rd_done,
+        std::uint64_t rd_remain,
+        detail::frame_header const& rd_fh) const
+    {
+        using beast::detail::clamp;
+        std::size_t result;
+        BOOST_ASSERT(initial_size > 0);
+        // compression is not supported
+        if(rd_done)
+        {
+            // first message frame
+            result = initial_size;
+        }
+        else if(rd_fh.fin)
+        {
+            // last message frame
+            BOOST_ASSERT(rd_remain > 0);
+            result = clamp(rd_remain);
+        }
+        else
+        {
+            result = (std::max)(
+                initial_size, clamp(rd_remain));
+        }
+        BOOST_ASSERT(result != 0);
+        return result;
     }
 };
 

--- a/include/boost/beast/websocket/impl/accept.ipp
+++ b/include/boost/beast/websocket/impl/accept.ipp
@@ -139,7 +139,7 @@ operator()(
             ec = d.result;
         if(! ec)
         {
-            d.ws.do_pmd_config(d.res, is_deflate_supported{});
+            d.ws.do_pmd_config(d.res);
             d.ws.open(role_type::server);
         }
         {
@@ -763,7 +763,7 @@ do_accept(
         //             teardown if Connection: close.
         return;
     }
-    do_pmd_config(res, is_deflate_supported{});
+    this->do_pmd_config(res);
     open(role_type::server);
 }
 

--- a/include/boost/beast/websocket/impl/handshake.ipp
+++ b/include/boost/beast/websocket/impl/handshake.ipp
@@ -135,7 +135,7 @@ operator()(error_code ec, std::size_t)
     BOOST_ASIO_CORO_REENTER(*this)
     {
         // Send HTTP Upgrade
-        d.ws.do_pmd_config(d.req, is_deflate_supported{});
+        d.ws.do_pmd_config(d.req);
         BOOST_ASIO_CORO_YIELD
         http::async_write(d.ws.stream_,
             d.req, std::move(*this));
@@ -407,7 +407,7 @@ do_handshake(
     {
         auto const req = build_request(
             key, host, target, decorator);
-        do_pmd_config(req, is_deflate_supported{});
+        this->do_pmd_config(req);
         http::write(stream_, req, ec);
     }
     if(ec)

--- a/test/beast/websocket/CMakeLists.txt
+++ b/test/beast/websocket/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable (tests-beast-websocket
     rfc6455.cpp
     role.cpp
     stream.cpp
+    stream_explicit.cpp
     stream_fwd.cpp
     teardown.cpp
     utf8_checker.cpp

--- a/test/beast/websocket/Jamfile
+++ b/test/beast/websocket/Jamfile
@@ -20,6 +20,7 @@ local SOURCES =
     rfc6455.cpp
     role.cpp
     stream.cpp
+    stream_explicit.cpp
     stream_fwd.cpp
     teardown.cpp
     utf8_checker.cpp

--- a/test/beast/websocket/stream_explicit.cpp
+++ b/test/beast/websocket/stream_explicit.cpp
@@ -1,0 +1,15 @@
+//
+// Copyright (w) 2016-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+// Test that header file is self-contained.
+#include <boost/beast/websocket/stream.hpp>
+#include <boost/asio/ip/tcp.hpp>
+
+template class boost::beast::websocket::stream<boost::asio::ip::tcp::socket, false>;
+template class boost::beast::websocket::stream<boost::asio::ip::tcp::socket, true>;


### PR DESCRIPTION
This enables users to improve compilation performance by explicitly instantiating the stream template in another TU.
