### PR TITLE
Set parser status and flags even if body_limit_ has been reached

### DIFF
--- a/include/boost/beast/http/impl/basic_parser.ipp
+++ b/include/boost/beast/http/impl/basic_parser.ipp
@@ -508,15 +508,16 @@ finish_header(error_code& ec, std::false_type)
     }
     else if(f_ & flagContentLength)
     {
-        if(len_ > body_limit_)
-        {
-            ec = error::body_limit;
-            return;
-        }
         if(len_ > 0)
         {
             f_ |= flagHasBody;
             state_ = state::body0;
+
+            if(len_ > body_limit_)
+            {
+                ec = error::body_limit;
+                return;
+            }
         }
         else
         {


### PR DESCRIPTION
Parsing the header of a request that is larger than 1 MB prevents the setting of body_limit and reading the request body