### PR TITLE
Remove linking with Boost.System

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -96,7 +96,6 @@ project /boost/beast
     <implicit-dependency>/boost//headers
     <include>.
     <include>./test/extras/include
-    <library>/boost/system//boost_system
     <library>/boost/coroutine//boost_coroutine
     <library>/boost/filesystem//boost_filesystem
     <library>static_asio

--- a/README.md
+++ b/README.md
@@ -105,10 +105,9 @@ to your source files, like this:
 #include <boost/beast.hpp>
 ```
 
-To build your program successfully, you'll need to add the Boost.System
-library to link with. If you use coroutines you'll also need to link
-with the Boost.Coroutine library. Please visit the Boost documentation
-for instructions on how to do this for your particular build system.
+If you use coroutines you'll need to link with the Boost.Coroutine
+library. Please visit the Boost documentation for instructions
+on how to do this for your particular build system.
 
 To build the documentation, examples, tests, and benchmarks it is
 necessary to first obtain the Boost "superproject" along with sources of


### PR DESCRIPTION
Since Boost.System is header-only now, no need to link with the library.