### PR TITLE
echo_op example

### DIFF
--- a/example/echo-op/echo_op.cpp
+++ b/example/echo-op/echo_op.cpp
@@ -301,6 +301,7 @@ int main(int, char** argv)
     boost::asio::ip::tcp::acceptor acceptor{ioc};
     endpoint_type ep{boost::asio::ip::make_address("0.0.0.0"), 0};
     acceptor.open(ep.protocol());
+    acceptor.set_option(boost::asio::socket_base::reuse_address(true));
     acceptor.bind(ep);
     acceptor.listen();
     acceptor.accept(sock);

--- a/example/echo-op/echo_op.cpp
+++ b/example/echo-op/echo_op.cpp
@@ -14,6 +14,39 @@
 #include <memory>
 #include <utility>
 
+template<class SyncStream>
+std::size_t
+echo(SyncStream& stream, boost::beast::error_code& ec)
+{
+    static_assert(boost::beast::is_sync_stream<SyncStream>::value,
+        "SyncStream requirements not met");
+
+    std::size_t bytes_transferred {0};
+    boost::asio::streambuf buffer;
+
+    bytes_transferred = boost::asio::read_until(stream, buffer, "\n", ec);
+    if (ec)
+        return 0;
+
+    bytes_transferred = boost::asio::write(stream,
+        boost::beast::buffers_prefix(bytes_transferred, buffer.data()), ec);
+    if (ec)
+        return 0;
+
+    buffer.consume(bytes_transferred);
+    return bytes_transferred;
+}
+
+template<class SyncStream>
+std::size_t
+echo(SyncStream& stream)
+{
+    boost::beast::error_code ec;
+    std::size_t bytes_transferred = echo(stream, ec);
+    boost::asio::detail::throw_error(ec, "echo");
+    return bytes_transferred;
+}
+
 //[example_core_echo_op_1
 
 template<

--- a/example/echo-op/echo_op.cpp
+++ b/example/echo-op/echo_op.cpp
@@ -289,8 +289,20 @@ async_echo(AsyncStream& stream, CompletionToken&& token)
 
 //]
 
-int main(int, char** argv)
+int main(int argc, char** argv)
 {
+    if(argc != 3)
+    {
+        std::cerr
+        << "Usage: echo-op <address> <port>\n"
+        << "Example:\n"
+        << "    echo-op 0.0.0.0 8080\n";
+        return EXIT_FAILURE;
+    }
+
+    auto const address{boost::asio::ip::make_address(argv[1])};
+    auto const port{static_cast<unsigned short>(std::atoi(argv[2]))};
+
     using socket_type = boost::asio::ip::tcp::socket;
     using endpoint_type = boost::asio::ip::tcp::endpoint;
 
@@ -299,7 +311,7 @@ int main(int, char** argv)
     boost::asio::io_context ioc;
     socket_type sock{ioc};
     boost::asio::ip::tcp::acceptor acceptor{ioc};
-    endpoint_type ep{boost::asio::ip::make_address("0.0.0.0"), 0};
+    endpoint_type ep{address, port};
     acceptor.open(ep.protocol());
     acceptor.set_option(boost::asio::socket_base::reuse_address(true));
     acceptor.bind(ep);
@@ -312,5 +324,5 @@ int main(int, char** argv)
                 std::cerr << argv[0] << ": " << ec.message() << std::endl;
         });
     ioc.run();
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/example/echo-op/echo_op.cpp
+++ b/example/echo-op/echo_op.cpp
@@ -30,7 +30,7 @@ async_echo(AsyncStream& stream, CompletionToken&& token)
 /** Asynchronously read a line and echo it back.
 
     This function is used to asynchronously read a line ending
-    in a carriage-return ("CR") from the stream, and then write
+    in a newline ("LF") from the stream, and then write
     it back. The function call always returns immediately. The
     asynchronous operation will continue until one of the
     following conditions is true:
@@ -209,7 +209,7 @@ operator()(boost::beast::error_code ec, std::size_t bytes_transferred)
         case 0:
             // read up to the first newline
             p.step = 1;
-            return boost::asio::async_read_until(p.stream, p.buffer, "\r", std::move(*this));
+            return boost::asio::async_read_until(p.stream, p.buffer, "\n", std::move(*this));
 
         case 1:
             // write everything back


### PR DESCRIPTION
Set the `reuse_address` socket option to match the style of the other examples.

---

Add the ability to set the listening address and port through command line arguments. Print out usage and return error exit status on invalid or missing arguments.

---

Currently, the __echo-op__ example uses the carriage return `\r` delimiter for `async_read_until`. Running the server and sending a message to it with curl or netcat:
```sh
printf 'Hello, World!\r\n' | nc 127.0.0.1 8080
```
leads to some potentially confusing behaviour. The `async_read_until` function reads up to and including the first `\r`. When the message is received by the client and printed to stdout, the trailing `\r` ends up moving the cursor back to the start of the line, resulting in the prompt overwriting the message. It appears as if nothing has happened.

If `async_read_until` uses the newline `\n` as the delimiter, the echoed output will not be overwritten, regardless of whether the line ends in `\n` or `\r\n`.

---

Had a go at adding a synchronous echo op function #1275.