### PR TITLE
Fix compilation on MSVC with std::string_view

### DIFF
--- a/include/boost/beast/http/detail/rfc7230.hpp
+++ b/include/boost/beast/http/detail/rfc7230.hpp
@@ -57,14 +57,6 @@ std::int8_t
 unhex(char c);
 
 BOOST_BEAST_DECL
-void
-skip_ows(char const*& it, char const* end);
-
-BOOST_BEAST_DECL
-void
-skip_token(char const*& it, char const* last);
-
-BOOST_BEAST_DECL
 string_view
 trim(string_view s);
 

--- a/include/boost/beast/http/detail/rfc7230.ipp
+++ b/include/boost/beast/http/detail/rfc7230.ipp
@@ -219,8 +219,9 @@ unhex(char c)
     return tab[static_cast<unsigned char>(c)];
 }
 
+template <class ForwardIt>
 void
-skip_ows(char const*& it, char const* end)
+skip_ows(ForwardIt& it, ForwardIt end)
 {
     while(it != end)
     {
@@ -230,8 +231,9 @@ skip_ows(char const*& it, char const* end)
     }
 }
 
+template <class ForwardIt>
 void
-skip_token(char const*& it, char const* last)
+skip_token(ForwardIt& it, ForwardIt last)
 {
     while(it != last && is_token_char(*it))
         ++it;


### PR DESCRIPTION
std::string_view::iterator is not necessarily a raw pointer.
Resolves: #1572