### PR TITLE
Version 256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version 256:
 * `allocator_traits::construct` is used for user-defined types
 * Add 1-element specialization for `buffers_cat`
 * Fix `buffers_cat` iterator tests
+* Don't pessimize-move
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 256:
 * Remove redundant use of `static_string`
 * Remove redundant template in service_base
 * Expand CI matrix using Azure Pipelines
+* Make chat websocket javascript client more user friendly
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Version 256:
 * Make chat websocket javascript client more user friendly
 * `allocator_traits::construct` is used for user-defined types
 * Add 1-element specialization for `buffers_cat`
+* Fix `buffers_cat` iterator tests
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Version 256:
 * Expand CI matrix using Azure Pipelines
 * Make chat websocket javascript client more user friendly
 * `allocator_traits::construct` is used for user-defined types
+* Add 1-element specialization for `buffers_cat`
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 256:
 
 * Remove uses of the deprecated `buffers` function
 * Remove uses of deprecated methods in websocket tests
+* Remove redundant use of `static_string`
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 256:
 * Remove redundant template in service_base
 * Expand CI matrix using Azure Pipelines
 * Make chat websocket javascript client more user friendly
+* `allocator_traits::construct` is used for user-defined types
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 256:
 * Remove uses of deprecated methods in websocket tests
 * Remove redundant use of `static_string`
 * Remove redundant template in service_base
+* Expand CI matrix using Azure Pipelines
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 256:
 
 * Remove uses of the deprecated `buffers` function
+* Remove uses of deprecated methods in websocket tests
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 256:
 * Remove uses of the deprecated `buffers` function
 * Remove uses of deprecated methods in websocket tests
 * Remove redundant use of `static_string`
+* Remove redundant template in service_base
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version 256:
 * Fix `buffers_cat` iterator tests
 * Don't pessimize-move
 * Use steady_timer type
+* Preserve operation_aborted on partial message
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version 256:
 * Add 1-element specialization for `buffers_cat`
 * Fix `buffers_cat` iterator tests
 * Don't pessimize-move
+* Use steady_timer type
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 256:
+
+* Remove uses of the deprecated `buffers` function
+
+--------------------------------------------------------------------------------
+
 Version 255:
 
 * Add idle ping suspend test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endfunction()
 #
 #-------------------------------------------------------------------------------
 
