### PR TITLE
Example/CppCon2018, Include error_code to acceptor_.set_option() call

### DIFF
--- a/example/cppcon2018/listener.cpp
+++ b/example/cppcon2018/listener.cpp
@@ -31,7 +31,7 @@ listener(
     }
 
     // Allow address reuse
-    acceptor_.set_option(net::socket_base::reuse_address(true));
+    acceptor_.set_option(net::socket_base::reuse_address(true), ec);
     if(ec)
     {
         fail(ec, "set_option");


### PR DESCRIPTION
Looking at the example code, it seems like this should be included in the call in order to update the content of the error_code variable.

If that's not the intention, the test for the error_code on the line after is likely unnecessary. 
