### PR TITLE
Use a struct instead of pair in flat_stream

### DIFF
--- a/include/boost/beast/_experimental/core/detail/flat_stream.hpp
+++ b/include/boost/beast/_experimental/core/detail/flat_stream.hpp
@@ -12,7 +12,6 @@
 
 #include <boost/asio/buffer.hpp>
 #include <cstdlib>
-#include <iterator>
 
 namespace boost {
 namespace beast {
@@ -25,19 +24,25 @@ public:
     // 16KB is the upper limit on reasonably sized HTTP messages.
     static std::size_t constexpr coalesce_limit = 16 * 1024;
 
+    struct coalesce_result
+    {
+        std::size_t size;
+        bool needs_coalescing;
+    };
+
     // calculates the coalesce settings for a buffer sequence
     template<class BufferSequence>
     static
-    std::pair<std::size_t, bool>
+    coalesce_result
     coalesce(BufferSequence const& buffers, std::size_t limit)
     {
-        std::pair<std::size_t, bool> result{0, false};
+        coalesce_result result{0, false};
         auto first = net::buffer_sequence_begin(buffers);
-        auto last = net::buffer_sequence_end(buffers);
+        auto last = net::asio::buffer_sequence_end(buffers);
         if(first != last)
         {
-            result.first = net::buffer_size(*first);
-            if(result.first < limit)
+            result.size = net::asio::buffer_size(*first);
+            if(result.size < limit)
             {
                 auto it = first;
                 auto prev = first;
@@ -45,12 +50,12 @@ public:
                 {
                     auto const n =
                         net::buffer_size(*it);
-                    if(result.first + n > limit)
+                    if(result.size + n > limit)
                         break;
-                    result.first += n;
+                    result.size += n;
                     prev = it;
                 }
-                result.second = prev != first;
+                result.needs_coalescing = prev != first;
             }
         }
         return result;

--- a/test/beast/experimental/flat_stream.cpp
+++ b/test/beast/experimental/flat_stream.cpp
@@ -40,8 +40,8 @@ public:
                     v.emplace_back("", n);
                 auto const result =
                     boost::beast::detail::flat_stream_base::coalesce(v, limit);
-                BEAST_EXPECT(result.first == count);
-                BEAST_EXPECT(result.second == copy);
+                BEAST_EXPECT(result.size == count);
+                BEAST_EXPECT(result.needs_coalescing == copy);
                 return result;
             };
         check({},           1,    0, false);


### PR DESCRIPTION
No need to instantiate a pair and a custom struct has better member names.
Doesn't affect public APIs.