### PR TITLE
Clean up typo in chat websocket javascript client

### DIFF
--- a/example/websocket/server/chat-multi/chat_client.html
+++ b/example/websocket/server/chat-multi/chat_client.html
@@ -51,7 +51,7 @@
     };
     sendMessage.onkeyup = function(ev) {
       ev.preventDefault();
-      if (event.keyCode === 13) {
+      if (ev.keyCode === 13) {
         send.click();
       }
     }


### PR DESCRIPTION
It so happened that the code works, because both variables exist,
but the code was not clean.