-project (Beast VERSION 255)
+project (Beast VERSION 256)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,270 @@
+variables:
+  GIT_BRANCH: $(Build.SourceBranch)
+
+jobs:
+  - job: 'LinuxCoverage'
+    pool:
+      vmImage: 'ubuntu-16.04'
+    container:
+      image: djarek/boost-beast-ci:latest
+      options: --privileged
+    steps:
+      - bash: |
+            sudo apt update && sudo apt install -y g++ lcov
+        displayName: Get dependencies
+      - bash: |
+            set -e
+            export BUILD_DIR=$(pwd)
+            cd ..
+            $BUILD_DIR/tools/get-boost.sh $GIT_BRANCH $BUILD_DIR
+            cd boost-root
+            export CXX=g++ CC=gcc
+            ./bootstrap.sh || cat bootstrap.log
+        displayName: Get Boost
+      - bash: |
+            set -e
+            cd ../boost-root
+            ./b2 libs/beast/test//run-fat-tests toolset=gcc coverage=all link=static cxxstd=11 -j2
+            libs/beast/tools/coverage.sh
+        env:
+            CODECOV_TOKEN: $(CODECOV_TOKEN)
+        displayName: Build & Run tests
+  - job: 'Linux'
+    pool:
+      vmImage: 'ubuntu-16.04'
+    container:
+      image: djarek/boost-beast-ci:latest
+      options: --privileged
+    strategy:
+      matrix:
+        GCC 8 C++17 Release:
+          TOOLSET: gcc
+          CXX: g++-8
+          PACKAGES: g++-8
+          VARIANT: release
+          B2_FLAGS: <define>BOOST_BEAST_USE_STD_STRING_VIEW
+          CXXSTD: 17
+          B2_TARGETS: libs/beast/test//run-fat-tests libs/beast/example
+        GCC 8 C++11 UBASAN:
+          TOOLSET: gcc
+          CXX: g++-8
+          PACKAGES: g++-8
+          VARIANT: debug
+          B2_FLAGS: <address-sanitizer>norecover <undefined-sanitizer>norecover
+          # use GOLD to workaround UBSAN linker issue in gcc 7/8
+          # https://stackoverflow.com/questions/50024731/ld-unrecognized-option-push-state-no-as-needed
+          CXX_FLAGS: <cxxflags>"-msse4.2 -funsigned-char -fno-omit-frame-pointer" <linkflags>-fuse-ld=gold
+          CXXSTD: 11
+          B2_TARGETS: libs/beast/test//run-fat-tests
+        GCC 8 C++11 TSAN:
+          TOOLSET: gcc
+          CXX: g++-8
+          PACKAGES: g++-8
+          VARIANT: release
+          B2_FLAGS: <thread-sanitizer>norecover
+          CXX_FLAGS: <cxxflags>"-msse4.2 -funsigned-char -fno-omit-frame-pointer"
+          CXXSTD: 11
+          B2_TARGETS: libs/beast/test//run-fat-tests
+        GCC 7 C++14 Valgrind:
+          TOOLSET: gcc
+          CXX: g++-7
+          PACKAGES: g++-7 valgrind
+          VARIANT: release
+          B2_FLAGS: <define>BOOST_BEAST_TEST_STATIC_PRNG_SEED <valgrind>on <testing.launcher>"valgrind --track-origins=yes --error-exitcode=1 --max-stackframe=16000000 --suppressions=libs/beast/tools/valgrind.supp"
+          CXXSTD: 14
+          B2_TARGETS: libs/beast/test//run-fat-tests
+        GCC Default C++11 Release:
+          TOOLSET: gcc
+          CXX: g++
+          PACKAGES: g++
+          VARIANT: release
+          CXXSTD: 11
+          B2_TARGETS: libs/beast/test//run-fat-tests libs/beast/example
+        Clang 6.0 C++11 Debug:
+          TOOLSET: clang
+          CXX: clang++-6.0
+          PACKAGES: clang-6.0
+          VARIANT: debug
+          CXXSTD: 11
+          B2_TARGETS: libs/beast/test//run-fat-tests libs/beast/example
+        Clang 7 libc++ C++14 Valgrind:
+          TOOLSET: clang
+          CXX: clang++-7
+          PACKAGES: clang-7 libc++-7-dev libc++abi-7-dev valgrind
+          VARIANT: release
+          B2_FLAGS: <valgrind>on <testing.launcher>"valgrind --track-origins=yes --error-exitcode=1 --max-stackframe=16000000 --suppressions=libs/beast/tools/valgrind.supp"
+          CXXSTD: 14
+          CXX_FLAGS: <cxxflags>"-stdlib=libc++" <linkflags>"-stdlib=libc++"
+          B2_TARGETS: libs/beast/test//run-fat-tests
+        Clang 7 C++11 Debug:
+          TOOLSET: clang
+          CXX: clang++-7
+          PACKAGES: clang-7
+          VARIANT: debug
+          CXXSTD: 11
+          B2_TARGETS: libs/beast/test//run-fat-tests libs/beast/example
+        Clang 7 C++14 Release:
+          TOOLSET: clang
+          CXX: clang++-7
+          PACKAGES: clang-7
+          VARIANT: release
+          CXXSTD: 14
+          B2_TARGETS: libs/beast/test//run-fat-tests libs/beast/example
+        Clang Default C++11 Debug:
+          TOOLSET: clang
+          CXX: clang++
+          PACKAGES: clang
+          VARIANT: debug
+          CXXSTD: 11
+          B2_TARGETS: libs/beast/test//run-fat-tests libs/beast/example
+        Clang 8 libc++ C++14 UBASAN:
+          TOOLSET: clang
+          CXX: clang++-8
+          PACKAGES: clang-8 libc++-8-dev libc++abi-8-dev
+          VARIANT: release
+          B2_FLAGS: <address-sanitizer>norecover <undefined-sanitizer>norecover
+          UBSAN_OPTIONS: print_stacktrace=1
+          CXXSTD: 14
+          CXX_FLAGS: <cxxflags>"-stdlib=libc++ -msse4.2 -funsigned-char -fno-omit-frame-pointer" <linkflags>-stdlib=libc++
+          B2_TARGETS: libs/beast/test//run-fat-tests
+        Clang 8 libc++ C++14 TSAN:
+          TOOLSET: clang
+          CXX: clang++-8
+          PACKAGES: clang-8 libc++-8-dev libc++abi-8-dev
+          VARIANT: release
+          B2_FLAGS: <thread-sanitizer>norecover
+          CXXSTD: 11
+          CXX_FLAGS: <cxxflags>"-stdlib=libc++ -msse4.2 -funsigned-char -fno-omit-frame-pointer" <linkflags>-stdlib=libc++
+          B2_TARGETS: libs/beast/test//run-fat-tests
+    steps:
+      - bash: |
+            sudo apt update && sudo apt install -y $PACKAGES
+        displayName: Get dependencies
+      - bash: |
+            set -e
+            export BUILD_DIR=$(pwd)
+            cd ..
+            $BUILD_DIR/tools/get-boost.sh $GIT_BRANCH $BUILD_DIR
+            cd boost-root
+            ./bootstrap.sh || cat bootstrap.log
+            cp libs/beast/tools/user-config.jam ~/user-config.jam
+            echo "using $TOOLSET : : $(which $CXX) : $CXX_FLAGS ;" >> ~/user-config.jam
+            echo "project : requirements $B2_FLAGS ;" >> ~/user-config.jam
+        displayName: Get Boost
+      - bash: |
+            set -e
+            cd ../boost-root
+            echo "B2_FLAGS: $B2_FLAGS"
+            ./b2 -j2 \
+              --debug-configuration \
+              cxxstd=$CXXSTD \
+              toolset=$TOOLSET \
+              variant=$VARIANT \
+              $B2_TARGETS
+        displayName: Build & Run tests
+
+  - job: 'macOS'
+    pool:
+      vmImage: 'macOS-10.13'
+    strategy:
+      matrix:
+        Xcode 10.1 C++17 Release:
+          TOOLSET: clang
+          VARIANT: release
+          CXXSTD: 17
+          XCODE_APP: /Applications/Xcode_10.1.app
+        Xcode 9.4.1 C++11 Release:
+          TOOLSET: clang
+          VARIANT: release
+          CXXSTD: 11
+          XCODE_APP: /Applications/Xcode_9.4.1.app
+    steps:
+      - bash: |
+          brew install openssl
+        displayName: Get OpenSSL
+      - bash: |
+          set -e
+          sudo xcode-select -switch ${XCODE_APP}
+          which clang++
+          export BUILD_DIR=$(pwd)
+          cd ..
+          $BUILD_DIR/tools/get-boost.sh $GIT_BRANCH $BUILD_DIR
+          cd boost-root
+          ./bootstrap.sh || cat bootstrap.log
+          cp libs/beast/tools/user-config.jam ~/user-config.jam
+        displayName: Get Boost
+      - bash: |
+            set -e
+            export OPENSSL_ROOT=$(brew --prefix openssl)
+            cd ../boost-root
+            ./b2 -j2 \
+              --debug-configuration \
+              define=BOOST_COROUTINES_NO_DEPRECATION_WARNING=1 \
+              cxxstd=$CXXSTD \
+              libs/beast/test//run-fat-tests \
+              libs/beast/example \
+              toolset=$TOOLSET \
+              variant=$VARIANT
+        displayName: Build & Run tests
+
+  - job: 'Windows'
+    strategy:
+      matrix:
+        # MSVC14.2: # FIXME(djarek): windows-2019 doesn't have vcpkg
+        #MSVC14.2 C++17 x64:
+          #VM_IMAGE: 'windows-2019'
+          #TOOLSET: msvc-14.2
+          #B2_FLAGS: define=BOOST_BEAST_USE_STD_STRING_VIEW
+          #CXXSTD: 17
+          #ADDRMODEL: 64
+        MSVC14.1 C++17 x64:
+          VM_IMAGE: 'vs2017-win2016'
+          TOOLSET: msvc-14.1
+          B2_FLAGS: define=BOOST_BEAST_USE_STD_STRING_VIEW
+          CXXSTD: 17
+          ADDRMODEL: 64
+        MSVC14.0 C++11 x64:
+          VM_IMAGE: 'vs2017-win2016'
+          TOOLSET: msvc-14.0
+          CXXSTD: 11
+          ADDRMODEL: 64
+    pool:
+      vmImage: $(VM_IMAGE)
+    steps:
+      - bash: |
+          vcpkg install openssl --triplet "x$ADDRMODEL""-windows"
+        displayName: Get OpenSSL
+
+      - bash: |
+          set -e
+          export BUILD_DIR=$(pwd)
+          cd ..
+          $BUILD_DIR/tools/get-boost.sh $GIT_BRANCH $BUILD_DIR
+          cd boost-root
+          ./bootstrap.sh
+          cp libs/beast/tools/user-config.jam ~/user-config.jam
+        displayName: Get Boost
+
+      - bash: |
+          set -e
+          echo "VCPKG_ROOT: $VCPKG_INSTALLATION_ROOT"
+          export OPENSSL_ROOT="$VCPKG_INSTALLATION_ROOT""/installed/x$ADDRMODEL""-windows"
+          cd ../boost-root
+          ./b2 -j2 \
+            --debug-configuration \
+            variant=debug \
+            cxxstd=$CXXSTD \
+            address-model=$ADDRMODEL \
+            toolset=$TOOLSET \
+            $B2_FLAGS \
+            libs/beast/example
+          ./b2 -j2 \
+            --debug-configuration \
+            variant=debug,release \
+            cxxstd=$CXXSTD \
+            address-model=$ADDRMODEL \
+            toolset=$TOOLSET \
+            $B2_FLAGS \
+            --verbose-test \
+            libs/beast/test//run-fat-tests
+        displayName: Build & Run tests

