### PR TITLE
Android: Use compiler pre-defined __ANDROID__

### DIFF
--- a/include/boost/beast/core/impl/file_posix.ipp
+++ b/include/boost/beast/core/impl/file_posix.ipp
@@ -24,7 +24,7 @@
 #include <limits.h>
 
 #if ! defined(BOOST_BEAST_NO_POSIX_FADVISE)
-# if defined(__APPLE__) || (defined(ANDROID) && (__ANDROID_API__ < 21))
+# if defined(__APPLE__) || (defined(__ANDROID__) && (__ANDROID_API__ < 21))
 #  define BOOST_BEAST_NO_POSIX_FADVISE
 # endif
 #endif


### PR DESCRIPTION
The ANDROID define us usually originationg from he build system
(like CMake, ndk-build, etc.). But some buildsystems like Bazel
do not set it which brakes Android platform detection.

Better use __ANDROID__ (like boost predef does) which is
predefined by the compiler if targeting Android.