### PR TITLE
ssl_stream enhancements

### DIFF
--- a/include/boost/beast/_experimental/core/ssl_stream.hpp
+++ b/include/boost/beast/_experimental/core/ssl_stream.hpp
@@ -108,19 +108,6 @@ public:
     {
     }
 
-    /// Move Constructor
-    ssl_stream(ssl_stream&& other)
-        : p_(std::move(other.p_))
-    {
-    }
-
-    /// Move Assignment
-    ssl_stream& operator=(ssl_stream&& other)
-    {
-        p_ = std::move(other.p_);
-        return *this;
-    }
-
     /** Get the executor associated with the object.
 
         This function may be used to obtain the executor object that the stream

--- a/include/boost/beast/_experimental/core/ssl_stream.hpp
+++ b/include/boost/beast/_experimental/core/ssl_stream.hpp
@@ -72,7 +72,6 @@ class ssl_stream
     using stream_type = boost::beast::flat_stream<ssl_stream_type>;
 
     std::unique_ptr<stream_type> p_;
-    boost::asio::ssl::context* ctx_;
 
 public:
     /// The native handle type of the SSL stream.
@@ -106,14 +105,12 @@ public:
         boost::asio::ssl::context& ctx)
         : p_(new stream_type{
             std::forward<Arg>(arg), ctx})
-        , ctx_(&ctx)
     {
     }
 
     /// Move Constructor
     ssl_stream(ssl_stream&& other)
         : p_(std::move(other.p_))
-        , ctx_(other.ctx_)
     {
     }
 
@@ -121,7 +118,6 @@ public:
     ssl_stream& operator=(ssl_stream&& other)
     {
         p_ = std::move(other.p_);
-        ctx_ = other.ctx_;
         return *this;
     }
 

--- a/include/boost/beast/_experimental/core/ssl_stream.hpp
+++ b/include/boost/beast/_experimental/core/ssl_stream.hpp
@@ -472,7 +472,7 @@ public:
     */
     template<class ConstBufferSequence, class BufferedHandshakeHandler>
     BOOST_ASIO_INITFN_RESULT_TYPE(BufferedHandshakeHandler,
-        void (boost::system::error_code, std::size_t))
+        void(boost::system::error_code, std::size_t))
     async_handshake(handshake_type type, ConstBufferSequence const& buffers,
         BOOST_ASIO_MOVE_ARG(BufferedHandshakeHandler) handler)
     {
@@ -520,7 +520,7 @@ public:
     */
     template<class ShutdownHandler>
     BOOST_ASIO_INITFN_RESULT_TYPE(ShutdownHandler,
-        void (boost::system::error_code))
+        void(boost::system::error_code))
     async_shutdown(BOOST_ASIO_MOVE_ARG(ShutdownHandler) handler)
     {
         return p_->next_layer().async_shutdown(
@@ -599,7 +599,7 @@ public:
     */
     template<class ConstBufferSequence, class WriteHandler>
     BOOST_ASIO_INITFN_RESULT_TYPE(WriteHandler,
-        void (boost::system::error_code, std::size_t))
+        void(boost::system::error_code, std::size_t))
     async_write_some(ConstBufferSequence const& buffers,
         BOOST_ASIO_MOVE_ARG(WriteHandler) handler)
     {


### PR DESCRIPTION
* Use std::make_unique instead of new in construction of std::unique_ptr.
* Explicitly make the object non-copyable by deleting the copy constructor and copy assignment operator.
* Remove the non-owning pointer to the ssl::context private member variable, due to it being unused after constructing the underlying stream.
* Fix a few style inconsistencies.
* Use the default move constructor and default move assignment operator.