--- a/example/advanced/server/advanced_server.cpp
+++ b/example/advanced/server/advanced_server.cpp
@@ -489,7 +489,7 @@ private:
         }
 
         // Send the response
-        handle_request(*doc_root_, std::move(parser_->release()), queue_);
+        handle_request(*doc_root_, parser_->release(), queue_);
 
         // If we aren't at the queue limit, try to pipeline another request
         if(! queue_.is_full())

--- a/example/http/server/fast/http_server_fast.cpp
+++ b/example/http/server/fast/http_server_fast.cpp
@@ -111,7 +111,7 @@ private:
     boost::optional<http::request_parser<request_body_t, alloc_t>> parser_;
 
     // The timer putting a time limit on requests.
-    net::basic_waitable_timer<std::chrono::steady_clock> request_deadline_{
+    net::steady_timer request_deadline_{
         acceptor_.get_executor(), (std::chrono::steady_clock::time_point::max)()};
 
     // The string-based response message.

--- a/example/http/server/small/http_server_small.cpp
+++ b/example/http/server/small/http_server_small.cpp
@@ -75,7 +75,7 @@ private:
     http::response<http::dynamic_body> response_;
 
     // The timer for putting a deadline on connection processing.
-    net::basic_waitable_timer<std::chrono::steady_clock> deadline_{
+    net::steady_timer deadline_{
         socket_.get_executor(), std::chrono::seconds(60)};
 
     // Asynchronously receive a complete request message.

--- a/example/websocket/server/chat-multi/chat_client.html
+++ b/example/websocket/server/chat-multi/chat_client.html
@@ -14,9 +14,7 @@
   <button class="echo-button" id="connect">Connect</button>
   <button class="echo-button" id="disconnect">Disconnect</button><br>
   Your Name: <input class="draw-border" id="userName" size=47 style="margin-bottom: 5px;"><br>
-
-  <pre id="messages" style="width: 600px; height: 400px; border: solid 1px #cccccc; margin-bottom: 5px;"></pre>
-
+  <pre id="messages" style="width: 600px; height: 400px; white-space: normal; overflow: auto; border: solid 1px #cccccc; margin-bottom: 5px;"></pre>
   <div style="margin-bottom: 5px;">
     Message<br>
     <input class="draw-border" id="sendMessage" size="74" value="">
@@ -24,20 +22,23 @@
   </div>
   <script>
     var ws = null;
-    
+    function showMessage(msg) {
+      messages.innerText += msg + "\n";
+      messages.scrollTop = messages.scrollHeight - messages.clientHeight;
+    };
     connect.onclick = function() {
       ws = new WebSocket(uri.value);
       ws.onopen = function(ev) {
-        messages.innerText += "[connection opened]\n";
+        showMessage("[connection opened]");
       };
       ws.onclose = function(ev) {
-        messages.innerText += "[connection closed]\n";
+        showMessage("[connection closed]");
       };
       ws.onmessage = function(ev) {
-        messages.innerText += ev.data + "\n";
+        showMessage(ev.data);
       };
       ws.onerror = function(ev) {
-        messages.innerText += "[error]\n";
+        showMessage("[error]");
         console.log(ev);
       };
     };

--- a/include/boost/beast/core/basic_stream.hpp
+++ b/include/boost/beast/core/basic_stream.hpp
@@ -73,7 +73,7 @@ namespace beast {
     be invoked by the executor associated with the stream upon construction.
     The type of executor used with this stream must meet the following
     requirements:
-    
+
     @li Function objects submitted to the executor shall never run
         concurrently with each other.
 
@@ -284,6 +284,7 @@ private:
     // but the implementation is still waiting on a timer.
     boost::shared_ptr<impl_type> impl_;
 
+    template<class Executor2>
     struct timeout_handler;
 
     struct ops;
@@ -367,7 +368,7 @@ public:
 
     /** Move constructor
 
-        @param other The other object from which the move will occur. 
+        @param other The other object from which the move will occur.
 
         @note Following the move, the moved-from object is in the
         same state as if newly constructed.
@@ -490,7 +491,7 @@ public:
     //--------------------------------------------------------------------------
 
     /** Get the executor associated with the object.
-    
+
         This function may be used to obtain the executor object that the
         stream uses to dispatch completion handlers without an assocaited
         executor.
@@ -525,7 +526,7 @@ public:
     }
 
     /** Connect the stream to the specified endpoint.
-        
+
         This function is used to connect the underlying socket to the
         specified remote endpoint. The function call will block until
         the connection is successfully made or an error occurs.
@@ -534,7 +535,7 @@ public:
         closed state upon failure.
 
         @param ep The remote endpoint to connect to.
-        
+
         @param ec Set to indicate what error occurred, if any.
 
         @see connect
@@ -546,7 +547,7 @@ public:
     }
 
     /** Establishes a connection by trying each endpoint in a sequence.
-    
+
         This function attempts to connect the stream to one of a sequence of
         endpoints by trying each endpoint until a connection is successfully
         established.
@@ -556,11 +557,11 @@ public:
 
         The algorithm, known as a <em>composed operation</em>, is implemented
         in terms of calls to the underlying socket's `connect` function.
-    
+
         @param endpoints A sequence of endpoints.
-    
+
         @returns The successfully connected endpoint.
-    
+
         @throws system_error Thrown on failure. If the sequence is
         empty, the associated error code is `net::error::not_found`.
         Otherwise, contains the error from the last connection attempt.
@@ -579,7 +580,7 @@ public:
     }
 
     /** Establishes a connection by trying each endpoint in a sequence.
-    
+
         This function attempts to connect the stream to one of a sequence of
         endpoints by trying each endpoint until a connection is successfully
         established.
@@ -589,16 +590,16 @@ public:
 
         The algorithm, known as a <em>composed operation</em>, is implemented
         in terms of calls to the underlying socket's `connect` function.
-        
+
         @param endpoints A sequence of endpoints.
-    
+
         @param ec Set to indicate what error occurred, if any. If the sequence is
         empty, set to `net::error::not_found`. Otherwise, contains the error
         from the last connection attempt.
-    
+
         @returns On success, the successfully connected endpoint. Otherwise, a
         default-constructed endpoint.
-    */    
+    */
     template<class EndpointSequence
     #if ! BOOST_BEAST_DOXYGEN
         ,class = typename std::enable_if<
@@ -616,27 +617,27 @@ public:
     }
 
     /** Establishes a connection by trying each endpoint in a sequence.
-    
+
         This function attempts to connect the stream to one of a sequence of
         endpoints by trying each endpoint until a connection is successfully
         established.
         The underlying socket is automatically opened if needed.
         An automatically opened socket is not returned to the
         closed state upon failure.
-    
+
         The algorithm, known as a <em>composed operation</em>, is implemented
         in terms of calls to the underlying socket's `connect` function.
-    
+
         @param begin An iterator pointing to the start of a sequence of endpoints.
-    
+
         @param end An iterator pointing to the end of a sequence of endpoints.
-    
+
         @returns An iterator denoting the successfully connected endpoint.
-    
+
         @throws system_error Thrown on failure. If the sequence is
         empty, the associated error code is `net::error::not_found`.
         Otherwise, contains the error from the last connection attempt.
-    */    
+    */
     template<class Iterator>
     Iterator
     connect(
@@ -646,25 +647,25 @@ public:
     }
 
     /** Establishes a connection by trying each endpoint in a sequence.
-    
+
         This function attempts to connect the stream to one of a sequence of
         endpoints by trying each endpoint until a connection is successfully
         established.
         The underlying socket is automatically opened if needed.
         An automatically opened socket is not returned to the
         closed state upon failure.
-    
+
         The algorithm, known as a <em>composed operation</em>, is implemented
         in terms of calls to the underlying socket's `connect` function.
-        
+
         @param begin An iterator pointing to the start of a sequence of endpoints.
-    
+
         @param end An iterator pointing to the end of a sequence of endpoints.
-    
+
         @param ec Set to indicate what error occurred, if any. If the sequence is
         empty, set to boost::asio::error::not_found. Otherwise, contains the error
         from the last connection attempt.
-    
+
         @returns On success, an iterator denoting the successfully connected
         endpoint. Otherwise, the end iterator.
     */
@@ -678,7 +679,7 @@ public:
     }
 
     /** Establishes a connection by trying each endpoint in a sequence.
-    
+
         This function attempts to connect the stream to one of a sequence of
         endpoints by trying each endpoint until a connection is successfully
         established.
@@ -688,9 +689,9 @@ public:
 
         The algorithm, known as a <em>composed operation</em>, is implemented
         in terms of calls to the underlying socket's `connect` function.
-        
+
         @param endpoints A sequence of endpoints.
-    
+
         @param connect_condition A function object that is called prior to each
         connection attempt. The signature of the function object must be:
         @code
@@ -703,9 +704,9 @@ public:
         indicate success. The @c next parameter is the next endpoint to be tried.
         The function object should return true if the next endpoint should be tried,
         and false if it should be skipped.
-    
+
         @returns The successfully connected endpoint.
-    
+
         @throws boost::system::system_error Thrown on failure. If the sequence is
         empty, the associated error code is `net::error::not_found`.
         Otherwise, contains the error from the last connection attempt.
@@ -779,7 +780,7 @@ public:
     }
 
     /** Establishes a connection by trying each endpoint in a sequence.
-    
+
         This function attempts to connect the stream to one of a sequence of
         endpoints by trying each endpoint until a connection is successfully
         established.
@@ -789,11 +790,11 @@ public:
 
         The algorithm, known as a <em>composed operation</em>, is implemented
         in terms of calls to the underlying socket's `connect` function.
-        
+
         @param begin An iterator pointing to the start of a sequence of endpoints.
-    
+
         @param end An iterator pointing to the end of a sequence of endpoints.
-    
+
         @param connect_condition A function object that is called prior to each
         connection attempt. The signature of the function object must be:
         @code
@@ -806,13 +807,13 @@ public:
         indicate success. The @c next parameter is the next endpoint to be tried.
         The function object should return true if the next endpoint should be tried,
         and false if it should be skipped.
-    
+
         @returns An iterator denoting the successfully connected endpoint.
-    
+
         @throws boost::system::system_error Thrown on failure. If the sequence is
         empty, the associated @c error_code is `net::error::not_found`.
         Otherwise, contains the error from the last connection attempt.
-    */  
+    */
     template<
         class Iterator, class ConnectCondition>
     Iterator
@@ -824,7 +825,7 @@ public:
     }
 
     /** Establishes a connection by trying each endpoint in a sequence.
-    
+
         This function attempts to connect the stream to one of a sequence of
         endpoints by trying each endpoint until a connection is successfully
         established.
@@ -834,11 +835,11 @@ public:
 
         The algorithm, known as a <em>composed operation</em>, is implemented
         in terms of calls to the underlying socket's `connect` function.
-        
+
         @param begin An iterator pointing to the start of a sequence of endpoints.
-    
+
         @param end An iterator pointing to the end of a sequence of endpoints.
-    
+
         @param connect_condition A function object that is called prior to each
         connection attempt. The signature of the function object must be:
         @code
@@ -851,11 +852,11 @@ public:
         indicate success. The @c next parameter is the next endpoint to be tried.
         The function object should return true if the next endpoint should be tried,
         and false if it should be skipped.
-    
+
         @param ec Set to indicate what error occurred, if any. If the sequence is
         empty, set to `net::error::not_found`. Otherwise, contains the error
         from the last connection attempt.
-    
+
         @returns On success, an iterator denoting the successfully connected
         endpoint. Otherwise, the end iterator.
     */
