### PR TITLE
Jamfile cleanup

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -51,67 +51,18 @@ variant beast_ubasan
 
 path-constant TEST_MAIN : include/boost/beast/_experimental/unit_test/main.cpp ;
 
-lib static_beast
-    : test/lib_beast.cpp
-    : requirements
-        [ requires
-            cxx11_constexpr
-            cxx11_decltype
-            cxx11_hdr_tuple
-            cxx11_template_aliases
-            cxx11_variadic_templates
-        ]
-        <define>BOOST_BEAST_SPLIT_COMPILATION
-        <define>BOOST_ASIO_SEPARATE_COMPILATION
-        <define>BOOST_ASIO_NO_DEPRECATED=1
-        <define>BOOST_ASIO_DISABLE_BOOST_ARRAY=1
-        <define>BOOST_ASIO_DISABLE_BOOST_BIND=1
-        <define>BOOST_ASIO_DISABLE_BOOST_DATE_TIME=1
-        <define>BOOST_ASIO_DISABLE_BOOST_REGEX=1
-        <define>BOOST_COROUTINES_NO_DEPRECATION_WARNING=1
-        <toolset>msvc-14.1:<cxxflags>"/permissive-"
-        <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS=1
-        <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS=1
-        <toolset>msvc:<define>_SILENCE_CXX17_ALLOCATOR_VOID_DEPRECATION_WARNING
-        <toolset>msvc:<define>_SILENCE_CXX17_ADAPTOR_TYPEDEFS_DEPRECATION_WARNING
-        <target-os>windows:<define>_WIN32_WINNT=0x0601
-        <link>static
-    : usage-requirements
-        <define>BOOST_BEAST_SPLIT_COMPILATION
-        <define>BOOST_ASIO_SEPARATE_COMPILATION
-        <define>BOOST_ASIO_NO_DEPRECATED=1
-        <define>BOOST_ASIO_DISABLE_BOOST_ARRAY=1
-        <define>BOOST_ASIO_DISABLE_BOOST_BIND=1
-        <define>BOOST_ASIO_DISABLE_BOOST_DATE_TIME=1
-        <define>BOOST_ASIO_DISABLE_BOOST_REGEX=1
-        <define>BOOST_COROUTINES_NO_DEPRECATION_WARNING=1
-        <toolset>msvc-14.1:<cxxflags>"/permissive-"
-        <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS=1
-        <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS=1
-        <toolset>msvc:<define>_SILENCE_CXX17_ALLOCATOR_VOID_DEPRECATION_WARNING
-        <toolset>msvc:<define>_SILENCE_CXX17_ADAPTOR_TYPEDEFS_DEPRECATION_WARNING
-        <target-os>windows:<define>_WIN32_WINNT=0x0601
-    ;
-lib static_ssl_asio
-    : test/lib_ssl.cpp
-    : requirements
-        <link>static
-        <library>static_beast
-        [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl/<link>shared : <build>no ]
-        [ ac.check-library /boost/beast//crypto : <library>/boost/beast//crypto/<link>shared : <build>no ]
-    ;
-
 project /boost/beast
   : requirements
+    [ requires
+    cxx11_constexpr
+    cxx11_decltype
+    cxx11_hdr_tuple
+    cxx11_template_aliases
+    cxx11_variadic_templates
+    ]
     <include>.
     <include>./test/extras/include
-    <library>/boost/coroutine//boost_coroutine
-    <library>/boost/filesystem//boost_filesystem
-    <library>static_beast
     <implicit-dependency>/boost//headers
-    <threading>multi
-    <debug-symbols>on
-    <runtime-link>shared
     <define>BOOST_ALL_NO_LIB=1
     <define>BOOST_BEAST_SPLIT_COMPILATION
     <define>BOOST_ASIO_SEPARATE_COMPILATION
@@ -145,7 +96,17 @@ project /boost/beast
     <target-os>hpux:<library>ipv6
     <target-os>qnxnto:<library>socket
     <target-os>haiku:<library>network
-
   : usage-requirements
   ;
 
+lib static_beast
+    : test/lib_beast.cpp
+    ;
+
+lib static_ssl_asio
+    : test/lib_ssl.cpp
+    : requirements
+        <library>/boost/beast//static_beast/<link>static
+        [ ac.check-library /boost/beast//ssl : <library>/boost/beast//ssl/<link>shared : <build>no ]
+        [ ac.check-library /boost/beast//crypto : <library>/boost/beast//crypto/<link>shared : <build>no ]
+    ;

--- a/example/advanced/server-flex/Jamfile
+++ b/example/advanced/server-flex/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe advanced-server-flex :

--- a/example/advanced/server/Jamfile
+++ b/example/advanced/server/Jamfile
@@ -12,4 +12,5 @@ exe advanced-server :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_beast/<link>static
     ;

--- a/example/echo-op/Jamfile
+++ b/example/echo-op/Jamfile
@@ -12,4 +12,5 @@ exe echo-op :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_beast/<link>static
     ;

--- a/example/http/client/async-ssl/Jamfile
+++ b/example/http/client/async-ssl/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe http-client-async-ssl :

--- a/example/http/client/async/Jamfile
+++ b/example/http/client/async/Jamfile
@@ -12,4 +12,5 @@ exe http-client-async :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_beast/<link>static
     ;

--- a/example/http/client/coro-ssl/Jamfile
+++ b/example/http/client/coro-ssl/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe http-client-coro-ssl :
@@ -19,4 +19,5 @@ exe http-client-coro-ssl :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/coroutine//boost_coroutine
     ;

--- a/example/http/client/coro/Jamfile
+++ b/example/http/client/coro/Jamfile
@@ -12,4 +12,6 @@ exe http-client-coro :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_beast/<link>static
+    <library>/boost/coroutine//boost_coroutine
     ;

--- a/example/http/client/crawl/Jamfile
+++ b/example/http/client/crawl/Jamfile
@@ -13,4 +13,5 @@ exe http-crawl :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_beast/<link>static
     ;

--- a/example/http/client/sync-ssl/Jamfile
+++ b/example/http/client/sync-ssl/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe http-client-sync-ssl :

--- a/example/http/client/sync/Jamfile
+++ b/example/http/client/sync/Jamfile
@@ -12,4 +12,5 @@ exe http-client-sync :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_beast/<link>static
     ;

--- a/example/http/server/async-ssl/Jamfile
+++ b/example/http/server/async-ssl/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe http-server-async-ssl :

--- a/example/http/server/async/Jamfile
+++ b/example/http/server/async/Jamfile
@@ -12,4 +12,5 @@ exe http-server-async :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_ssl_asio/<link>static
     ;

--- a/example/http/server/coro-ssl/Jamfile
+++ b/example/http/server/coro-ssl/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe http-server-coro-ssl :
@@ -19,4 +19,5 @@ exe http-server-coro-ssl :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/coroutine//boost_coroutine
     ;

--- a/example/http/server/coro/Jamfile
+++ b/example/http/server/coro/Jamfile
@@ -12,4 +12,6 @@ exe http-server-coro :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_ssl_asio/<link>static
+    <library>/boost/coroutine//boost_coroutine
     ;

--- a/example/http/server/fast/Jamfile
+++ b/example/http/server/fast/Jamfile
@@ -16,4 +16,6 @@ exe http-server-fast :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_ssl_asio/<link>static
+    <library>/boost/coroutine//boost_coroutine
     ;

--- a/example/http/server/flex/Jamfile
+++ b/example/http/server/flex/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe http-server-flex :

--- a/example/http/server/small/Jamfile
+++ b/example/http/server/small/Jamfile
@@ -12,4 +12,5 @@ exe http-server-small :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_ssl_asio/<link>static
     ;

--- a/example/http/server/stackless-ssl/Jamfile
+++ b/example/http/server/stackless-ssl/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe http-server-stackless-ssl :

--- a/example/http/server/stackless/Jamfile
+++ b/example/http/server/stackless/Jamfile
@@ -12,4 +12,5 @@ exe http-server-stackless :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_ssl_asio/<link>static
     ;

--- a/example/http/server/sync-ssl/Jamfile
+++ b/example/http/server/sync-ssl/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe http-server-sync-ssl :

--- a/example/http/server/sync/Jamfile
+++ b/example/http/server/sync/Jamfile
@@ -12,4 +12,5 @@ exe http-server-sync :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_ssl_asio/<link>static
     ;

--- a/example/websocket/client/async-ssl/Jamfile
+++ b/example/websocket/client/async-ssl/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe websocket-client-async-ssl :

--- a/example/websocket/client/async/Jamfile
+++ b/example/websocket/client/async/Jamfile
@@ -12,4 +12,5 @@ exe websocket-client-async :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_beast/<link>static
     ;

--- a/example/websocket/client/coro-ssl/Jamfile
+++ b/example/websocket/client/coro-ssl/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe websocket-client-coro-ssl :
@@ -19,4 +19,5 @@ exe websocket-client-coro-ssl :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/coroutine//boost_coroutine
     ;

--- a/example/websocket/client/coro/Jamfile
+++ b/example/websocket/client/coro/Jamfile
@@ -12,4 +12,6 @@ exe websocket-client-coro :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_beast/<link>static
+    <library>/boost/coroutine//boost_coroutine
     ;

--- a/example/websocket/client/sync-ssl/Jamfile
+++ b/example/websocket/client/sync-ssl/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe websocket-client-sync-ssl :

--- a/example/websocket/client/sync/Jamfile
+++ b/example/websocket/client/sync/Jamfile
@@ -12,4 +12,5 @@ exe websocket-client-sync :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_beast/<link>static
     ;

--- a/example/websocket/server/async-ssl/Jamfile
+++ b/example/websocket/server/async-ssl/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe websocket-server-async-ssl :

--- a/example/websocket/server/async/Jamfile
+++ b/example/websocket/server/async/Jamfile
@@ -12,4 +12,5 @@ exe websocket-server-async :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_beast/<link>static
     ;

--- a/example/websocket/server/chat-multi/Jamfile
+++ b/example/websocket/server/chat-multi/Jamfile
@@ -16,4 +16,5 @@ exe websocket-chat-multi :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_beast/<link>static
     ;

--- a/example/websocket/server/coro-ssl/Jamfile
+++ b/example/websocket/server/coro-ssl/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe websocket-server-coro-ssl :
@@ -19,4 +19,5 @@ exe websocket-server-coro-ssl :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/coroutine//boost_coroutine
     ;

--- a/example/websocket/server/coro/Jamfile
+++ b/example/websocket/server/coro/Jamfile
@@ -12,4 +12,6 @@ exe websocket-server-coro :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_beast/<link>static
+    <library>/boost/coroutine//boost_coroutine
     ;

--- a/example/websocket/server/fast/Jamfile
+++ b/example/websocket/server/fast/Jamfile
@@ -12,4 +12,6 @@ exe websocket-server-fast :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_beast/<link>static
+    <library>/boost/coroutine//boost_coroutine
     ;

--- a/example/websocket/server/stackless-ssl/Jamfile
+++ b/example/websocket/server/stackless-ssl/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe websocket-server-stackless-ssl :

--- a/example/websocket/server/stackless/Jamfile
+++ b/example/websocket/server/stackless/Jamfile
@@ -12,4 +12,5 @@ exe websocket-server-stackless :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_beast/<link>static
     ;

--- a/example/websocket/server/sync-ssl/Jamfile
+++ b/example/websocket/server/sync-ssl/Jamfile
@@ -11,7 +11,7 @@ import ac ;
 
 project
     : requirements
-        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio : <build>no ]
+        [ ac.check-library /boost/beast//static_ssl_asio : <library>/boost/beast//static_ssl_asio/<link>static : <build>no ]
     ;
 
 exe websocket-server-sync-ssl :

--- a/example/websocket/server/sync/Jamfile
+++ b/example/websocket/server/sync/Jamfile
@@ -12,4 +12,5 @@ exe websocket-server-sync :
     :
     <variant>coverage:<build>no
     <variant>ubasan:<build>no
+    <library>/boost/beast//static_beast/<link>static
     ;

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -10,6 +10,12 @@
 import testing ;
 import ../../config/checks/config : requires ;
 
+lib test_main
+    : $(TEST_MAIN)
+    : requirements
+
+    ;
+
 project /boost/beast/test
     : requirements
     [ requires
@@ -23,8 +29,10 @@ project /boost/beast/test
     <include>./extern
     <define>BOOST_BEAST_ALLOW_DEPRECATED
     <define>BOOST_BEAST_TESTS
-    <define>BOOST_ASIO_SEPARATE_COMPILATION
-    <library>/boost/beast//static_ssl_asio
+    <library>/boost/beast//static_ssl_asio/<link>static
+    <library>/boost/beast/test//test_main/<link>static
+    <library>/boost/filesystem//boost_filesystem
+    <library>/boost/coroutine//boost_coroutine
     ;
 
 path-constant ZLIB_SOURCES :

--- a/test/beast/_experimental/Jamfile
+++ b/test/beast/_experimental/Jamfile
@@ -17,15 +17,15 @@ local RUN_TESTS ;
 
 for local f in $(SOURCES)
 {
-    RUN_TESTS += [ run $(f) $(TEST_MAIN) ] ;
+    RUN_TESTS += [ run $(f)  ] ;
 }
 
 alias run-tests : $(RUN_TESTS) ;
 
-exe fat-tests : $(TEST_MAIN) $(SOURCES) ;
+exe fat-tests :  $(SOURCES) ;
 
 explicit fat-tests ;
 
-run $(TEST_MAIN) $(SOURCES) : : : : run-fat-tests ;
+run  $(SOURCES) : : : : run-fat-tests ;
 
 explicit run-fat-tests ;

--- a/test/beast/core/Jamfile
+++ b/test/beast/core/Jamfile
@@ -61,15 +61,15 @@ local RUN_TESTS ;
 
 for local f in $(SOURCES)
 {
-    RUN_TESTS += [ run $(f) $(TEST_MAIN) ] ;
+    RUN_TESTS += [ run $(f) ] ;
 }
 
 alias run-tests : $(RUN_TESTS) ;
 
-exe fat-tests : $(TEST_MAIN) $(SOURCES) ;
+exe fat-tests : $(SOURCES) ;
 
 explicit fat-tests ;
 
-run $(TEST_MAIN) $(SOURCES) : : : : run-fat-tests ;
+run $(SOURCES) : : : : run-fat-tests ;
 
 explicit run-fat-tests ;

--- a/test/beast/http/Jamfile
+++ b/test/beast/http/Jamfile
@@ -36,15 +36,15 @@ local RUN_TESTS ;
 
 for local f in $(SOURCES)
 {
-    RUN_TESTS += [ run $(f) $(TEST_MAIN) ] ;
+    RUN_TESTS += [ run $(f)  ] ;
 }
 
 alias run-tests : $(RUN_TESTS) ;
 
-exe fat-tests : $(TEST_MAIN) $(SOURCES) ;
+exe fat-tests :  $(SOURCES) ;
 
 explicit fat-tests ;
 
-run $(TEST_MAIN) $(SOURCES) : : : : run-fat-tests ;
+run  $(SOURCES) : : : : run-fat-tests ;
 
 explicit run-fat-tests ;

--- a/test/beast/ssl/Jamfile
+++ b/test/beast/ssl/Jamfile
@@ -15,15 +15,15 @@ local RUN_TESTS ;
 
 for local f in $(SOURCES)
 {
-    RUN_TESTS += [ run $(f) $(TEST_MAIN) ] ;
+    RUN_TESTS += [ run $(f)  ] ;
 }
 
 alias run-tests : $(RUN_TESTS) ;
 
-exe fat-tests : $(TEST_MAIN) $(SOURCES) ;
+exe fat-tests :  $(SOURCES) ;
 
 explicit fat-tests ;
 
-run $(TEST_MAIN) $(SOURCES) : : : : run-fat-tests ;
+run  $(SOURCES) : : : : run-fat-tests ;
 
 explicit run-fat-tests ;

--- a/test/beast/websocket/Jamfile
+++ b/test/beast/websocket/Jamfile
@@ -37,15 +37,15 @@ local RUN_TESTS ;
 
 for local f in $(SOURCES)
 {
-    RUN_TESTS += [ run $(f) $(TEST_MAIN) ] ;
+    RUN_TESTS += [ run $(f)  ] ;
 }
 
 alias run-tests : $(RUN_TESTS) ;
 
-exe fat-tests : $(TEST_MAIN) $(SOURCES) ;
+exe fat-tests :  $(SOURCES) ;
 
 explicit fat-tests ;
 
-run $(TEST_MAIN) $(SOURCES) : : : : run-fat-tests ;
+run  $(SOURCES) : : : : run-fat-tests ;
 
 explicit run-fat-tests ;

--- a/test/beast/zlib/Jamfile
+++ b/test/beast/zlib/Jamfile
@@ -18,15 +18,15 @@ local RUN_TESTS ;
 
 for local f in $(SOURCES)
 {
-    RUN_TESTS += [ run $(f) $(TEST_MAIN) $(ZLIB_SOURCES) ] ;
+    RUN_TESTS += [ run $(f)  $(ZLIB_SOURCES) ] ;
 }
 
 alias run-tests : $(RUN_TESTS) ;
 
-exe fat-tests : $(TEST_MAIN) $(ZLIB_SOURCES) $(SOURCES) ;
+exe fat-tests :  $(ZLIB_SOURCES) $(SOURCES) ;
 
 explicit fat-tests ;
 
-run $(TEST_MAIN) $(ZLIB_SOURCES) $(SOURCES) : : : : run-fat-tests ;
+run  $(ZLIB_SOURCES) $(SOURCES) : : : : run-fat-tests ;
 
 explicit run-fat-tests ;

--- a/test/bench/buffers/Jamfile
+++ b/test/bench/buffers/Jamfile
@@ -8,7 +8,7 @@
 #
 
 exe bench-buffers :
-    $(TEST_MAIN)
+
     bench_buffers.cpp
     ;
 

--- a/test/bench/parser/Jamfile
+++ b/test/bench/parser/Jamfile
@@ -7,7 +7,7 @@
 # Official repository: https://github.com/boostorg/beast
 #
 
-run $(TEST_MAIN) nodejs_parser.cpp bench_parser.cpp : : : : bench-parser ;
+run  nodejs_parser.cpp bench_parser.cpp : : : : bench-parser ;
 
 explicit bench-parser ;
 

--- a/test/bench/utf8_checker/Jamfile
+++ b/test/bench/utf8_checker/Jamfile
@@ -8,7 +8,7 @@
 #
 
 exe bench-utf8-checker :
-    $(TEST_MAIN)
+
     bench_utf8_checker.cpp
     ;
 

--- a/test/bench/zlib/Jamfile
+++ b/test/bench/zlib/Jamfile
@@ -9,7 +9,7 @@
 
 exe bench-zlib :
     $(ZLIB_SOURCES)
-    $(TEST_MAIN)
+
     deflate_stream.cpp
     inflate_stream.cpp
     ;

--- a/test/doc/Jamfile
+++ b/test/doc/Jamfile
@@ -18,24 +18,24 @@ project
 alias run-tests :
     [ compile core_snippets.cpp ]
     [ compile http_snippets.cpp ]
-    [ run core_1_refresher.cpp $(TEST_MAIN) ]
-    [ run core_3_timeouts.cpp $(TEST_MAIN) ]
-    [ run core_4_layers.cpp $(TEST_MAIN) ]
-    [ run http_10_custom_parser.cpp $(TEST_MAIN) ]
-    [ run http_examples.cpp $(TEST_MAIN) ]
-    [ run websocket.cpp $(TEST_MAIN) ]
-    [ run websocket_1_connecting.cpp $(TEST_MAIN) ]
-    [ run websocket_2_handshaking.cpp $(TEST_MAIN) ]
-    [ run websocket_3_decorator.cpp $(TEST_MAIN) ]
-    [ run websocket_4_messages.cpp $(TEST_MAIN) ]
-    [ run websocket_5_control_frames.cpp $(TEST_MAIN) ]
-    [ run websocket_6_timeouts.cpp $(TEST_MAIN) ]
-    [ run websocket_7_teardown.cpp $(TEST_MAIN) ]
-    [ run websocket_8_notes.cpp $(TEST_MAIN) ]
+    [ run core_1_refresher.cpp  ]
+    [ run core_3_timeouts.cpp  ]
+    [ run core_4_layers.cpp  ]
+    [ run http_10_custom_parser.cpp  ]
+    [ run http_examples.cpp  ]
+    [ run websocket.cpp  ]
+    [ run websocket_1_connecting.cpp  ]
+    [ run websocket_2_handshaking.cpp  ]
+    [ run websocket_3_decorator.cpp  ]
+    [ run websocket_4_messages.cpp  ]
+    [ run websocket_5_control_frames.cpp  ]
+    [ run websocket_6_timeouts.cpp  ]
+    [ run websocket_7_teardown.cpp  ]
+    [ run websocket_8_notes.cpp  ]
     ;
 
 exe fat-tests :
-    $(TEST_MAIN)
+
     core_1_refresher.cpp
     core_3_timeouts.cpp
     core_4_layers.cpp
@@ -54,6 +54,6 @@ exe fat-tests :
 
 explicit fat-tests ;
 
-run $(TEST_MAIN) $(SOURCES) : : : : run-fat-tests ;
+run  $(SOURCES) : : : : run-fat-tests ;
 
 explicit run-fat-tests ;

--- a/test/example/Jamfile
+++ b/test/example/Jamfile
@@ -15,6 +15,6 @@ alias fat-tests ;
 
 explicit fat-tests ;
 
-run $(TEST_MAIN) $(SOURCES) : : : : run-fat-tests ;
+run  $(SOURCES) : : : : run-fat-tests ;
 
 explicit run-fat-tests ;


### PR DESCRIPTION
- Don't set the global link settings (`<link>`) to avoid dependency
ordering issues in the future.
- Allow the user to decide on the link settings for dependencies
(filesystem/coroutine).
- Make dependencies in examples explicit.
- Remove dependency of examples on Boost.Filesystem (was not used there).
- Deduplicate build settings.
- Speed up test compilation by avoiding rebuilding of main test file.