### PR TITLE
Fix test::stream async ops for custom result types

### DIFF
--- a/include/boost/beast/_experimental/http/impl/icy_stream.ipp
+++ b/include/boost/beast/_experimental/http/impl/icy_stream.ipp
@@ -63,7 +63,7 @@ public:
     {
         return b_.size();
     }
-    
+
     std::size_t
     max_size() const
     {
@@ -196,7 +196,7 @@ template<class MutableBufferSequence, class Handler>
 class icy_stream<NextLayer>::read_op
     : public boost::asio::coroutine
 {
-    using alloc_type = typename 
+    using alloc_type = typename
 #if defined(BOOST_NO_CXX11_ALLOCATOR)
         boost::asio::associated_allocator_t<Handler>::template
             rebind<char>::other;
@@ -290,7 +290,7 @@ operator()(
         {
             BOOST_ASIO_CORO_YIELD
             boost::asio::post(d.s.get_executor(),
-                bind_handler(std::move(*this), ec, 0));
+                beast::bind_handler(std::move(*this), ec, 0));
             goto upcall;
         }
         if(! d.s.detect_)

--- a/include/boost/beast/_experimental/test/impl/stream.ipp
+++ b/include/boost/beast/_experimental/test/impl/stream.ipp
@@ -223,7 +223,7 @@ read_some(MutableBufferSequence const& buffers,
         });
     std::size_t bytes_transferred;
     if(in_->b.size() > 0)
-    {   
+    {
         ec.assign(0, ec.category());
         bytes_transferred = buffer_copy(
             buffers, in_->b.data(), in_->read_max);
@@ -257,17 +257,18 @@ async_read_some(
     using boost::asio::buffer_size;
     BOOST_BEAST_HANDLER_INIT(
         ReadHandler, void(error_code, std::size_t));
-    if(in_->fc)
+
+    error_code ec;
+    if(in_->fc && in_->fc->fail(ec))
     {
-        error_code ec;
-        if(in_->fc->fail(ec))
-            return boost::asio::post(
-                in_->ioc.get_executor(),
-                bind_front_handler(
-                    std::move(init.completion_handler),
-                    ec,
-                    0));
+        boost::asio::post(
+            in_->ioc.get_executor(),
+            bind_front_handler(
+                std::move(init.completion_handler),
+                ec,
+                0));
     }
+    else
     {
         std::unique_lock<std::mutex> lock{in_->m};
         BOOST_ASSERT(! in_->op);
@@ -378,39 +379,47 @@ async_write_some(ConstBufferSequence const& buffers,
         WriteHandler, void(error_code, std::size_t));
     auto out = out_.lock();
     if(! out)
-        return boost::asio::post(
+    {
+        boost::asio::post(
             in_->ioc.get_executor(),
             bind_front_handler(
                 std::move(init.completion_handler),
                 boost::asio::error::connection_reset,
                 0));
-    BOOST_ASSERT(out->code == status::ok);
-    if(in_->fc)
+    }
+    else
     {
+        BOOST_ASSERT(out->code == status::ok);
         error_code ec;
-        if(in_->fc->fail(ec))
-            return boost::asio::post(
+        if(in_->fc && in_->fc->fail(ec))
+        {
+            boost::asio::post(
                 in_->ioc.get_executor(),
                 bind_front_handler(
                     std::move(init.completion_handler),
                     ec,
                     0));
+        }
+        else
+        {
+            auto const n =
+                (std::min)(buffer_size(buffers), in_->write_max);
+            std::unique_lock<std::mutex> lock{out->m};
+            auto const bytes_transferred =
+                buffer_copy(out->b.prepare(n), buffers);
+            out->b.commit(bytes_transferred);
+            out->on_write();
+            lock.unlock();
+            ++in_->nwrite;
+            boost::asio::post(
+                in_->ioc.get_executor(),
+                bind_front_handler(
+                    std::move(init.completion_handler),
+                    error_code{},
+                    bytes_transferred));
+        }
     }
-    auto const n =
-        (std::min)(buffer_size(buffers), in_->write_max);
-    std::unique_lock<std::mutex> lock{out->m};
-    auto const bytes_transferred =
-        buffer_copy(out->b.prepare(n), buffers);
-    out->b.commit(bytes_transferred);
-    out->on_write();
-    lock.unlock();
-    ++in_->nwrite;
-    boost::asio::post(
-        in_->ioc.get_executor(),
-        bind_front_handler(
-            std::move(init.completion_handler),
-            error_code{},
-            bytes_transferred));
+
     return init.result.get();
 }
 

--- a/include/boost/beast/_experimental/test/impl/stream.ipp
+++ b/include/boost/beast/_experimental/test/impl/stream.ipp
@@ -263,7 +263,7 @@ async_read_some(
     {
         boost::asio::post(
             in_->ioc.get_executor(),
-            bind_front_handler(
+            beast::bind_front_handler(
                 std::move(init.completion_handler),
                 ec,
                 0));
@@ -282,7 +282,7 @@ async_read_some(
             ++in_->nread;
             boost::asio::post(
                 in_->ioc.get_executor(),
-                bind_front_handler(
+                beast::bind_front_handler(
                     std::move(init.completion_handler),
                     error_code{},
                     bytes_transferred));
@@ -298,7 +298,7 @@ async_read_some(
                 ec = boost::asio::error::connection_reset;
             boost::asio::post(
                 in_->ioc.get_executor(),
-                bind_front_handler(
+                beast::bind_front_handler(
                     std::move(init.completion_handler),
                     ec,
                     0));
@@ -382,7 +382,7 @@ async_write_some(ConstBufferSequence const& buffers,
     {
         boost::asio::post(
             in_->ioc.get_executor(),
-            bind_front_handler(
+            beast::bind_front_handler(
                 std::move(init.completion_handler),
                 boost::asio::error::connection_reset,
                 0));
@@ -395,7 +395,7 @@ async_write_some(ConstBufferSequence const& buffers,
         {
             boost::asio::post(
                 in_->ioc.get_executor(),
-                bind_front_handler(
+                beast::bind_front_handler(
                     std::move(init.completion_handler),
                     ec,
                     0));
@@ -413,7 +413,7 @@ async_write_some(ConstBufferSequence const& buffers,
             ++in_->nwrite;
             boost::asio::post(
                 in_->ioc.get_executor(),
-                bind_front_handler(
+                beast::bind_front_handler(
                     std::move(init.completion_handler),
                     error_code{},
                     bytes_transferred));
@@ -456,7 +456,7 @@ TeardownHandler&& handler)
         s.in_->fc->fail(ec))
         return boost::asio::post(
             s.get_executor(),
-            bind_front_handler(std::move(handler), ec));
+            beast::bind_front_handler(std::move(handler), ec));
     s.close();
     if( s.in_->fc &&
         s.in_->fc->fail(ec))
@@ -466,7 +466,7 @@ TeardownHandler&& handler)
 
     boost::asio::post(
         s.get_executor(),
-        bind_front_handler(std::move(handler), ec));
+        beast::bind_front_handler(std::move(handler), ec));
 }
 
 //------------------------------------------------------------------------------
@@ -522,7 +522,7 @@ class stream::read_op : public stream::read_op_base
                 ++s.nread;
                 boost::asio::post(
                     s.ioc.get_executor(),
-                    bind_front_handler(
+                    beast::bind_front_handler(
                         std::move(h),
                         error_code{},
                         bytes_transferred));
@@ -541,7 +541,7 @@ class stream::read_op : public stream::read_op_base
                     ec = boost::asio::error::connection_reset;
                 boost::asio::post(
                     s.ioc.get_executor(),
-                    bind_front_handler(std::move(h), ec, 0));
+                    beast::bind_front_handler(std::move(h), ec, 0));
             }
         }
     };

--- a/include/boost/beast/core/impl/buffered_read_stream.ipp
+++ b/include/boost/beast/core/impl/buffered_read_stream.ipp
@@ -126,7 +126,7 @@ read_some_op<MutableBufferSequence, Handler>::operator()(
         step_ = 3;
         return boost::asio::post(
             s_.get_executor(),
-            bind_front_handler(std::move(*this), ec, 0));
+            beast::bind_front_handler(std::move(*this), ec, 0));
 
     case 1:
         // upcall

--- a/include/boost/beast/http/impl/read.ipp
+++ b/include/boost/beast/http/impl/read.ipp
@@ -182,7 +182,7 @@ operator()(
             BOOST_ASIO_CORO_YIELD
             boost::asio::post(
                 s_.get_executor(),
-                bind_front_handler(std::move(*this),
+                beast::bind_front_handler(std::move(*this),
                     ec, bytes_transferred_));
         }
         h_(ec, bytes_transferred_);
@@ -305,7 +305,7 @@ operator()(
         {
             BOOST_ASIO_CORO_YIELD
             boost::asio::post(s_.get_executor(),
-                bind_front_handler(std::move(*this), ec));
+                beast::bind_front_handler(std::move(*this), ec));
             goto upcall;
         }
         for(;;)

--- a/include/boost/beast/http/impl/write.ipp
+++ b/include/boost/beast/http/impl/write.ipp
@@ -147,7 +147,7 @@ operator()()
             BOOST_ASSERT(! f.invoked);
             return boost::asio::post(
                 s_.get_executor(),
-                bind_front_handler(std::move(*this), ec, 0));
+                beast::bind_front_handler(std::move(*this), ec, 0));
         }
         if(f.invoked)
         {
@@ -160,7 +160,7 @@ operator()()
     }
     return boost::asio::post(
         s_.get_executor(),
-        bind_front_handler(std::move(*this), ec, 0));
+        beast::bind_front_handler(std::move(*this), ec, 0));
 }
 
 template<

--- a/include/boost/beast/websocket/impl/accept.ipp
+++ b/include/boost/beast/websocket/impl/accept.ipp
@@ -269,7 +269,7 @@ operator()(error_code ec, std::size_t)
             BOOST_ASIO_CORO_YIELD
             boost::asio::post(
                 d.ws.get_executor(),
-                bind_front_handler(std::move(*this), ec));
+                beast::bind_front_handler(std::move(*this), ec));
         }
         else
         {

--- a/include/boost/beast/websocket/impl/close.ipp
+++ b/include/boost/beast/websocket/impl/close.ipp
@@ -181,7 +181,7 @@ operator()(
             // The read_op will be suspended on the write block.
             goto teardown;
         }
-        
+
         // Maybe suspend
         if(! d.ws.rd_block_.try_lock(this))
         {
@@ -304,7 +304,7 @@ operator()(
             BOOST_ASIO_CORO_YIELD
             boost::asio::post(
                 d.ws.get_executor(),
-                bind_front_handler(std::move(*this), ec));
+                beast::bind_front_handler(std::move(*this), ec));
         }
         {
             auto wg = std::move(d.wg);

--- a/include/boost/beast/websocket/impl/ping.ipp
+++ b/include/boost/beast/websocket/impl/ping.ipp
@@ -140,7 +140,7 @@ operator()(error_code ec, std::size_t)
                 BOOST_ASIO_CORO_YIELD
                 boost::asio::post(
                     d.ws.get_executor(),
-                    bind_front_handler(std::move(*this), ec));
+                    beast::bind_front_handler(std::move(*this), ec));
                 goto upcall;
             }
         }

--- a/include/boost/beast/websocket/impl/read.ipp
+++ b/include/boost/beast/websocket/impl/read.ipp
@@ -705,7 +705,7 @@ operator()(
             BOOST_ASIO_CORO_YIELD
             boost::asio::post(
                 ws_.get_executor(),
-                bind_front_handler(std::move(*this),
+                beast::bind_front_handler(std::move(*this),
                     ec, bytes_written_));
         }
         h_(ec, bytes_written_);
@@ -813,7 +813,7 @@ operator()(
                 if(ec)
                     boost::asio::post(
                         ws_.get_executor(),
-                        bind_front_handler(
+                        beast::bind_front_handler(
                             std::move(*this), ec, 0));
                 else
                     read_some_op<typename
@@ -1125,7 +1125,7 @@ loop:
                 // _Start the WebSocket Closing Handshake_
                 do_fail(
                     cr.code == close_code::none ?
-                        close_code::normal : 
+                        close_code::normal :
                         static_cast<close_code>(cr.code),
                     error::closed, ec);
                 return bytes_written;

--- a/include/boost/beast/websocket/impl/teardown.ipp
+++ b/include/boost/beast/websocket/impl/teardown.ipp
@@ -118,7 +118,7 @@ operator()(error_code ec, std::size_t bytes_transferred)
             BOOST_ASIO_CORO_YIELD
             boost::asio::post(
                 s_.get_executor(),
-                bind_front_handler(std::move(*this), ec, 0));
+                beast::bind_front_handler(std::move(*this), ec, 0));
             goto upcall;
         }
         for(;;)

--- a/include/boost/beast/websocket/impl/write.ipp
+++ b/include/boost/beast/websocket/impl/write.ipp
@@ -578,7 +578,7 @@ operator()(
             BOOST_ASIO_CORO_YIELD
             boost::asio::post(
                 ws_.get_executor(),
-                bind_front_handler(
+                beast::bind_front_handler(
                     std::move(*this),
                     ec, bytes_transferred_));
         }


### PR DESCRIPTION
Async initiating functions must return init.result.get(). Returning the result of post caused a compilation failure for custom completion tokens.