@@ -885,7 +886,7 @@ public:
 
         @param ep The remote endpoint to which the underlying socket will be
         connected. Copies will be made of the endpoint object as required.
-        
+
         @param handler The completion handler to invoke when the operation
         completes. The implementation takes ownership of the handler by
         performing a decay-copy. The equivalent function signature of
@@ -909,7 +910,7 @@ public:
         ConnectHandler&& handler);
 
     /** Establishes a connection by trying each endpoint in a sequence asynchronously.
-   
+
         This function attempts to connect the stream to one of a sequence of
         endpoints by trying each endpoint until a connection is successfully
         established.
@@ -924,10 +925,10 @@ public:
         If the timeout timer expires while the operation is outstanding,
         the current connection attempt will be canceled and the completion
         handler will be invoked with the error @ref error::timeout.
-    
+
         @param endpoints A sequence of endpoints. This this object must meet
         the requirements of <em>EndpointSequence</em>.
-    
+
         @param handler The completion handler to invoke when the operation
         completes. The implementation takes ownership of the handler by
         performing a decay-copy. The equivalent function signature of
@@ -938,7 +939,7 @@ public:
             // net::error::not_found. Otherwise, contains the
             // error from the last connection attempt.
             error_code const& error,
-    
+
             // On success, the successfully connected endpoint.
             // Otherwise, a default-constructed endpoint.
             typename Protocol::endpoint const& endpoint
@@ -964,7 +965,7 @@ public:
         RangeConnectHandler&& handler);
 
     /** Establishes a connection by trying each endpoint in a sequence asynchronously.
-    
+
         This function attempts to connect the stream to one of a sequence of
         endpoints by trying each endpoint until a connection is successfully
         established.
@@ -982,7 +983,7 @@ public:
 
         @param endpoints A sequence of endpoints. This this object must meet
         the requirements of <em>EndpointSequence</em>.
-    
+
         @param connect_condition A function object that is called prior to each
         connection attempt. The signature of the function object must be:
         @code
@@ -1006,7 +1007,7 @@ public:
             // net::error::not_found. Otherwise, contains the
             // error from the last connection attempt.
             error_code const& error,
-    
+
             // On success, the successfully connected endpoint.
             // Otherwise, a default-constructed endpoint.
             typename Protocol::endpoint const& endpoint
@@ -1052,7 +1053,7 @@ public:
         RangeConnectHandler&& handler);
 
     /** Establishes a connection by trying each endpoint in a sequence asynchronously.
-    
+
         This function attempts to connect the stream to one of a sequence of
         endpoints by trying each endpoint until a connection is successfully
         established.
@@ -1067,9 +1068,9 @@ public:
         If the timeout timer expires while the operation is outstanding,
         the current connection attempt will be canceled and the completion
         handler will be invoked with the error @ref error::timeout.
-    
+
         @param begin An iterator pointing to the start of a sequence of endpoints.
-    
+
         @param end An iterator pointing to the end of a sequence of endpoints.
 
         @param handler The completion handler to invoke when the operation
@@ -1082,7 +1083,7 @@ public:
             // net::error::not_found. Otherwise, contains the
             // error from the last connection attempt.
             error_code const& error,
-    
+
             // On success, an iterator denoting the successfully
             // connected endpoint. Otherwise, the end iterator.
             Iterator iterator
@@ -1102,7 +1103,7 @@ public:
         IteratorConnectHandler&& handler);
 
     /** Establishes a connection by trying each endpoint in a sequence asynchronously.
-    
+
         This function attempts to connect the stream to one of a sequence of
         endpoints by trying each endpoint until a connection is successfully
         established.
@@ -1113,11 +1114,11 @@ public:
         If the timeout timer expires while the operation is outstanding,
         the current connection attempt will be canceled and the completion
         handler will be invoked with the error @ref error::timeout.
-    
+
         @param begin An iterator pointing to the start of a sequence of endpoints.
 
         @param end An iterator pointing to the end of a sequence of endpoints.
-    
+
         @param connect_condition A function object that is called prior to each
         connection attempt. The signature of the function object must be:
         @code
@@ -1136,7 +1137,7 @@ public:
             // net::error::not_found. Otherwise, contains the
             // error from the last connection attempt.
             error_code const& error,
-    
+
             // On success, an iterator denoting the successfully
             // connected endpoint. Otherwise, the end iterator.
             Iterator iterator
@@ -1162,7 +1163,7 @@ public:
     /** Read some data.
 
         This function is used to read some data from the stream.
-        
+
         The call blocks until one of the following is true:
 
         @li One or more bytes are read from the stream.
@@ -1172,11 +1173,11 @@ public:
         @param buffers The buffers into which the data will be read. If the
         size of the buffers is zero bytes, the call always returns
         immediately with no error.
-        
+
         @returns The number of bytes read.
-        
+
         @throws system_error Thrown on failure.
-        
+
         @note The `read_some` operation may not receive all of the requested
         number of bytes. Consider using the function `net::read` if you need
         to ensure that the requested amount of data is read before the
@@ -1202,11 +1203,11 @@ public:
         @param buffers The buffers into which the data will be read. If the
         size of the buffers is zero bytes, the call always returns
         immediately with no error.
-        
+
         @param ec Set to indicate what error occurred, if any.
 
         @returns The number of bytes read.
-                
+
         @note The `read_some` operation may not receive all of the requested
         number of bytes. Consider using the function `net::read` if you need
         to ensure that the requested amount of data is read before the
@@ -1224,7 +1225,7 @@ public:
     /** Read some data asynchronously.
 
         This function is used to asynchronously read data from the stream.
-        
+
         This call always returns immediately. The asynchronous operation
         will continue until one of the following conditions is true:
 
@@ -1247,7 +1248,7 @@ public:
         Although the buffers object may be copied as necessary, ownership of the
         underlying memory blocks is retained by the caller, which must guarantee
         that they remain valid until the handler is called.
-        
+
         @param handler The completion handler to invoke when the operation
         completes. The implementation takes ownership of the handler by
         performing a decay-copy. The equivalent function signature of
@@ -1277,7 +1278,7 @@ public:
     /** Write some data.
 
         This function is used to write some data to the stream.
-        
+
         The call blocks until one of the following is true:
 
         @li One or more bytes are written to the stream.
@@ -1289,9 +1290,9 @@ public:
         with no error.
 
         @returns The number of bytes written.
-        
+
         @throws system_error Thrown on failure.
-        
+
         @note The `write_some` operation may not transmit all of the requested
         number of bytes. Consider using the function `net::write` if you need
         to ensure that the requested amount of data is written before the
@@ -1307,7 +1308,7 @@ public:
     /** Write some data.
 
         This function is used to write some data to the stream.
-        
+
         The call blocks until one of the following is true:
 
         @li One or more bytes are written to the stream.
@@ -1321,9 +1322,9 @@ public:
         @param ec Set to indicate what error occurred, if any.
 
         @returns The number of bytes written.
-        
+
         @throws system_error Thrown on failure.
-        
+
         @note The `write_some` operation may not transmit all of the requested
         number of bytes. Consider using the function `net::write` if you need
         to ensure that the requested amount of data is written before the
@@ -1341,7 +1342,7 @@ public:
     /** Write some data asynchronously.
 
         This function is used to asynchronously write data to the underlying socket.
-        
+
         This call always returns immediately. The asynchronous operation
         will continue until one of the following conditions is true:
 
@@ -1364,7 +1365,7 @@ public:
         Although the buffers object may be copied as necessary, ownership of the
         underlying memory blocks is retained by the caller, which must guarantee
         that they remain valid until the handler is called.
-        
+
         @param handler The completion handler to invoke when the operation
         completes. The implementation takes ownership of the handler by
         performing a decay-copy. The equivalent function signature of

--- a/include/boost/beast/core/buffers_cat.hpp
+++ b/include/boost/beast/core/buffers_cat.hpp
@@ -19,7 +19,6 @@ namespace boost {
 namespace beast {
 
 /** A buffer sequence representing a concatenation of buffer sequences.
-
     @see buffers_cat
 */
 template<class... Buffers>
