### PR TITLE
Fix async_base immediate completion

### DIFF
--- a/include/boost/beast/core/async_base.hpp
+++ b/include/boost/beast/core/async_base.hpp
@@ -340,7 +340,7 @@ public:
         if(! is_continuation)
         {
             net::post(net::bind_executor(
-                wg1_.get_executor(),
+                get_executor(),
                 beast::bind_front_handler(
                     std::move(h_),
                     std::forward<Args>(args)...)));
@@ -348,8 +348,8 @@ public:
         }
         else
         {
-            h_(std::forward<Args>(args)...);
             wg1_.reset();
+            h_(std::forward<Args>(args)...);
         }
     }
 

--- a/test/beast/core/async_base.cpp
+++ b/test/beast/core/async_base.cpp
@@ -503,13 +503,17 @@ public:
             op.complete(true);
         }
         {
-            net::io_context ioc;
+            net::io_context ioc1;
+            net::io_context ioc2;
+            auto h = net::bind_executor(ioc2, test::any_handler());
             stable_async_base<
-                test::handler,
+                decltype(h),
                 net::io_context::executor_type> op(
-                    test::any_handler(), ioc.get_executor());
+                    std::move(h),
+                    ioc1.get_executor());
             op.complete(false);
-            ioc.run();
+            BEAST_EXPECT(ioc1.run() == 0);
+            BEAST_EXPECT(ioc2.run() == 1);
         }
         {
             stable_async_base<


### PR DESCRIPTION
`complete(false, ...)` used the wrong executor when an async operation completed immediately, potentially executing the completion handler on the IO executor in some cases.