### PR TITLE
Version 242

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 Version 242:
 
 * test::stream has deprecated lowest_layer for ssl
-* MSVC use ::fopen_s
+* MSVC uses ::fopen_s
+* Fix http::message constructor constraint
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 242:
+
+* test::stream has deprecated lowest_layer for ssl
+
+--------------------------------------------------------------------------------
+
 Version 241:
 
 * Tidy up a doc code snippet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 242:
 * test::stream has deprecated lowest_layer for ssl
 * MSVC uses ::fopen_s
 * Fix http::message constructor constraint
+* Check defined(BOOST_MSVC)
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 242:
 
 * test::stream has deprecated lowest_layer for ssl
+* MSVC use ::fopen_s
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endfunction()
 #
 #-------------------------------------------------------------------------------
 
-project (Beast VERSION 241)
+project (Beast VERSION 242)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/example/advanced/server-flex/advanced_server_flex.cpp
+++ b/example/advanced/server-flex/advanced_server_flex.cpp
@@ -88,7 +88,7 @@ path_cat(
     if(base.empty())
         return std::string(path);
     std::string result(base);
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
     char constexpr path_separator = '\\';
     if(result.back() == path_separator)
         result.resize(result.size() - 1);

--- a/example/advanced/server/advanced_server.cpp
+++ b/example/advanced/server/advanced_server.cpp
@@ -83,7 +83,7 @@ path_cat(
     if(base.empty())
         return std::string(path);
     std::string result(base);
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
     char constexpr path_separator = '\\';
     if(result.back() == path_separator)
         result.resize(result.size() - 1);

--- a/example/http/server/async-ssl/http_server_async_ssl.cpp
+++ b/example/http/server/async-ssl/http_server_async_ssl.cpp
@@ -82,7 +82,7 @@ path_cat(
     if(base.empty())
         return std::string(path);
     std::string result(base);
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
     char constexpr path_separator = '\\';
     if(result.back() == path_separator)
         result.resize(result.size() - 1);

--- a/example/http/server/async/http_server_async.cpp
+++ b/example/http/server/async/http_server_async.cpp
@@ -78,7 +78,7 @@ path_cat(
     if(base.empty())
         return std::string(path);
     std::string result(base);
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
     char constexpr path_separator = '\\';
     if(result.back() == path_separator)
         result.resize(result.size() - 1);

--- a/example/http/server/coro-ssl/http_server_coro_ssl.cpp
+++ b/example/http/server/coro-ssl/http_server_coro_ssl.cpp
@@ -81,7 +81,7 @@ path_cat(
     if(base.empty())
         return std::string(path);
     std::string result(base);
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
     char constexpr path_separator = '\\';
     if(result.back() == path_separator)
         result.resize(result.size() - 1);

--- a/example/http/server/coro/http_server_coro.cpp
+++ b/example/http/server/coro/http_server_coro.cpp
@@ -78,7 +78,7 @@ path_cat(
     if(base.empty())
         return std::string(path);
     std::string result(base);
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
     char constexpr path_separator = '\\';
     if(result.back() == path_separator)
         result.resize(result.size() - 1);

--- a/example/http/server/flex/http_server_flex.cpp
+++ b/example/http/server/flex/http_server_flex.cpp
@@ -81,7 +81,7 @@ path_cat(
     if(base.empty())
         return std::string(path);
     std::string result(base);
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
     char constexpr path_separator = '\\';
     if(result.back() == path_separator)
         result.resize(result.size() - 1);

--- a/example/http/server/stackless-ssl/http_server_stackless_ssl.cpp
+++ b/example/http/server/stackless-ssl/http_server_stackless_ssl.cpp
@@ -83,7 +83,7 @@ path_cat(
     if(base.empty())
         return std::string(path);
     std::string result(base);
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
     char constexpr path_separator = '\\';
     if(result.back() == path_separator)
         result.resize(result.size() - 1);

--- a/example/http/server/stackless/http_server_stackless.cpp
+++ b/example/http/server/stackless/http_server_stackless.cpp
@@ -79,7 +79,7 @@ path_cat(
     if(base.empty())
         return std::string(path);
     std::string result(base);
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
     char constexpr path_separator = '\\';
     if(result.back() == path_separator)
         result.resize(result.size() - 1);

--- a/example/http/server/sync-ssl/http_server_sync_ssl.cpp
+++ b/example/http/server/sync-ssl/http_server_sync_ssl.cpp
@@ -80,7 +80,7 @@ path_cat(
     if(base.empty())
         return std::string(path);
     std::string result(base);
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
     char constexpr path_separator = '\\';
     if(result.back() == path_separator)
         result.resize(result.size() - 1);

--- a/example/http/server/sync/http_server_sync.cpp
+++ b/example/http/server/sync/http_server_sync.cpp
@@ -77,7 +77,7 @@ path_cat(
 	if (base.empty())
 		return std::string(path);
     std::string result(base);
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
     char constexpr path_separator = '\\';
     if(result.back() == path_separator)
         result.resize(result.size() - 1);

--- a/example/websocket/server/chat-multi/http_session.cpp
+++ b/example/websocket/server/chat-multi/http_session.cpp
@@ -62,7 +62,7 @@ path_cat(
     if(base.empty())
         return std::string(path);
     std::string result(base);
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
     char constexpr path_separator = '\\';
     if(result.back() == path_separator)
         result.resize(result.size() - 1);

--- a/include/boost/beast/_experimental/test/stream.hpp
+++ b/include/boost/beast/_experimental/test/stream.hpp
@@ -32,6 +32,16 @@
 #include <mutex>
 #include <utility>
 
+#if ! BOOST_BEAST_DOXYGEN
+namespace boost {
+namespace asio {
+namespace ssl {
+template<typename> class stream;
+} // ssl
+} // asio
+} // boost
+#endif
+
 namespace boost {
 namespace beast {
 namespace test {
@@ -173,6 +183,27 @@ class stream
         boost::shared_ptr<state> const& in,
         std::unique_ptr<read_op_base>&& op,
         std::size_t buf_size);
+
+#if ! BOOST_BEAST_DOXYGEN
+    // boost::asio::ssl::stream needs these
+    // DEPRECATED
+    template<class>
+    friend class boost::asio::ssl::stream;
+    // DEPRECATED
+    using lowest_layer_type = stream;
+    // DEPRECATED
+    lowest_layer_type&
+    lowest_layer() noexcept
+    {
+        return *this;
+    }
+    // DEPRECATED
+    lowest_layer_type const&
+    lowest_layer() const noexcept
+    {
+        return *this;
+    }
+#endif
 
 public:
     using buffer_type = flat_buffer;

--- a/include/boost/beast/_experimental/unit_test/main.ipp
+++ b/include/boost/beast/_experimental/unit_test/main.ipp
@@ -38,7 +38,7 @@ int main(int ac, char const* av[])
     dstream log(std::cerr);
     std::unitbuf(log);
 
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
     {
         int flags = _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG);
         flags |= _CRTDBG_LEAK_CHECK_DF;

--- a/include/boost/beast/http/message.hpp
+++ b/include/boost/beast/http/message.hpp
@@ -223,7 +223,7 @@ public:
             ! std::is_convertible<typename
                 std::decay<Arg1>::type, verb>::value &&
             ! std::is_convertible<typename
-                std::decay<Arg1>::type, header>::value
+                std::decay<Arg1>::type, status>::value
         >::type>
     explicit
     header(Arg1&& arg1, ArgN&&... argn);

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 241
+#define BOOST_BEAST_VERSION 242
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/test/doc/http_snippets.cpp
+++ b/test/doc/http_snippets.cpp
@@ -417,7 +417,7 @@ print(message<isRequest, Body, Fields> const& m)
 
 //]
 
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
 //[http_snippet_16
 
 template<bool isRequest, class Body, class Fields>


### PR DESCRIPTION
* test::stream has deprecated lowest_layer for ssl
* MSVC uses ::fopen_s