@@ -29,7 +28,6 @@ class buffers_cat_view
 
 public:
     /** The type of buffer returned when dereferencing an iterator.
-
         If every buffer sequence in the view is a <em>MutableBufferSequence</em>,
         then `value_type` will be `net::mutable_buffer`.
         Otherwise, `value_type` will be `net::const_buffer`.
@@ -50,7 +48,6 @@ public:
     buffers_cat_view& operator=(buffers_cat_view const&) = default;
 
     /** Constructor
-
         @param buffers The list of buffer sequences to concatenate.
         Copies of the arguments will be maintained for the lifetime
         of the concatenated sequence; however, the ownership of the
@@ -63,28 +60,24 @@ public:
     const_iterator
     begin() const;
 
-    /// Returns an iterator to one past the last buffer in the sequence 
+    /// Returns an iterator to one past the last buffer in the sequence
     const_iterator
     end() const;
 };
 
 /** Concatenate 2 or more buffer sequences.
-
     This function returns a constant or mutable buffer sequence which,
     when iterated, efficiently concatenates the input buffer sequences.
     Copies of the arguments passed will be made; however, the returned
     object does not take ownership of the underlying memory. The
     application is still responsible for managing the lifetime of the
     referenced memory.
-
     @param buffers The list of buffer sequences to concatenate.
-
     @return A new buffer sequence that represents the concatenation of
     the input buffer sequences. This buffer sequence will be a
     <em>MutableBufferSequence</em> if each of the passed buffer sequences is
     also a <em>MutableBufferSequence</em>; otherwise the returned buffer
     sequence will be a <em>ConstBufferSequence</em>.
-
     @see buffers_cat_view
 */
 #if BOOST_BEAST_DOXYGEN

