### PR TITLE
Relax requirements for vector_body

### DIFF
--- a/include/boost/beast/http/vector_body.hpp
+++ b/include/boost/beast/http/vector_body.hpp
@@ -39,8 +39,7 @@ template<class T, class Allocator = std::allocator<T>>
 struct vector_body
 {
 private:
-    static_assert(sizeof(T) == 1 &&
-        std::is_integral<T>::value,
+    static_assert(sizeof(T) == 1,
         "T requirements not met");
 
 public:

--- a/test/beast/http/vector_body.cpp
+++ b/test/beast/http/vector_body.cpp
@@ -9,6 +9,7 @@
 
 // Test that header file is self-contained.
 #include <boost/beast/http/vector_body.hpp>
+#include <cstddef>
 
 namespace boost {
 namespace beast {
@@ -17,6 +18,12 @@ namespace http {
 BOOST_STATIC_ASSERT(is_body<vector_body<char>>::value);
 BOOST_STATIC_ASSERT(is_body_writer<vector_body<char>>::value);
 BOOST_STATIC_ASSERT(is_body_reader<vector_body<char>>::value);
+
+#if __cpp_lib_byte >= 201603
+BOOST_STATIC_ASSERT(is_body<vector_body<std::byte>>::value);
+BOOST_STATIC_ASSERT(is_body_writer<vector_body<std::byte>>::value);
+BOOST_STATIC_ASSERT(is_body_reader<vector_body<std::byte>>::value);
+#endif
 
 } // http
 } // beast


### PR DESCRIPTION
std::byte is not an arithmetic type, which caused compilation to fail when it was used in vector_body.