### PR TITLE
Remove the need for OpenSSL in examples that don't use it

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -76,6 +76,29 @@ lib static_beast
         <toolset>msvc:<define>_SILENCE_CXX17_ADAPTOR_TYPEDEFS_DEPRECATION_WARNING
         <target-os>windows:<define>_WIN32_WINNT=0x0601
         <link>static
+    : usage-requirements
+        <define>BOOST_BEAST_SPLIT_COMPILATION
+        <define>BOOST_ASIO_SEPARATE_COMPILATION
+        <define>BOOST_ASIO_NO_DEPRECATED=1
+        <define>BOOST_ASIO_DISABLE_BOOST_ARRAY=1
+        <define>BOOST_ASIO_DISABLE_BOOST_BIND=1
+        <define>BOOST_ASIO_DISABLE_BOOST_DATE_TIME=1
+        <define>BOOST_ASIO_DISABLE_BOOST_REGEX=1
+        <define>BOOST_COROUTINES_NO_DEPRECATION_WARNING=1
+        <toolset>msvc-14.1:<cxxflags>"/permissive-"
+        <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS=1
+        <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS=1
+        <toolset>msvc:<define>_SILENCE_CXX17_ALLOCATOR_VOID_DEPRECATION_WARNING
+        <toolset>msvc:<define>_SILENCE_CXX17_ADAPTOR_TYPEDEFS_DEPRECATION_WARNING
+        <target-os>windows:<define>_WIN32_WINNT=0x0601
+    ;
+lib static_ssl_asio
+    : test/lib_ssl.cpp
+    : requirements
+        <link>static
+        <library>static_beast
+        [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl/<link>shared : <build>no ]
+        [ ac.check-library /boost/beast//crypto : <library>/boost/beast//crypto/<link>shared : <build>no ]
     ;
 
 project /boost/beast
@@ -84,14 +107,11 @@ project /boost/beast
     <include>./test/extras/include
     <library>/boost/coroutine//boost_coroutine
     <library>/boost/filesystem//boost_filesystem
-    #<library>static_asio
     <library>static_beast
     <implicit-dependency>/boost//headers
     <threading>multi
     <debug-symbols>on
     <runtime-link>shared
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
     <define>BOOST_ALL_NO_LIB=1
     <define>BOOST_BEAST_SPLIT_COMPILATION
     <define>BOOST_ASIO_SEPARATE_COMPILATION

--- a/example/advanced/server-flex/Jamfile
+++ b/example/advanced/server-flex/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe advanced-server-flex :

--- a/example/http/client/async-ssl/Jamfile
+++ b/example/http/client/async-ssl/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe http-client-async-ssl :

--- a/example/http/client/coro-ssl/Jamfile
+++ b/example/http/client/coro-ssl/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe http-client-coro-ssl :

--- a/example/http/client/sync-ssl/Jamfile
+++ b/example/http/client/sync-ssl/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe http-client-sync-ssl :

--- a/example/http/server/async-ssl/Jamfile
+++ b/example/http/server/async-ssl/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe http-server-async-ssl :

--- a/example/http/server/coro-ssl/Jamfile
+++ b/example/http/server/coro-ssl/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe http-server-coro-ssl :

--- a/example/http/server/flex/Jamfile
+++ b/example/http/server/flex/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe http-server-flex :

--- a/example/http/server/stackless-ssl/Jamfile
+++ b/example/http/server/stackless-ssl/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe http-server-stackless-ssl :

--- a/example/http/server/sync-ssl/Jamfile
+++ b/example/http/server/sync-ssl/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe http-server-sync-ssl :

--- a/example/websocket/client/async-ssl/Jamfile
+++ b/example/websocket/client/async-ssl/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe websocket-client-async-ssl :

--- a/example/websocket/client/coro-ssl/Jamfile
+++ b/example/websocket/client/coro-ssl/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe websocket-client-coro-ssl :

--- a/example/websocket/client/sync-ssl/Jamfile
+++ b/example/websocket/client/sync-ssl/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe websocket-client-sync-ssl :

--- a/example/websocket/server/async-ssl/Jamfile
+++ b/example/websocket/server/async-ssl/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe websocket-server-async-ssl :

--- a/example/websocket/server/coro-ssl/Jamfile
+++ b/example/websocket/server/coro-ssl/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe websocket-server-coro-ssl :

--- a/example/websocket/server/stackless-ssl/Jamfile
+++ b/example/websocket/server/stackless-ssl/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe websocket-server-stackless-ssl :

--- a/example/websocket/server/sync-ssl/Jamfile
+++ b/example/websocket/server/sync-ssl/Jamfile
@@ -11,8 +11,7 @@ import ac ;
 
 project
     : requirements
-    [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl : <build>no ]
-    <library>/boost/beast//crypto
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
     ;
 
 exe websocket-server-sync-ssl :

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -24,6 +24,7 @@ project /boost/beast/test
     <define>BOOST_BEAST_ALLOW_DEPRECATED
     <define>BOOST_BEAST_TESTS
     <define>BOOST_ASIO_SEPARATE_COMPILATION
+    <library>/boost/beast//static_ssl_asio
     ;
 
 path-constant ZLIB_SOURCES :

--- a/test/lib_ssl.cpp
+++ b/test/lib_ssl.cpp
@@ -10,13 +10,6 @@
 // This file is used to build a static library with
 // asio and beast definitions, to reduce compilation time.
 
-// BOOST_ASIO_SEPARATE_COMPILATION for asio
-#include <boost/asio/impl/src.hpp>
+// BOOST_ASIO_SEPARATE_COMPILATION for asio::ssl
 
-// BOOST_BEAST_SPLIT_COMPILATION for beast
-#include <boost/beast/src.hpp>
-//#include <boost/beast/ssl/impl/src.hpp>
-
-#ifdef BOOST_BEAST_INCLUDE_TEST_MAIN
-#include <boost/beast/_experimental/unit_test/main.cpp>
-#endif
+#include <boost/asio/ssl/impl/src.hpp>


### PR DESCRIPTION
It is now possible to compile examples without OpenSSL. Examples that do require OpenSSL will be omitted.