--- a/include/boost/beast/core/buffers_cat.hpp
+++ b/include/boost/beast/core/buffers_cat.hpp
@@ -65,7 +65,8 @@ public:
     end() const;
 };
 
-/** Concatenate 2 or more buffer sequences.
+/** Concatenate 1 or more buffer sequences.
+
     This function returns a constant or mutable buffer sequence which,
     when iterated, efficiently concatenates the input buffer sequences.
     Copies of the arguments passed will be made; however, the returned
@@ -85,15 +86,15 @@ template<class... BufferSequence>
 buffers_cat_view<BufferSequence...>
 buffers_cat(BufferSequence const&... buffers)
 #else
-template<class B1, class B2, class... Bn>
-buffers_cat_view<B1, B2, Bn...>
-buffers_cat(B1 const& b1, B2 const& b2, Bn const&... bn)
+template<class B1, class... Bn>
+buffers_cat_view<B1, Bn...>
+buffers_cat(B1 const& b1, Bn const&... bn)
 #endif
 {
     static_assert(
-        is_const_buffer_sequence<B1, B2, Bn...>::value,
+        is_const_buffer_sequence<B1, Bn...>::value,
         "BufferSequence type requirements not met");
-    return buffers_cat_view<B1, B2, Bn...>{b1, b2, bn...};
+    return buffers_cat_view<B1, Bn...>{b1, bn...};
 }
 
 } // beast

--- a/include/boost/beast/core/detail/service_base.hpp
+++ b/include/boost/beast/core/detail/service_base.hpp
@@ -17,14 +17,9 @@ namespace beast {
 namespace detail {
 
 template<class T>
-struct service_id : net::execution_context::id
-{
-};
-
-template<class T>
 struct service_base : net::execution_context::service
 {
-    static service_id<T> id;
+    static net::execution_context::id const id;
 
     explicit
     service_base(net::execution_context& ctx)
@@ -34,7 +29,7 @@ struct service_base : net::execution_context::service
 };
 
 template<class T>
-service_id<T> service_base<T>::id;
+net::execution_context::id const service_base<T>::id;
 
 } // detail
 } // beast

--- a/include/boost/beast/core/impl/buffers_cat.hpp
+++ b/include/boost/beast/core/impl/buffers_cat.hpp
@@ -23,6 +23,34 @@
 namespace boost {
 namespace beast {
 
+template<class Buffer>
+class buffers_cat_view<Buffer>
+{
+    Buffer buffer_;
+public:
+    using value_type = buffers_type<Buffer>;
+
+    using const_iterator = buffers_iterator_type<Buffer>;
+
+    explicit
+    buffers_cat_view(Buffer const& buffer)
+        : buffer_(buffer)
+    {
+    }
+
+    const_iterator
+    begin() const
+    {
+        return net::buffer_sequence_begin(buffer_);
+    }
+
+    const_iterator
+    end() const
+    {
+        return net::buffer_sequence_end(buffer_);
+    }
+};
+
 #if defined(_MSC_VER) && ! defined(__clang__)
 # define BOOST_BEAST_UNREACHABLE() __assume(false)
 # define BOOST_BEAST_UNREACHABLE_RETURN(v) __assume(false)

--- a/include/boost/beast/http/impl/read.hpp
+++ b/include/boost/beast/http/impl/read.hpp
@@ -62,8 +62,12 @@ parse_until(
         // caller to distinguish an SSL short read which
         // represents a safe connection closure, versus
         // a closure with data loss.
-        if(parser.got_some() && ! parser.is_done())
+        if( ec != net::error::operation_aborted &&
+            parser.got_some() && ! parser.is_done())
+        {
             ec = error::partial_message;
+        }
+
         return 0;
     }
     if(parser.is_done())

--- a/include/boost/beast/http/impl/write.hpp
+++ b/include/boost/beast/http/impl/write.hpp
@@ -14,7 +14,7 @@
 #include <boost/beast/core/async_base.hpp>
 #include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/buffers_range.hpp>
-#include <boost/beast/core/ostream.hpp>
+#include <boost/beast/core/make_printable.hpp>
 #include <boost/beast/core/stream_traits.hpp>
 #include <boost/asio/coroutine.hpp>
 #include <boost/asio/post.hpp>
@@ -262,7 +262,7 @@ struct run_write_some_op
 {
     template<
         class WriteHandler,
-        class Stream, 
+        class Stream,
         bool isRequest, class Body, class Fields>
     void
     operator()(
@@ -903,7 +903,7 @@ operator<<(std::ostream& os,
 {
     typename Fields::writer fr{
         h, h.version(), h.method()};
-    return os << buffers(fr.get());
+    return os << beast::make_printable(fr.get());
 }
 
 template<class Fields>
@@ -913,7 +913,7 @@ operator<<(std::ostream& os,
 {
     typename Fields::writer fr{
         h, h.version(), h.result_int()};
-    return os << buffers(fr.get());
+    return os << beast::make_printable(fr.get());
 }
 
 template<bool isRequest, class Body, class Fields>

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 255
+#define BOOST_BEAST_VERSION 256
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/impl/accept.hpp
+++ b/include/boost/beast/websocket/impl/accept.hpp
@@ -80,13 +80,8 @@ build_response(
             decorator_opt(res);
             decorator(res);
             if(! res.count(http::field::server))
-            {
-                // VFALCO this is weird..
-                BOOST_STATIC_ASSERT(sizeof(
-                    BOOST_BEAST_VERSION_STRING) < 20);
-                static_string<20> s(BOOST_BEAST_VERSION_STRING);
-                res.set(http::field::server, s);
-            }
+                res.set(http::field::server,
+                    string_view(BOOST_BEAST_VERSION_STRING));
         };
     auto err =
         [&](error e)

--- a/test/beast/core/buffers_cat.cpp
+++ b/test/beast/core/buffers_cat.cpp
@@ -302,6 +302,21 @@ public:
             buffers_cat(buffers_prefix(i, buffers), cb));
     }
 
+    void
+    testSingleBuffer()
+    {
+        char c[1] = {};
+        auto b = net::const_buffer(c, 1);
+        auto bs = buffers_cat(net::const_buffer(c, 1));
+        auto first = net::buffer_sequence_begin(bs);
+        auto last = net::buffer_sequence_end(bs);
+        BOOST_ASSERT(first != last);
+        BEAST_EXPECT(std::distance(first, last) == 1);
+        net::const_buffer b2(*first);
+        BEAST_EXPECT(b.data() == b2.data());
+        BEAST_EXPECT(b.size() == b2.size());
+    }
+
     void run() override
     {
         testBufferSequence();
@@ -309,6 +324,7 @@ public:
         testEmpty();
         testGccWarning1();
         testGccWarning2();
+        testSingleBuffer();
     }
 };
 

--- a/test/beast/core/buffers_cat.cpp
+++ b/test/beast/core/buffers_cat.cpp
@@ -38,8 +38,6 @@ public:
             net::const_buffer(&c[0], 1),
             net::const_buffer(&c[1], 1));
         decltype(bs)::const_iterator it;
-        BEAST_EXPECT(bs.end() == it);
-        BEAST_EXPECT(it == bs.end());
         decltype(bs)::const_iterator it2;
         BEAST_EXPECT(it == it2);
         BEAST_EXPECT(it2 == it);
@@ -319,6 +317,7 @@ public:
 
     void run() override
     {
+        testDefaultIterators();
         testBufferSequence();
         testExceptions();
         testEmpty();

--- a/test/beast/ssl/Jamfile
+++ b/test/beast/ssl/Jamfile
@@ -24,7 +24,7 @@ for local f in $(SOURCES)
 alias run-tests : $(RUN_TESTS) ;
 
 exe fat-tests
-    : 
+    :
     $(SOURCES)
     /boost/beast//lib-asio-ssl
     /boost/beast/test//lib-test

--- a/test/beast/websocket/Jamfile
+++ b/test/beast/websocket/Jamfile
@@ -46,7 +46,7 @@ for local f in $(SOURCES)
 alias run-tests : $(RUN_TESTS) ;
 
 exe fat-tests
-    : 
+    :
     $(SOURCES)
     /boost/beast//lib-asio-ssl
     /boost/beast/test//lib-test

--- a/test/beast/websocket/_detail_prng.cpp
+++ b/test/beast/websocket/_detail_prng.cpp
@@ -17,6 +17,16 @@ namespace beast {
 namespace websocket {
 namespace detail {
 
+#ifdef BOOST_BEAST_TEST_STATIC_PRNG_SEED
+auto prng_init = []()
+{
+    // Workaround for https://bugs.launchpad.net/ubuntu/+source/valgrind/+bug/1501545
+    std::seed_seq seq{{0xDEAD, 0xBEEF}};
+    detail::prng_seed(&seq);
+    return 0;
+}();
+#endif // BOOST_BEAST_TEST_STATIC_PRNG_SEED
+
 class prng_test
     : public beast::unit_test::suite
 {

--- a/test/beast/websocket/accept.cpp
+++ b/test/beast/websocket/accept.cpp
@@ -126,7 +126,9 @@ public:
                 "\r\n");
             ws.next_layer().read_size(20);
             bool called = false;
-            api.accept_ex(ws, res_decorator{called});
+            ws.set_option(stream_base::decorator(
+                res_decorator{called}));
+            api.accept(ws);
             BEAST_EXPECT(called);
         });
 
@@ -148,15 +150,16 @@ public:
         fail_loop([&](stream<test::stream>& ws)
         {
             bool called = false;
-            api.accept_ex(ws, sbuf(
+            ws.set_option(stream_base::decorator(
+                res_decorator{called}));
+            api.accept(ws, sbuf(
                 "GET / HTTP/1.1\r\n"
                 "Host: localhost\r\n"
                 "Upgrade: websocket\r\n"
                 "Connection: upgrade\r\n"
                 "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
                 "Sec-WebSocket-Version: 13\r\n"
-                "\r\n"),
-                res_decorator{called});
+                "\r\n"));
             BEAST_EXPECT(called);
         });
 
@@ -187,11 +190,12 @@ public:
                 "\r\n");
             ws.next_layer().read_size(16);
             bool called = false;
-            api.accept_ex(ws, sbuf(
+            ws.set_option(stream_base::decorator(
+                res_decorator{called}));
+            api.accept(ws, sbuf(
                 "GET / HTTP/1.1\r\n"
                 "Host: localhost\r\n"
-                "Upgrade: websocket\r\n"),
-                res_decorator{called});
+                "Upgrade: websocket\r\n"));
             BEAST_EXPECT(called);
         });
 
@@ -228,8 +232,9 @@ public:
             fail_loop([&](stream<test::stream>& ws)
             {
                 bool called = false;
-                api.accept_ex(ws, req,
-                    res_decorator{called});
+                ws.set_option(stream_base::decorator(
+                    res_decorator{called}));
+                api.accept(ws, req);
                 BEAST_EXPECT(called);
             });
         }
@@ -343,7 +348,9 @@ public:
             try
             {
                 bool called = false;
-                api.accept_ex(ws, res_decorator{called});
+                ws.set_option(stream_base::decorator(
+                    res_decorator{called}));
+                api.accept(ws);
                 BEAST_FAIL();
             }
             catch(system_error const& se)
@@ -388,7 +395,9 @@ public:
             try
             {
                 bool called = false;
-                api.accept_ex(ws, net::buffer(
+                ws.set_option(stream_base::decorator(
+                    res_decorator{called}));
+                api.accept(ws, net::buffer(
                     "GET / HTTP/1.1\r\n"
                     "Host: localhost\r\n"
                     "Upgrade: websocket\r\n"
@@ -396,8 +405,7 @@ public:
                     "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
                     "Sec-WebSocket-Version: 13\r\n"
                     + big +
-                    "\r\n"),
-                    res_decorator{called});
+                    "\r\n"));
                 BEAST_FAIL();
             }
             catch(system_error const& se)
@@ -446,11 +454,12 @@ public:
             try
             {
                 bool called = false;
-                api.accept_ex(ws, websocket_test_suite::sbuf(
+                ws.set_option(stream_base::decorator(
+                    res_decorator{called}));
+                api.accept(ws, websocket_test_suite::sbuf(
                     "GET / HTTP/1.1\r\n"
                     "Host: localhost\r\n"
-                    "Upgrade: websocket\r\n"),
-                    res_decorator{called});
+                    "Upgrade: websocket\r\n"));
                 BEAST_FAIL();
             }
             catch(system_error const& se)

--- a/test/beast/websocket/handshake.cpp
+++ b/test/beast/websocket/handshake.cpp
@@ -97,8 +97,9 @@ public:
             bool called = false;
             try
             {
-                w.handshake_ex(ws, "localhost", "/",
-                    req_decorator{called});
+                ws.set_option(stream_base::decorator(
+                    req_decorator{called}));
+                w.handshake(ws, "localhost", "/");
                 BEAST_EXPECT(called);
             }
             catch(...)
@@ -119,8 +120,9 @@ public:
             response_type res;
             try
             {
-                w.handshake_ex(ws, res, "localhost", "/",
-                    req_decorator{called});
+                ws.set_option(stream_base::decorator(
+                    req_decorator{called}));
+                w.handshake(ws, res, "localhost", "/");
                 // VFALCO validate res?
                 BEAST_EXPECT(called);
             }
@@ -355,7 +357,7 @@ public:
         po.client_max_window_bits = 0;
         po.server_no_context_takeover = false;
         po.client_no_context_takeover = false;
-        
+
         check("permessage-deflate");
 
         po.server_max_window_bits = 10;

--- a/test/doc/http_snippets.cpp
+++ b/test/doc/http_snippets.cpp
@@ -366,7 +366,7 @@ print_cxx14(message<isRequest, Body, Fields> const& m)
             [&sr](error_code& ec, auto const& buffer)
             {
                 ec = {};
-                std::cout << buffers(buffer);
+                std::cout << make_printable(buffer);
                 sr.consume(buffer_bytes(buffer));
             });
     }
@@ -393,7 +393,7 @@ struct lambda
     void operator()(error_code& ec, ConstBufferSequence const& buffer) const
     {
         ec = {};
-        std::cout << buffers(buffer);
+        std::cout << make_printable(buffer);
         sr.consume(buffer_bytes(buffer));
     }
 };
@@ -434,7 +434,7 @@ split_print_cxx14(message<isRequest, Body, Fields> const& m)
             [&sr](error_code& ec, auto const& buffer)
             {
                 ec = {};
-                std::cout << buffers(buffer);
+                std::cout << make_printable(buffer);
                 sr.consume(buffer_bytes(buffer));
             });
     }
@@ -448,7 +448,7 @@ split_print_cxx14(message<isRequest, Body, Fields> const& m)
                 [&sr](error_code& ec, auto const& buffer)
                 {
                     ec = {};
-                    std::cout << buffers(buffer);
+                    std::cout << make_printable(buffer);
                     sr.consume(buffer_bytes(buffer));
                 });
         }
@@ -461,6 +461,6 @@ split_print_cxx14(message<isRequest, Body, Fields> const& m)
 //]
 #endif
 
-// Highest snippet: 
+// Highest snippet:
 
 } // doc_http_snippets

--- a/tools/blacklist.supp
+++ b/tools/blacklist.supp
@@ -1,3 +1,4 @@
+
 # Remember that this blacklist file is GLOBAL to all sanitizers
 # Be therefore extremely careful when considering to add a sanitizer
 # filter here instead of using a runtime suppression

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+set -e
+lcov --directory bin.v2 --capture --no-external --directory $(pwd) --output-file coverage.info > /dev/null 2>&1
+lcov --extract coverage.info $(pwd)'/boost/beast/*' --output-file coverage.info > /dev/null
+lcov --remove coverage.info $(pwd)'/boost/beast/_experimental/*' --output-file coverage.info > /dev/null
+lcov --list coverage.info
+# Codecov improperly detects project root in AzP, so we need to upload from beast git repo
+cd libs/beast
+curl -s https://codecov.io/bash -o codecov && bash ./codecov -X gcov -f ../../coverage.info -t $CODECOV_TOKEN

--- a/tools/get-boost.sh
+++ b/tools/get-boost.sh
@@ -5,9 +5,13 @@ set -e
 build_dir=$2
 
 branch="master"
-if [ "$1" != "master" ]; then
+
+if [ "$1" != "master" -a "$1" != "refs/heads/master" ]; then
     branch="develop"
 fi
+
+echo "BUILD_DIR: $build_dir"
+echo "BRANCH: $branch"
 
 git clone -b $branch --depth 1 https://github.com/boostorg/boost.git boost-root
 cd boost-root
@@ -80,8 +84,6 @@ git submodule update --init --depth 20 --jobs 4 \
     libs/unordered
 
 echo Submodule update complete
-
-echo "BUILD_DIR: $build_dir"
 
 rm -rf libs/beast
 cp -r $build_dir libs/beast

--- a/tools/valgrind.supp
+++ b/tools/valgrind.supp
@@ -3,6 +3,13 @@
    Memcheck:Cond
    fun:fill_window
 }
+
+{
+   zlib_deflate_fast
+   Memcheck:Cond
+   fun:deflate_fast
+}
+
 {
    Ignore OpenSSL malloc
    Memcheck:Leak


### PR DESCRIPTION
* Remove uses of the deprecated `buffers` function
* Remove uses of deprecated methods in websocket tests
* Remove redundant use of `static_string`
* Remove redundant template in service_base
* Expand CI matrix using Azure Pipelines
* Make chat websocket javascript client more user friendly
* `allocator_traits::construct` is used for user-defined types
* Add 1-element specialization for `buffers_cat`
* Fix `buffers_cat` iterator tests
* Don't pessimize-move
* Use steady_timer type
* Preserve operation_aborted on partial message