### PR TITLE
Ensure order of evaluation for executor

### DIFF
--- a/include/boost/beast/core/async_base.hpp
+++ b/include/boost/beast/core/async_base.hpp
@@ -339,8 +339,9 @@ public:
         this->before_invoke_hook();
         if(! is_continuation)
         {
+            auto executor = get_executor();
             net::post(net::bind_executor(
-                get_executor(),
+                executor,
                 beast::bind_front_handler(
                     std::move(h_),
                     std::forward<Args>(args)...)));


### PR DESCRIPTION
Obtain the executor from the handler prior to moving it into net::post