### PR TITLE
Cleanup endianness conversions:

### DIFF
--- a/include/boost/beast/websocket/detail/frame.hpp
+++ b/include/boost/beast/websocket/detail/frame.hpp
@@ -14,76 +14,16 @@
 #include <boost/beast/websocket/error.hpp>
 #include <boost/beast/websocket/rfc6455.hpp>
 #include <boost/beast/websocket/detail/utf8_checker.hpp>
-#include <boost/beast/core/buffers_suffix.hpp>
 #include <boost/beast/core/flat_static_buffer.hpp>
-#include <boost/beast/core/static_string.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/assert.hpp>
-// This is for <boost/endian/buffers.hpp>
-#if BOOST_WORKAROUND(BOOST_MSVC, > 0)
-# pragma warning (push)
-# pragma warning (disable: 4127) // conditional expression is constant
-#endif
-#include <boost/endian/buffers.hpp>
-#if BOOST_WORKAROUND(BOOST_MSVC, > 0)
-# pragma warning (pop)
-#endif
+#include <boost/endian/conversion.hpp>
 #include <cstdint>
 
 namespace boost {
 namespace beast {
 namespace websocket {
 namespace detail {
-
-inline
-std::uint16_t
-big_uint16_to_native(void const* buf)
-{
-    auto const p = static_cast<
-        std::uint8_t const*>(buf);
-    return (p[0]<<8) + p[1];
-}
-
-inline
-std::uint64_t
-big_uint64_to_native(void const* buf)
-{
-    auto const p = static_cast<
-        std::uint8_t const*>(buf);
-    return
-        (static_cast<std::uint64_t>(p[0])<<56) +
-        (static_cast<std::uint64_t>(p[1])<<48) +
-        (static_cast<std::uint64_t>(p[2])<<40) +
-        (static_cast<std::uint64_t>(p[3])<<32) +
-        (static_cast<std::uint64_t>(p[4])<<24) +
-        (static_cast<std::uint64_t>(p[5])<<16) +
-        (static_cast<std::uint64_t>(p[6])<< 8) +
-                                    p[7];
-}
-
-inline
-std::uint32_t
-little_uint32_to_native(void const* buf)
-{
-    auto const p = static_cast<
-        std::uint8_t const*>(buf);
-    return
-                                    p[0] +
-        (static_cast<std::uint32_t>(p[1])<< 8) +
-        (static_cast<std::uint32_t>(p[2])<<16) +
-        (static_cast<std::uint32_t>(p[3])<<24);
-}
-
-inline
-void
-native_to_little_uint32(std::uint32_t v, void* buf)
-{
-    auto p = static_cast<std::uint8_t*>(buf);
-    p[0] =  v        & 0xff;
-    p[1] = (v >>  8) & 0xff;
-    p[2] = (v >> 16) & 0xff;
-    p[3] = (v >> 24) & 0xff;
-}
 
 // frame header opcodes
 enum class opcode : std::uint8_t
@@ -193,7 +133,6 @@ template<class DynamicBuffer>
 void
 write(DynamicBuffer& db, frame_header const& fh)
 {
-    using namespace boost::endian;
     std::size_t n;
     std::uint8_t b[14];
     b[0] = (fh.fin ? 0x80 : 0x00) | static_cast<std::uint8_t>(fh.op);
@@ -212,19 +151,24 @@ write(DynamicBuffer& db, frame_header const& fh)
     else if(fh.len <= 65535)
     {
         b[1] |= 126;
-        ::new(&b[2]) big_uint16_buf_t{
-            (std::uint16_t)fh.len};
+        auto len_be = endian::native_to_big(
+            static_cast<std::uint16_t>(fh.len));
+        std::memcpy(&b[2], &len_be, sizeof(len_be));
         n = 4;
     }
     else
     {
         b[1] |= 127;
-        ::new(&b[2]) big_uint64_buf_t{fh.len};
+        auto len_be = endian::native_to_big(
+            static_cast<std::uint64_t>(fh.len));
+        std::memcpy(&b[2], &len_be, sizeof(len_be));
         n = 10;
     }
     if(fh.mask)
     {
-        native_to_little_uint32(fh.key, &b[n]);
+        auto key_le = endian::native_to_little(
+            static_cast<std::uint32_t>(fh.key));
+        std::memcpy(&b[n], &key_le, sizeof(key_le));
         n += 4;
     }
     db.commit(net::buffer_copy(
@@ -254,8 +198,7 @@ read_close(
     Buffers const& bs,
     error_code& ec)
 {
-    using namespace boost::endian;
-    auto n = buffer_bytes(bs);
+    auto const n = buffer_bytes(bs);
     BOOST_ASSERT(n <= 125);
     if(n == 0)
     {
@@ -269,36 +212,29 @@ read_close(
         ec = error::bad_close_size;
         return;
     }
-    buffers_suffix<Buffers> cb(bs);
+
+    std::uint16_t code_be;
+    cr.reason.resize(n - 2);
+    std::array<net::mutable_buffer, 2> out_bufs{
+        net::mutable_buffer(&code_be, sizeof(code_be)),
+        net::mutable_buffer(&cr.reason[0], n - 2)};
+
+    net::buffer_copy(out_bufs, bs);
+
+    cr.code = endian::big_to_native(code_be);
+    if(! is_valid_close_code(cr.code))
     {
-        std::uint8_t b[2];
-        net::buffer_copy(net::buffer(b), cb);
-        cr.code = big_uint16_to_native(&b[0]);
-        cb.consume(2);
-        n -= 2;
-        if(! is_valid_close_code(cr.code))
-        {
-            // invalid close code
-            ec = error::bad_close_code;
-            return;
-        }
+        // invalid close code
+        ec = error::bad_close_code;
+        return;
     }
-    if(n > 0)
+
+    if(n > 2 && !check_utf8(
+        cr.reason.data(), cr.reason.size()))
     {
-        cr.reason.resize(n);
-        net::buffer_copy(
-            net::buffer(&cr.reason[0], n), cb);
-        if(! check_utf8(
-            cr.reason.data(), cr.reason.size()))
-        {
-            // not valid utf-8
-            ec = error::bad_close_payload;
-            return;
-        }
-    }
-    else
-    {
-        cr.reason = "";
+        // not valid utf-8
+        ec = error::bad_close_payload;
+        return;
     }
     ec = {};
 }

--- a/include/boost/beast/websocket/impl/stream.hpp
+++ b/include/boost/beast/websocket/impl/stream.hpp
@@ -29,7 +29,6 @@
 #include <boost/asio/bind_executor.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/assert.hpp>
-#include <boost/endian/buffers.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/throw_exception.hpp>
 #include <algorithm>

--- a/include/boost/beast/websocket/impl/stream_impl.hpp
+++ b/include/boost/beast/websocket/impl/stream_impl.hpp
@@ -767,10 +767,12 @@ parse_fh(
     {
     case 126:
     {
-        std::uint8_t tmp[2];
-        BOOST_ASSERT(buffer_bytes(cb) >= sizeof(tmp));
-        cb.consume(net::buffer_copy(net::buffer(tmp), cb));
-        fh.len = detail::big_uint16_to_native(&tmp[0]);
+
+        std::uint16_t len_be;
+        BOOST_ASSERT(buffer_bytes(cb) >= sizeof(len_be));
+        cb.consume(net::buffer_copy(
+            net::mutable_buffer(&len_be, sizeof(len_be)), cb));
+        fh.len = endian::big_to_native(len_be);
         if(fh.len < 126)
         {
             // length not canonical
@@ -781,10 +783,11 @@ parse_fh(
     }
     case 127:
     {
-        std::uint8_t tmp[8];
-        BOOST_ASSERT(buffer_bytes(cb) >= sizeof(tmp));
-        cb.consume(net::buffer_copy(net::buffer(tmp), cb));
-        fh.len = detail::big_uint64_to_native(&tmp[0]);
+        std::uint64_t len_be;
+        BOOST_ASSERT(buffer_bytes(cb) >= sizeof(len_be));
+        cb.consume(net::buffer_copy(
+            net::mutable_buffer(&len_be, sizeof(len_be)), cb));
+        fh.len = endian::big_to_native(len_be);
         if(fh.len < 65536)
         {
             // length not canonical
@@ -796,10 +799,11 @@ parse_fh(
     }
     if(fh.mask)
     {
-        std::uint8_t tmp[4];
-        BOOST_ASSERT(buffer_bytes(cb) >= sizeof(tmp));
-        cb.consume(net::buffer_copy(net::buffer(tmp), cb));
-        fh.key = detail::little_uint32_to_native(&tmp[0]);
+        std::uint32_t key_le;
+        BOOST_ASSERT(buffer_bytes(cb) >= sizeof(key_le));
+        cb.consume(net::buffer_copy(
+            net::mutable_buffer(&key_le, sizeof(key_le)), cb));
+        fh.key = endian::little_to_native(key_le);
         detail::prepare_key(rd_key, fh.key);
     }
     else
@@ -905,12 +909,10 @@ write_close(DynamicBuffer& db, close_reason const& cr)
         if(fh.mask)
             detail::prepare_key(key, fh.key);
         {
-            std::uint8_t tmp[2];
-            ::new(&tmp[0]) big_uint16_buf_t{
-                (std::uint16_t)cr.code};
+            auto code_be = endian::native_to_big<std::uint16_t>(cr.code);
             auto mb = db.prepare(2);
             net::buffer_copy(mb,
-                net::buffer(tmp));
+                net::const_buffer(&code_be, sizeof(code_be)));
             if(fh.mask)
                 detail::mask_inplace(mb, key);
             db.commit(2);


### PR DESCRIPTION
- Use Boost.Endian conversions functions.
- Remove existing private conversion functions.