### PR TITLE
Replace static_string in parser

### DIFF
--- a/include/boost/beast/core/static_string.hpp
+++ b/include/boost/beast/core/static_string.hpp
@@ -16,8 +16,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <initializer_list>
-#include <iterator>
-#include <ostream>
+#include <iosfwd>
 #include <stdexcept>
 #include <string>
 #include <type_traits>

--- a/include/boost/beast/http/detail/basic_parser.hpp
+++ b/include/boost/beast/http/detail/basic_parser.hpp
@@ -10,7 +10,6 @@
 #ifndef BOOST_BEAST_HTTP_DETAIL_BASIC_PARSER_HPP
 #define BOOST_BEAST_HTTP_DETAIL_BASIC_PARSER_HPP
 
-#include <boost/beast/core/static_string.hpp>
 #include <boost/beast/core/string.hpp>
 #include <boost/beast/http/error.hpp>
 #include <boost/beast/http/detail/rfc7230.hpp>
@@ -23,6 +22,59 @@ namespace boost {
 namespace beast {
 namespace http {
 namespace detail {
+
+template <std::size_t N>
+class char_buffer
+{
+public:
+    bool try_push_back(char c)
+    {
+        if (size_ == N)
+            return false;
+        buf_[size_++] = c;
+        return true;
+    }
+
+    bool try_append(char const* first, char const* last)
+    {
+        std::size_t const n = last - first;
+        if (n > N - size_)
+            return false;
+        std::memmove(&buf_[size_], first, n);
+        size_ += n;
+        return true;
+    }
+
+    void clear() noexcept
+    {
+        size_ = 0;
+    }
+
+    char* data() noexcept
+    {
+        return buf_;
+    }
+
+    char const* data() const noexcept
+    {
+        return buf_;
+    }
+
+    std::size_t size() const noexcept
+    {
+        return size_;
+    }
+
+    bool empty() const noexcept
+    {
+        return size_ == 0;
+    }
+
+private:
+    std::size_t size_= 0;
+    char buf_[N];
+};
+
 
 struct basic_parser_base
 {
@@ -182,7 +234,7 @@ struct basic_parser_base
         char const* last,
         string_view& name,
         string_view& value,
-        static_string<max_obs_fold>& buf,
+        char_buffer<max_obs_fold>& buf,
         error_code& ec);
 
     BOOST_BEAST_DECL

--- a/include/boost/beast/http/detail/basic_parser.ipp
+++ b/include/boost/beast/http/detail/basic_parser.ipp
@@ -491,7 +491,7 @@ parse_field(
     char const* last,
     string_view& name,
     string_view& value,
-    static_string<max_obs_fold>& buf,
+    char_buffer<max_obs_fold>& buf,
     error_code& ec)
 {
 /*  header-field    = field-name ":" OWS field-value OWS
@@ -607,63 +607,60 @@ parse_field(
         if(token_last != first)
             break;
     }
-    buf.resize(0);
-    buf.append(first, token_last);
-    BOOST_ASSERT(! buf.empty());
-#ifndef BOOST_NO_EXCEPTIONS
-    try
-#endif
+    buf.clear();
+    if (!buf.try_append(first, token_last))
     {
-        for(;;)
+        ec = error::header_limit;
+        return;
+    }
+
+    BOOST_ASSERT(! buf.empty());
+    for(;;)
+    {
+        // eat leading ' ' and '\t'
+        for(;;++p)
         {
-            // eat leading ' ' and '\t'
-            for(;;++p)
-            {
-                if(p + 1 > last)
-                {
-                    ec = error::need_more;
-                    return;
-                }
-                if(! (*p == ' ' || *p == '\t'))
-                    break;
-            }
-            // parse to CRLF
-            first = p;
-            p = parse_token_to_eol(p, last, token_last, ec);
-            if(ec)
-                return;
-            if(! p)
-            {
-                ec = error::bad_value;
-                return;
-            }
-            // Look 1 char past the CRLF to handle obs-fold.
             if(p + 1 > last)
             {
                 ec = error::need_more;
                 return;
             }
-            token_last = trim_back(token_last, first);
-            if(first != token_last)
+            if(! (*p == ' ' || *p == '\t'))
+                break;
+        }
+        // parse to CRLF
+        first = p;
+        p = parse_token_to_eol(p, last, token_last, ec);
+        if(ec)
+            return;
+        if(! p)
+        {
+            ec = error::bad_value;
+            return;
+        }
+        // Look 1 char past the CRLF to handle obs-fold.
+        if(p + 1 > last)
+        {
+            ec = error::need_more;
+            return;
+        }
+        token_last = trim_back(token_last, first);
+        if(first != token_last)
+        {
+            if (!buf.try_push_back(' ') ||
+                !buf.try_append(first, token_last))
             {
-                buf.push_back(' ');
-                buf.append(first, token_last);
-            }
-            if(*p != ' ' && *p != '\t')
-            {
-                value = {buf.data(), buf.size()};
+                ec = error::header_limit;
                 return;
             }
-            ++p;
         }
+        if(*p != ' ' && *p != '\t')
+        {
+            value = {buf.data(), buf.size()};
+            return;
+        }
+        ++p;
     }
-#ifndef BOOST_NO_EXCEPTIONS
-    catch(std::length_error const&)
-    {
-        ec = error::header_limit;
-        return;
-    }
-#endif
 }
 
 

--- a/include/boost/beast/http/impl/basic_parser.ipp
+++ b/include/boost/beast/http/impl/basic_parser.ipp
@@ -14,7 +14,6 @@
 #include <boost/beast/http/error.hpp>
 #include <boost/beast/http/rfc7230.hpp>
 #include <boost/beast/core/buffer_traits.hpp>
-#include <boost/beast/core/static_string.hpp>
 #include <boost/beast/core/detail/clamp.hpp>
 #include <boost/beast/core/detail/config.hpp>
 #include <boost/asio/buffer.hpp>
@@ -405,7 +404,7 @@ parse_fields(char const*& in,
     string_view name;
     string_view value;
     // https://stackoverflow.com/questions/686217/maximum-on-http-header-values
-    static_string<max_obs_fold> buf;
+    detail::char_buffer<max_obs_fold> buf;
     auto p = in;
     for(;;)
     {


### PR DESCRIPTION
This change yields a modest performance improment of 1-2% by replacing the exception-based handling of buffer overflow with one based on regular conditional checks.