### PR TITLE
Version 214

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 214:
 
-* handler binders use the associated allocator
+* Handler binders use the associated allocator
+* Add detail::bind_continuation
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 214:
+
+* handler binders use the associated allocator
+
+--------------------------------------------------------------------------------
+
 Version 213:
 
 * Fix posix_file::close handling of EINTR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 214:
 
 * Handler binders use the associated allocator
 * Add detail::bind_continuation
+* Rewrite the echo-op example
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 cmake_minimum_required (VERSION 3.5.1)
 cmake_policy (SET CMP0074 NEW)
 
-project (Beast VERSION 213)
+project (Beast VERSION 214)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/doc/qbk/03_core/6_composed.qbk
+++ b/doc/qbk/03_core/6_composed.qbk
@@ -18,13 +18,19 @@ informed of the asynchronous operation result. __Asio__ comes with the
 special tokens __use_future__ and __yield_context__ for using futures
 and coroutines respectively. This system of customizing the return value
 and method of completion notification is known as the
-['Extensible Asynchronous Model] described in __N3747__, and a built in
+['Universal Asynchronous Model] described in __N3747__, and a built in
 to __NetTS__. Here is an example of an initiating function which reads a
 line from the stream and echoes it back. This function is developed
 further in the next section:
 
 [example_core_echo_op_1]
 
+[tip
+    This initiating function receives the dynamic buffer by lvalue-reference,
+    instead of by rvalue-reference as specified in networking. An explanation
+    for this difference may be found in
+    [@http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1100r0.html [P1100R0] Efficient composition with DynamicBuffer].
+]
 Authors using Beast can reuse the library's primitives to create their
 own initiating functions for performing a series of other, intermediate
 asynchronous operations before invoking a final completion handler.
@@ -113,8 +119,6 @@ composed operations:
 This example develops an initiating function called [*echo].
 The operation will read up to the first newline on a stream, and
 then write the same line including the newline back on the stream.
-The implementation performs both reading and writing, and has a
-non-trivially-copyable state.
 First we define the input parameters and results, then declare our
 initiation function. For our echo operation the only inputs are the
 stream and the completion token. The output is the error code which
@@ -125,47 +129,25 @@ is usually included in all completion handler signatures.
 Now that we have a declaration, we will define the body of the function.
 We want to achieve the following goals: perform static type checking on
 the input parameters, set up the return value as per __N3747__, and launch
-the composed operation by constructing the object and invoking it.
-
-[example_core_echo_op_3]
+the composed operation by constructing an intermediate, stateful completion
+handler and invoking it.
 
 The initiating function contains a few relatively simple parts. There is
 the customization of the return value type, static type checking, building
 the return value type using the helper, and creating and launching the
-composed operation object. The [*`echo_op`] object does most of the work
-here, and has a somewhat non-trivial structure. This structure is necessary
-to meet the stringent requirements of composed operations (described in more
-detail in the __Asio__ documentation). We will touch on these requirements
-without explaining them in depth.
+`echo_op` composed operation object.
 
-Here is the boilerplate present in all composed operations written
-in this style:
+The implementation strategy is to make the composed object meet the
+requirements of a completion handler by being movable, and by making it
+invocable so it can be used as a continuation for the asynchronous operations
+it launches. Rather than using `std::bind` or `boost::bind`, which destroys
+the type information and therefore breaks the allocation and invocation hooks,
+we will simply pass `std::move(*this)` as the completion handler parameter for
+any operations that we initiate. For the move to work correctly, care must be
+taken to ensure that no access to data members are made after the move takes
+place. Here is the complete implementation of our composed operation:
 
-[example_core_echo_op_4]
-
-Next is to implement the function call operator. Our strategy is to make our
-composed object meet the requirements of a completion handler by being movable,
-and by providing the function call operator with the correct signature. Rather
-than using `std::bind` or `boost::bind`, which destroys the type information
-and therefore breaks the allocation and invocation hooks, we will simply pass
-`std::move(*this)` as the completion handler parameter for any operations that
-we initiate. For the move to work correctly, care must be taken to ensure that
-no access to data members are made after the move takes place. Here is the
-implementation of the function call operator for this echo operation:
-
-[example_core_echo_op_5]
-
-This is the most important element of writing a composed operation, and
-the part which is often neglected or implemented incorrectly. It is the
-forwarding of the final handler's associated allocator and associated
-executor to the composed operation.
-
-Our composed operation stores the final handler and performs its own
-intermediate asynchronous operations. To ensure that I/O objects, in this
-case the stream, are accessed safely it is important to use the same
-executor to invoke intermediate handlers as that used to invoke the final
-handler. Similarly, for memory allocations our composed operation should
-use the allocator associated with the final handler.
+[example_core_echo_op_3]
 
 There are some common mistakes that should be avoided when writing
 composed operations:
@@ -184,7 +166,8 @@ composed operations:
   if someone  calls the initiating function with a strand-wrapped
   function object, and there is more than thread running on the
   __io_context__, the underlying stream may be accessed in a fashion
-  that violates safety guarantees.
+  that violates safety guarantees. Beast provides class templates
+  to take care of this boilerplate for you.
 
 * Forgetting to create an object of type __executor_work_guard__ with the
   type of executor returned by the stream's `get_executor` member function.

--- a/example/websocket/server/chat-multi/http_session.cpp
+++ b/example/websocket/server/chat-multi/http_session.cpp
@@ -268,7 +268,7 @@ on_read(beast::error_code ec, std::size_t)
     {
         // Create a WebSocket session by transferring the socket
         boost::make_shared<websocket_session>(
-            std::move(stream_.release_socket()),
+            stream_.release_socket(),
                 state_)->run(std::move(req_));
         return;
     }

--- a/include/boost/beast/core/bind_continuation.hpp
+++ b/include/boost/beast/core/bind_continuation.hpp
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2016-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_BIND_CONTINUATION_HPP
+#define BOOST_BEAST_BIND_CONTINUATION_HPP
+
+#include <boost/beast/core/detail/config.hpp>
+#include <boost/beast/core/detail/remap_post_to_defer.hpp>
+#include <boost/asio/bind_executor.hpp>
+#include <boost/core/empty_value.hpp>
+#include <type_traits>
+#include <utility>
+
+namespace boost {
+namespace beast {
+
+/** Mark a completion handler as a continuation.
+
+    This function wraps a completion handler to associate it with an
+    executor whose `post` operation is remapped to the `defer` operation.
+    It is used by composed asynchronous operation implementations to
+    indicate that a completion handler submitted to an initiating
+    function represents a continuation of the current asynchronous
+    flow of control.
+
+    @see
+
+    @li <a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4242.html">[N4242] Executors and Asynchronous Operations, Revision 1</a>
+*/
+template<class Executor, class CompletionHandler>
+#if BOOST_BEAST_DOXYGEN
+__implementation_defined__
+#else
+net::executor_binder<typename
+    std::decay<CompletionHandler>::type,
+    detail::remap_post_to_defer<Executor>>
+#endif
+bind_continuation(
+    Executor const& ex, CompletionHandler&& handler)
+{
+    return net::bind_executor(
+        detail::remap_post_to_defer<Executor>(ex),
+        std::forward<CompletionHandler>(handler));
+}
+
+} // beast
+} // boost
+
+#endif

--- a/include/boost/beast/core/detail/remap_post_to_defer.hpp
+++ b/include/boost/beast/core/detail/remap_post_to_defer.hpp
@@ -1,0 +1,109 @@
+//
+// Copyright (c) 2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_DETAIL_REMAP_POST_TO_DEFER_HPP
+#define BOOST_BEAST_DETAIL_REMAP_POST_TO_DEFER_HPP
+
+#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/is_executor.hpp>
+#include <boost/core/empty_value.hpp>
+#include <type_traits>
+#include <utility>
+
+namespace boost {
+namespace beast {
+namespace detail {
+
+template<class Executor>
+class remap_post_to_defer
+    : private boost::empty_value<Executor>
+{
+    BOOST_STATIC_ASSERT(
+        net::is_executor<Executor>::value);
+
+    Executor const&
+    ex() const noexcept
+    {
+        return this->get();
+    }
+
+public:
+    remap_post_to_defer(
+        remap_post_to_defer&&) = default;
+
+    remap_post_to_defer(
+        remap_post_to_defer const&) = default;
+
+    explicit
+    remap_post_to_defer(
+        Executor const& ex)
+        : boost::empty_value<Executor>(
+            boost::empty_init_t{}, ex)
+    {
+    }
+
+    bool
+    operator==(
+        remap_post_to_defer const& other) const noexcept
+    {
+        return ex() == other.ex();
+    }
+
+    bool
+    operator!=(
+        remap_post_to_defer const& other) const noexcept
+    {
+        return ex() != other.ex();
+    }
+
+    decltype(std::declval<Executor const&>().context())
+    context() const noexcept
+    {
+        return ex().context();
+    }
+
+    void
+    on_work_started() const noexcept
+    {
+        ex().on_work_started();
+    }
+
+    void
+    on_work_finished() const noexcept
+    {
+        ex().on_work_finished();
+    }
+
+    template<class F, class A>
+    void
+    dispatch(F&& f, A const& a) const
+    {
+        ex().dispatch(std::forward<F>(f), a);
+    }
+
+    template<class F, class A>
+    void
+    post(F&& f, A const& a) const
+    {
+        ex().defer(std::forward<F>(f), a);
+    }
+
+    template<class F, class A>
+    void
+    defer(F&& f, A const& a) const
+    {
+        ex().defer(std::forward<F>(f), a);
+    }
+};
+
+} // detail
+} // beast
+} // boost
+
+#endif

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 213
+#define BOOST_BEAST_VERSION 214
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/test/beast/core/CMakeLists.txt
+++ b/test/beast/core/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable (tests-beast-core
     _detail_varint.cpp
     async_op_base.cpp
     basic_stream.cpp
+    bind_continuation.cpp
     bind_handler.cpp
     buffer_size.cpp
     buffer_traits.cpp

--- a/test/beast/core/Jamfile
+++ b/test/beast/core/Jamfile
@@ -19,6 +19,7 @@ local SOURCES =
     _detail_varint.cpp
     async_op_base.cpp
     basic_stream.cpp
+    bind_continuation.cpp
     bind_handler.cpp
     buffer_size.cpp
     buffer_traits.cpp

--- a/test/beast/core/bind_continuation.cpp
+++ b/test/beast/core/bind_continuation.cpp
@@ -1,0 +1,186 @@
+//
+// Copyright (c) 2018 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+// Test that header file is self-contained.
+#include <boost/beast/core/bind_continuation.hpp>
+
+#include "test_executor.hpp"
+#include "test_handler.hpp"
+
+#include <boost/beast/_experimental/unit_test/suite.hpp>
+#include <boost/beast/core/error.hpp>
+#include <boost/beast/core/stream_traits.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/asio/defer.hpp>
+#include <boost/core/exchange.hpp>
+
+namespace boost {
+namespace beast {
+
+class bind_continuation_test
+    : public beast::unit_test::suite
+{
+public:
+    class handler
+    {
+        bool pass_ = false;
+
+    public:
+        handler() = default;
+
+        ~handler()
+        {
+            BEAST_EXPECT(pass_);
+        }
+
+        handler(handler&& other)
+            : pass_(boost::exchange(other.pass_, true))
+        {
+        }
+
+        void operator()()
+        {
+            pass_ = true;
+        }
+    };
+
+    void
+    testBinder()
+    {
+        net::io_context ioc;
+        
+        // free functions
+
+        {
+            test_executor<> ex(ioc.get_executor());
+            BEAST_EXPECT(ex->total == 0);
+            net::dispatch(
+                bind_continuation(ex, handler{}));
+            ioc.run();
+            ioc.restart();
+            BEAST_EXPECT(ex->dispatch == 1);
+        }
+
+        {
+            test_executor<> ex(ioc.get_executor());
+            BEAST_EXPECT(ex->total == 0);
+            net::post(
+                bind_continuation(ex, handler{}));
+            ioc.run();
+            ioc.restart();
+            BEAST_EXPECT(ex->defer == 1);
+        }
+
+        {
+            test_executor<> ex(ioc.get_executor());
+            BEAST_EXPECT(ex->total == 0);
+            net::defer(
+                bind_continuation(ex, handler{}));
+            ioc.run();
+            ioc.restart();
+            BEAST_EXPECT(ex->defer == 1);
+        }
+
+        // members
+
+        {
+            test_executor<> ex(ioc.get_executor());
+            BEAST_EXPECT(ex->total == 0);
+            ex.dispatch(
+                bind_continuation(ex, handler{}),
+                std::allocator<void>{});
+            ioc.run();
+            ioc.restart();
+            BEAST_EXPECT(ex->dispatch == 1);
+        }
+
+        {
+            test_executor<> ex(ioc.get_executor());
+            BEAST_EXPECT(ex->total == 0);
+            ex.post(
+                bind_continuation(ex, handler{}),
+                std::allocator<void>{});
+            ioc.run();
+            ioc.restart();
+            BEAST_EXPECT(ex->post == 1);
+        }
+
+        {
+            test_executor<> ex(ioc.get_executor());
+            BEAST_EXPECT(ex->total == 0);
+            ex.defer(
+                bind_continuation(ex, handler{}),
+                std::allocator<void>{});
+            ioc.run();
+            ioc.restart();
+            BEAST_EXPECT(ex->defer == 1);
+        }
+
+        // relational
+
+        {
+            auto h1 = bind_continuation(
+                ioc.get_executor(), handler{});
+            auto h2 = bind_continuation(
+                ioc.get_executor(), handler{});
+            BEAST_EXPECT(
+                net::get_associated_executor(h1) ==
+                net::get_associated_executor(h2));
+            BEAST_EXPECT(
+                std::addressof(
+                    net::get_associated_executor(h1).context()) ==
+                std::addressof(
+                    net::get_associated_executor(h2).context()));
+            h1();
+            h2();
+        }
+
+        {
+            net::io_context ioc1;
+            net::io_context ioc2;
+            auto h1 = bind_continuation(
+                ioc1.get_executor(), handler{});
+            auto h2 = bind_continuation(
+                ioc2.get_executor(), handler{});
+            BEAST_EXPECT(
+                net::get_associated_executor(h1) !=
+                net::get_associated_executor(h2));
+            BEAST_EXPECT(
+                std::addressof(
+                    net::get_associated_executor(h1).context()) !=
+                std::addressof(
+                    net::get_associated_executor(h2).context()));
+            h1();
+            h2();
+        }
+    }
+
+    //--------------------------------------------------------------------------
+
+    void
+    testJavadoc()
+    {
+    }
+
+    //--------------------------------------------------------------------------
+
+    void
+    run() override
+    {
+        testBinder();
+        testJavadoc();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(beast,core,bind_continuation);
+
+} // beast
+} // boost

--- a/test/beast/core/test_executor.hpp
+++ b/test/beast/core/test_executor.hpp
@@ -1,0 +1,122 @@
+//
+// Copyright (c) 2018 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_TEST_TEST_EXECUTOR_HPP
+#define BOOST_BEAST_TEST_TEST_EXECUTOR_HPP
+
+#include <boost/beast/core/detail/config.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/io_context.hpp>
+#include <memory>
+
+namespace boost {
+namespace beast {
+
+template<class Executor = net::io_context::executor_type>
+class test_executor
+{
+public:
+    // VFALCO These need to be atomic or something
+    struct info
+    {
+        int dispatch = 0;
+        int post = 0;
+        int defer = 0;
+        int work = 0;
+        int total = 0;
+    };
+
+private:
+    struct state
+    {
+        Executor ex;
+        info info_;
+
+        state(Executor const& ex_)
+            : ex(ex_)
+        {
+        }
+    };
+
+    std::shared_ptr<state> sp_;
+
+public:
+    test_executor(test_executor const&) = default;
+    test_executor& operator=(test_executor const&) = default;
+
+    explicit
+    test_executor(Executor const& ex)
+        : sp_(std::make_shared<state>(ex))
+    {
+    }
+
+    decltype(sp_->ex.context())
+    context() const noexcept
+    {
+        return sp_->ex.context();
+    }
+
+    info&
+    operator*() noexcept
+    {
+        return sp_->info_;
+    }
+
+    info*
+    operator->() noexcept
+    {
+        return &sp_->info_;
+    }
+
+    void
+    on_work_started() const noexcept
+    {
+        ++sp_->info_.work;
+    }
+
+    void
+    on_work_finished() const noexcept
+    {
+    }
+
+    template<class F, class A>
+    void
+    dispatch(F&& f, A const& a) const
+    {
+        ++sp_->info_.dispatch;
+        ++sp_->info_.total;
+        sp_->ex.dispatch(
+            std::forward<F>(f), a);
+    }
+
+    template<class F, class A>
+    void
+    post(F&& f, A const& a) const
+    {
+        ++sp_->info_.post;
+        ++sp_->info_.total;
+        sp_->ex.post(
+            std::forward<F>(f), a);
+    }
+
+    template<class F, class A>
+    void
+    defer(F&& f, A const& a) const
+    {
+        ++sp_->info_.defer;
+        ++sp_->info_.total;
+        sp_->ex.defer(
+            std::forward<F>(f), a);
+    }
+};
+
+} // beast
+} // boost
+
+#endif


### PR DESCRIPTION
* Handler binders use the associated allocator
* Add detail::bind_continuation
* Rewrite the echo-op example
