### PR TITLE
Fix completion handler invocation signatures

### DIFF
--- a/include/boost/beast/websocket/impl/accept.hpp
+++ b/include/boost/beast/websocket/impl/accept.hpp
@@ -195,7 +195,7 @@ public:
                 std::forward<Handler_>(h),
                     sp->stream().get_executor())
         , wp_(sp)
-        , res_(beast::allocate_stable<response_type>(*this, 
+        , res_(beast::allocate_stable<response_type>(*this,
             sp->build_response(req, decorator, result_)))
     {
         (*this)({}, 0, cont);
@@ -209,8 +209,10 @@ public:
         boost::ignore_unused(bytes_transferred);
         auto sp = wp_.lock();
         if(! sp)
-            return this->complete(cont,
-                net::error::operation_aborted);
+        {
+            ec = net::error::operation_aborted;
+            return this->complete(cont, ec);
+        }
         auto& impl = *sp;
         BOOST_ASIO_CORO_REENTER(*this)
         {
@@ -287,8 +289,10 @@ public:
         boost::ignore_unused(bytes_transferred);
         auto sp = wp_.lock();
         if(! sp)
-            return this->complete(cont,
-                net::error::operation_aborted);
+        {
+            ec = net::error::operation_aborted;
+            return this->complete(cont, ec);
+        }
         auto& impl = *sp;
         BOOST_ASIO_CORO_REENTER(*this)
         {
@@ -306,7 +310,7 @@ public:
                 ec = error::closed;
             if(impl.check_stop_now(ec))
                 goto upcall;
-            
+
             {
                 // Arguments from our state must be
                 // moved to the stack before releasing

--- a/include/boost/beast/websocket/impl/close.hpp
+++ b/include/boost/beast/websocket/impl/close.hpp
@@ -75,8 +75,10 @@ public:
         using beast::detail::clamp;
         auto sp = wp_.lock();
         if(! sp)
-            return this->complete(cont,
-                net::error::operation_aborted);
+        {
+            ec = net::error::operation_aborted;
+            return this->complete(cont, ec);
+        }
         auto& impl = *sp;
         BOOST_ASIO_CORO_REENTER(*this)
         {

--- a/include/boost/beast/websocket/impl/handshake.hpp
+++ b/include/boost/beast/websocket/impl/handshake.hpp
@@ -92,8 +92,10 @@ public:
         boost::ignore_unused(bytes_used);
         auto sp = wp_.lock();
         if(! sp)
-            return this->complete(cont,
-                net::error::operation_aborted);
+        {
+            ec = net::error::operation_aborted;
+            return this->complete(cont, ec);
+        }
         auto& impl = *sp;
         BOOST_ASIO_CORO_REENTER(*this)
         {

--- a/include/boost/beast/websocket/impl/ping.hpp
+++ b/include/boost/beast/websocket/impl/ping.hpp
@@ -71,8 +71,10 @@ public:
         boost::ignore_unused(bytes_transferred);
         auto sp = wp_.lock();
         if(! sp)
-            return this->complete(cont,
-                net::error::operation_aborted);
+        {
+            ec = net::error::operation_aborted;
+            return this->complete(cont, ec);
+        }
         auto& impl = *sp;
         BOOST_ASIO_CORO_REENTER(*this)
         {

--- a/include/boost/beast/websocket/impl/read.hpp
+++ b/include/boost/beast/websocket/impl/read.hpp
@@ -85,8 +85,11 @@ public:
         using beast::detail::clamp;
         auto sp = wp_.lock();
         if(! sp)
-            return this->complete(cont,
-                net::error::operation_aborted, 0);
+        {
+            ec = net::error::operation_aborted;
+            bytes_written_ = 0;
+            return this->complete(cont, ec, bytes_written_);
+        }
         auto& impl = *sp;
         BOOST_ASIO_CORO_REENTER(*this)
         {
@@ -652,8 +655,11 @@ public:
         using beast::detail::clamp;
         auto sp = wp_.lock();
         if(! sp)
-            return this->complete(cont,
-                net::error::operation_aborted, 0);
+        {
+            ec = net::error::operation_aborted;
+            bytes_written_ = 0;
+            return this->complete(cont, ec, bytes_written_);
+        }
         auto& impl = *sp;
         using mutable_buffers_type = typename
             DynamicBuffer::mutable_buffers_type;

--- a/include/boost/beast/websocket/impl/write.hpp
+++ b/include/boost/beast/websocket/impl/write.hpp
@@ -161,8 +161,11 @@ operator()(
     net::mutable_buffer b;
     auto sp = wp_.lock();
     if(! sp)
-        return this->complete(cont,
-            net::error::operation_aborted, 0);
+    {
+        ec = net::error::operation_aborted;
+        bytes_transferred_ = 0;
+        return this->complete(cont, ec, bytes_transferred_);
+    }
     auto& impl = *sp;
     BOOST_ASIO_CORO_REENTER(*this)
     {


### PR DESCRIPTION
Completion handlers should be called with the exact same signature as provided to `async_result`.

Fixes: #1506 