### PR TITLE
Allow the use of string_body and vector_body with -fno-exceptions

### DIFF
--- a/include/boost/beast/http/string_body.hpp
+++ b/include/boost/beast/http/string_body.hpp
@@ -94,21 +94,13 @@ public:
         {
             if(length)
             {
-                if(static_cast<std::size_t>(*length) != *length)
+                std::size_t len = *length;
+                if(len != *length || len > body_.max_size())
                 {
                     ec = error::buffer_overflow;
                     return;
                 }
-                try
-                {
-                    body_.reserve(
-                        static_cast<std::size_t>(*length));
-                }
-                catch(std::exception const&)
-                {
-                    ec = error::buffer_overflow;
-                    return;
-                }
+                body_.reserve(len);
             }
             ec = {};
         }
@@ -120,15 +112,13 @@ public:
         {
             auto const extra = buffer_size(buffers);
             auto const size = body_.size();
-            try
-            {
-                body_.resize(size + extra);
-            }
-            catch(std::exception const&)
+            if (extra > body_.max_size() - size)
             {
                 ec = error::buffer_overflow;
                 return 0;
             }
+
+            body_.resize(size + extra);
             ec = {};
             CharT* dest = &body_[size];
             for(auto b : beast::buffers_range_ref(buffers))

--- a/include/boost/beast/http/vector_body.hpp
+++ b/include/boost/beast/http/vector_body.hpp
@@ -88,21 +88,13 @@ public:
         {
             if(length)
             {
-                if(static_cast<std::size_t>(*length) != *length)
+                std::size_t const len = *length;
+                if(len != *length || len > body_.max_size())
                 {
                     ec = error::buffer_overflow;
                     return;
                 }
-                try
-                {
-                    body_.reserve(
-                        static_cast<std::size_t>(*length));
-                }
-                catch(std::exception const&)
-                {
-                    ec = error::buffer_overflow;
-                    return;
-                }
+                body_.reserve(len);
             }
             ec = {};
         }
@@ -114,15 +106,13 @@ public:
         {
             auto const n = buffer_size(buffers);
             auto const len = body_.size();
-            try
-            {
-                body_.resize(len + n);
-            }
-            catch(std::exception const&)
+            if (n > body_.max_size() - len)
             {
                 ec = error::buffer_overflow;
                 return 0;
             }
+
+            body_.resize(len + n);
             ec = {};
             return net::buffer_copy(net::buffer(
                 &body_[0] + len, n), buffers);


### PR DESCRIPTION
`string_body` and `vector_body` will no longer translate all exceptions
to "buffer_overflow" error code. `buffer_overflow` error can now only
occur if the Body's max_size() is exceeded.

Changes required:
Code that relies on exceptions thrown from value_type's reserve/resize
being translated into an error code must implement a mechanism to catch
the exception.