### PR TITLE
Disable vulnerable versions of TLS/SSL

### DIFF
--- a/example/advanced/server-flex/advanced_server_flex.cpp
+++ b/example/advanced/server-flex/advanced_server_flex.cpp
@@ -971,7 +971,7 @@ int main(int argc, char* argv[])
     net::io_context ioc{threads};
 
     // The SSL context is required, and holds certificates
-    ssl::context ctx{ssl::context::sslv23};
+    ssl::context ctx{ssl::context::tlsv12};
 
     // This holds the self-signed certificate used by the server
     load_server_certificate(ctx);

--- a/example/http/client/async-ssl/http_client_async_ssl.cpp
+++ b/example/http/client/async-ssl/http_client_async_ssl.cpp
@@ -150,7 +150,7 @@ public:
 
         if(ec)
             return fail(ec, "write");
-        
+
         // Receive the HTTP response
         http::async_read(stream_, buffer_, res_,
             beast::bind_front_handler(
@@ -220,11 +220,11 @@ int main(int argc, char** argv)
     net::io_context ioc;
 
     // The SSL context is required, and holds certificates
-    ssl::context ctx{ssl::context::sslv23_client};
+    ssl::context ctx{ssl::context::tlsv12_client};
 
     // This holds the root certificate used for verification
     load_root_certificates(ctx);
-    
+
     // Verify the remote server's certificate
     ctx.set_verify_mode(ssl::verify_peer);
 

--- a/example/http/client/coro-ssl/http_client_coro_ssl.cpp
+++ b/example/http/client/coro-ssl/http_client_coro_ssl.cpp
@@ -153,11 +153,11 @@ int main(int argc, char** argv)
     net::io_context ioc;
 
     // The SSL context is required, and holds certificates
-    ssl::context ctx{ssl::context::sslv23_client};
+    ssl::context ctx{ssl::context::tlsv12_client};
 
     // This holds the root certificate used for verification
     load_root_certificates(ctx);
-    
+
     // Verify the remote server's certificate
     ctx.set_verify_mode(ssl::verify_peer);
 

--- a/example/http/client/sync-ssl/http_client_sync_ssl.cpp
+++ b/example/http/client/sync-ssl/http_client_sync_ssl.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv)
         net::io_context ioc;
 
         // The SSL context is required, and holds certificates
-        ssl::context ctx(ssl::context::sslv23_client);
+        ssl::context ctx(ssl::context::tlsv12_client);
 
         // This holds the root certificate used for verification
         load_root_certificates(ctx);

--- a/example/http/server/async-ssl/http_server_async_ssl.cpp
+++ b/example/http/server/async-ssl/http_server_async_ssl.cpp
@@ -521,7 +521,7 @@ int main(int argc, char* argv[])
     net::io_context ioc{threads};
 
     // The SSL context is required, and holds certificates
-    ssl::context ctx{ssl::context::sslv23};
+    ssl::context ctx{ssl::context::tlsv12};
 
     // This holds the self-signed certificate used by the server
     load_server_certificate(ctx);

--- a/example/http/server/coro-ssl/http_server_coro_ssl.cpp
+++ b/example/http/server/coro-ssl/http_server_coro_ssl.cpp
@@ -402,7 +402,7 @@ int main(int argc, char* argv[])
     net::io_context ioc{threads};
 
     // The SSL context is required, and holds certificates
-    ssl::context ctx{ssl::context::sslv23};
+    ssl::context ctx{ssl::context::tlsv12};
 
     // This holds the self-signed certificate used by the server
     load_server_certificate(ctx);

--- a/example/http/server/flex/http_server_flex.cpp
+++ b/example/http/server/flex/http_server_flex.cpp
@@ -671,7 +671,7 @@ int main(int argc, char* argv[])
     net::io_context ioc{threads};
 
     // The SSL context is required, and holds certificates
-    ssl::context ctx{ssl::context::sslv23};
+    ssl::context ctx{ssl::context::tlsv12};
 
     // This holds the self-signed certificate used by the server
     load_server_certificate(ctx);

--- a/example/http/server/stackless-ssl/http_server_stackless_ssl.cpp
+++ b/example/http/server/stackless-ssl/http_server_stackless_ssl.cpp
@@ -308,7 +308,7 @@ public:
     }
 
     #include <boost/asio/yield.hpp>
-    
+
     void
     loop(
         beast::error_code ec,
@@ -465,7 +465,7 @@ public:
 private:
 
     #include <boost/asio/yield.hpp>
-    
+
     void
     loop(beast::error_code ec = {})
     {
@@ -523,7 +523,7 @@ int main(int argc, char* argv[])
     net::io_context ioc{threads};
 
     // The SSL context is required, and holds certificates
-    ssl::context ctx{ssl::context::sslv23};
+    ssl::context ctx{ssl::context::tlsv12};
 
     // This holds the self-signed certificate used by the server
     load_server_certificate(ctx);

--- a/example/http/server/sync-ssl/http_server_sync_ssl.cpp
+++ b/example/http/server/sync-ssl/http_server_sync_ssl.cpp
@@ -325,7 +325,7 @@ int main(int argc, char* argv[])
         net::io_context ioc{1};
 
         // The SSL context is required, and holds certificates
-        ssl::context ctx{ssl::context::sslv23};
+        ssl::context ctx{ssl::context::tlsv12};
 
         // This holds the self-signed certificate used by the server
         load_server_certificate(ctx);

--- a/example/websocket/client/async-ssl/websocket_client_async_ssl.cpp
+++ b/example/websocket/client/async-ssl/websocket_client_async_ssl.cpp
@@ -153,7 +153,7 @@ public:
     {
         if(ec)
             return fail(ec, "handshake");
-        
+
         // Send the message
         ws_.async_write(
             net::buffer(text_),
@@ -171,7 +171,7 @@ public:
 
         if(ec)
             return fail(ec, "write");
-        
+
         // Read a message into our buffer
         ws_.async_read(
             buffer_,
@@ -231,7 +231,7 @@ int main(int argc, char** argv)
     net::io_context ioc;
 
     // The SSL context is required, and holds certificates
-    ssl::context ctx{ssl::context::sslv23_client};
+    ssl::context ctx{ssl::context::tlsv12_client};
 
     // This holds the root certificate used for verification
     load_root_certificates(ctx);

--- a/example/websocket/client/coro-ssl/websocket_client_coro_ssl.cpp
+++ b/example/websocket/client/coro-ssl/websocket_client_coro_ssl.cpp
@@ -147,7 +147,7 @@ int main(int argc, char** argv)
     net::io_context ioc;
 
     // The SSL context is required, and holds certificates
-    ssl::context ctx{ssl::context::sslv23_client};
+    ssl::context ctx{ssl::context::tlsv12_client};
 
     // This holds the root certificate used for verification
     load_root_certificates(ctx);

--- a/example/websocket/client/sync-ssl/websocket_client_sync_ssl.cpp
+++ b/example/websocket/client/sync-ssl/websocket_client_sync_ssl.cpp
@@ -55,7 +55,7 @@ int main(int argc, char** argv)
         net::io_context ioc;
 
         // The SSL context is required, and holds certificates
-        ssl::context ctx{ssl::context::sslv23_client};
+        ssl::context ctx{ssl::context::tlsv12_client};
 
         // This holds the root certificate used for verification
         load_root_certificates(ctx);

--- a/example/websocket/server/async-ssl/websocket_server_async_ssl.cpp
+++ b/example/websocket/server/async-ssl/websocket_server_async_ssl.cpp
@@ -277,9 +277,9 @@ int main(int argc, char* argv[])
 
     // The io_context is required for all I/O
     net::io_context ioc{threads};
-    
+
     // The SSL context is required, and holds certificates
-    ssl::context ctx{ssl::context::sslv23};
+    ssl::context ctx{ssl::context::tlsv12};
 
     // This holds the self-signed certificate used by the server
     load_server_certificate(ctx);

--- a/example/websocket/server/coro-ssl/websocket_server_coro_ssl.cpp
+++ b/example/websocket/server/coro-ssl/websocket_server_coro_ssl.cpp
@@ -177,7 +177,7 @@ int main(int argc, char* argv[])
     net::io_context ioc{threads};
 
     // The SSL context is required, and holds certificates
-    ssl::context ctx{ssl::context::sslv23};
+    ssl::context ctx{ssl::context::tlsv12};
 
     // This holds the self-signed certificate used by the server
     load_server_certificate(ctx);

--- a/example/websocket/server/stackless-ssl/websocket_server_stackless_ssl.cpp
+++ b/example/websocket/server/stackless-ssl/websocket_server_stackless_ssl.cpp
@@ -69,7 +69,7 @@ public:
     }
 
     #include <boost/asio/yield.hpp>
-    
+
     void
     loop(
         beast::error_code ec,
@@ -228,7 +228,7 @@ public:
 private:
 
     #include <boost/asio/yield.hpp>
-    
+
     void
     loop(beast::error_code ec = {})
     {
@@ -280,9 +280,9 @@ int main(int argc, char* argv[])
 
     // The io_context is required for all I/O
     net::io_context ioc{threads};
-    
+
     // The SSL context is required, and holds certificates
-    ssl::context ctx{ssl::context::sslv23};
+    ssl::context ctx{ssl::context::tlsv12};
 
     // This holds the self-signed certificate used by the server
     load_server_certificate(ctx);

--- a/example/websocket/server/sync-ssl/websocket_server_sync_ssl.cpp
+++ b/example/websocket/server/sync-ssl/websocket_server_sync_ssl.cpp
@@ -107,7 +107,7 @@ int main(int argc, char* argv[])
         net::io_context ioc{1};
 
         // The SSL context is required, and holds certificates
-        ssl::context ctx{ssl::context::sslv23};
+        ssl::context ctx{ssl::context::tlsv12};
 
         // This holds the self-signed certificate used by the server
         load_server_certificate(ctx);

--- a/include/boost/beast/ssl/ssl_stream.hpp
+++ b/include/boost/beast/ssl/ssl_stream.hpp
@@ -19,7 +19,7 @@
 
 // VFALCO We include this because anyone who uses ssl will
 //        very likely need to check for ssl::error::stream_truncated
-#include <boost/asio/ssl/error.hpp> 
+#include <boost/asio/ssl/error.hpp>
 
 #include <boost/asio/ssl/stream.hpp>
 #include <cstddef>
@@ -34,28 +34,28 @@ namespace beast {
 
     The stream class template provides asynchronous and blocking
     stream-oriented functionality using SSL.
-    
+
     @par Thread Safety
     @e Distinct @e objects: Safe.@n
     @e Shared @e objects: Unsafe. The application must also ensure that all
     asynchronous operations are performed within the same implicit or explicit
     strand.
-    
+
     @par Example
     To use this template with a @ref tcp_stream, you would write:
     @code
         net::io_context ioc;
-        net::ssl::context ctx{net::ssl::context::sslv23};
+        net::ssl::context ctx{net::ssl::context::tlsv12};
         beast::ssl_stream<beast::tcp_stream> sock{ioc, ctx};
     @endcode
 
     In addition to providing an interface identical to `net::ssl::stream`,
     the wrapper has the following additional properties:
-    
+
     @li Satisfies @b MoveConstructible
-    
+
     @li Satisfies @b MoveAssignable
-   
+
     @li Constructible from a moved socket.
 
     @li Uses @ref flat_stream internally, as a performance work-around for a
@@ -128,16 +128,16 @@ public:
         This function may be used to obtain the underlying implementation of the
         context. This is intended to allow access to context functionality that is
         not otherwise provided.
-        
+
         @par Example
         The native_handle() function returns a pointer of type @c SSL* that is
         suitable for passing to functions such as @c SSL_get_verify_result and
         @c SSL_get_peer_certificate:
         @code
         boost::beast::ssl_stream<net::ip::tcp::socket> ss{ioc, ctx};
-        
+
         // ... establish connection and perform handshake ...
-        
+
         if (X509* cert = SSL_get_peer_certificate(ss.native_handle()))
         {
           if (SSL_get_verify_result(ss.native_handle()) == X509_V_OK)
@@ -191,11 +191,11 @@ public:
 
         This function may be used to configure the peer verification mode used by
         the stream. The new mode will override the mode inherited from the context.
-        
+
         @param v A bitmask of peer verification modes.
-        
+
         @throws boost::system::system_error Thrown on failure.
-        
+
         @note Calls @c SSL_set_verify.
     */
     void
@@ -208,12 +208,12 @@ public:
 
         This function may be used to configure the peer verification mode used by
         the stream. The new mode will override the mode inherited from the context.
-        
+
         @param v A bitmask of peer verification modes. See `verify_mode` for
         available values.
-        
+
         @param ec Set to indicate what error occurred, if any.
-        
+
         @note Calls @c SSL_set_verify.
     */
     void
@@ -227,12 +227,12 @@ public:
 
         This function may be used to configure the maximum verification depth
         allowed by the stream.
-        
+
         @param depth Maximum depth for the certificate chain verification that
         shall be allowed.
-        
+
         @throws boost::system::system_error Thrown on failure.
-        
+
         @note Calls @c SSL_set_verify_depth.
     */
     void
@@ -245,12 +245,12 @@ public:
 
         This function may be used to configure the maximum verification depth
         allowed by the stream.
-        
+
         @param depth Maximum depth for the certificate chain verification that
         shall be allowed.
-        
+
         @param ec Set to indicate what error occurred, if any.
-        
+
         @note Calls @c SSL_set_verify_depth.
     */
     void
@@ -264,7 +264,7 @@ public:
 
         This function is used to specify a callback function that will be called
         by the implementation when it needs to verify a peer certificate.
-        
+
         @param callback The function object to be used for verifying a certificate.
         The function signature of the handler must be:
         @code bool verify_callback(
@@ -273,9 +273,9 @@ public:
         ); @endcode
         The return value of the callback is true if the certificate has passed
         verification, false otherwise.
-        
+
         @throws boost::system::system_error Thrown on failure.
-        
+
         @note Calls @c SSL_set_verify.
     */
     template<class VerifyCallback>
@@ -289,7 +289,7 @@ public:
 
         This function is used to specify a callback function that will be called
         by the implementation when it needs to verify a peer certificate.
-        
+
         @param callback The function object to be used for verifying a certificate.
         The function signature of the handler must be:
         @code bool verify_callback(
@@ -298,9 +298,9 @@ public:
         ); @endcode
         The return value of the callback is true if the certificate has passed
         verification, false otherwise.
-        
+
         @param ec Set to indicate what error occurred, if any.
-        
+
         @note Calls @c SSL_set_verify.
     */
     template<class VerifyCallback>

--- a/test/beast/websocket/doc_snippets.cpp
+++ b/test/beast/websocket/doc_snippets.cpp
@@ -255,7 +255,7 @@ net::ip::tcp::socket sock{ios};
 
 {
 //[wss_snippet_2
-    net::ssl::context ctx{net::ssl::context::sslv23};
+    net::ssl::context ctx{net::ssl::context::tlsv12};
     stream<net::ssl::stream<net::ip::tcp::socket>> wss{ios, ctx};
 //]
 }
@@ -263,7 +263,7 @@ net::ip::tcp::socket sock{ios};
 {
 //[wss_snippet_3
     net::ip::tcp::endpoint ep;
-    net::ssl::context ctx{net::ssl::context::sslv23};
+    net::ssl::context ctx{net::ssl::context::tlsv12};
     stream<net::ssl::stream<net::ip::tcp::socket>> ws{ios, ctx};
 
     // connect the underlying TCP/IP socket

--- a/test/beast/websocket/ssl.cpp
+++ b/test/beast/websocket/ssl.cpp
@@ -31,7 +31,7 @@ public:
     testTeardown()
     {
         net::io_context ioc;
-        net::ssl::context ctx(net::ssl::context::sslv23);
+        net::ssl::context ctx(net::ssl::context::tlsv12);
         Socket ss(ioc, ctx);
 
         struct handler

--- a/test/doc/core_3_timeouts.cpp
+++ b/test/doc/core_3_timeouts.cpp
@@ -299,7 +299,7 @@ https_get (std::string const& host, std::string const& target, error_code& ec)
     // This context is used to hold client and server certificates.
     // We do not perform certificate verification in this example.
 
-    net::ssl::context ctx(net::ssl::context::sslv23);
+    net::ssl::context ctx(net::ssl::context::tlsv12);
 
     // This string will hold the body of the HTTP response, if any.
     std::string result;

--- a/test/doc/snippets.ipp
+++ b/test/doc/snippets.ipp
@@ -22,5 +22,5 @@ std::thread t{[&](){ ioc.run(); }};
 
 tcp::socket sock(ioc);
 
-ssl::context ctx(ssl::context::sslv23);
+ssl::context ctx(ssl::context::tlsv12);
 

--- a/test/doc/websocket_common.ipp
+++ b/test/doc/websocket_common.ipp
@@ -16,6 +16,6 @@ using namespace boost::beast::websocket;
 
 net::io_context ioc;
 tcp_stream sock(ioc);
-net::ssl::context ctx(net::ssl::context::sslv23);
+net::ssl::context ctx(net::ssl::context::tlsv12);
 
 //]


### PR DESCRIPTION
TLS1.2 can be used instead, it is available in all currently supported versions of OpenSSL.

Close: #1519 