### PR TITLE
Version 258

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 258:
 * Fix clang inititalization warning in websocket
 * Remove redundant use of `yield_to` in parser tests
 * Add VS 2019 AzP CI matrix item
+* Clean up typo in chat websocket javascript client
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 258:
 
 * Fix separate compilation in CI
+* Fix clang inititalization warning in websocket
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 258:
 * Fix separate compilation in CI
 * Fix clang inititalization warning in websocket
 * Remove redundant use of `yield_to` in parser tests
+* Add VS 2019 AzP CI matrix item
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 258:
+
+* Fix separate compilation in CI
+
+--------------------------------------------------------------------------------
+
 Version 257:
 
 * Add b2 features for compile-time options used in testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 258:
 
 * Fix separate compilation in CI
 * Fix clang inititalization warning in websocket
+* Remove redundant use of `yield_to` in parser tests
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endfunction()
 #
 #-------------------------------------------------------------------------------
 
-project (Beast VERSION 257)
+project (Beast VERSION 258)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/Jamfile
+++ b/Jamfile
@@ -31,10 +31,10 @@ lib crypt32 ;
 lib ssl : : <target-os>windows <name>ssleay32 ;
 lib crypto : : <target-os>windows <name>libeay32 ;
 
-feature.feature boost.beast.allow-deprecated : on off : optional propagated composite ;
+feature.feature boost.beast.allow-deprecated : on off : propagated composite ;
 feature.compose <boost.beast.allow-deprecated>on : <define>BOOST_BEAST_ALLOW_DEPRECATED ;
 
-feature.feature boost.beast.separate-compilation : on off : optional propagated composite ;
+feature.feature boost.beast.separate-compilation : on off : propagated composite ;
 feature.compose <boost.beast.separate-compilation>on : <define>BOOST_BEAST_SEPARATE_COMPILATION ;
 
 variant beast_coverage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -228,12 +228,12 @@ jobs:
     strategy:
       matrix:
         # MSVC14.2: # FIXME(djarek): windows-2019 doesn't have vcpkg
-        #MSVC14.2 C++17 x64:
-          #VM_IMAGE: 'windows-2019'
-          #TOOLSET: msvc-14.2
-          #B2_FLAGS: define=BOOST_BEAST_USE_STD_STRING_VIEW
-          #CXXSTD: 17
-          #ADDRMODEL: 64
+        MSVC14.2 C++17 x64:
+          VM_IMAGE: 'windows-2019'
+          TOOLSET: msvc-14.2
+          B2_FLAGS: define=BOOST_BEAST_USE_STD_STRING_VIEW
+          CXXSTD: 17
+          ADDRMODEL: 64
         MSVC14.1 C++17 x64:
           VM_IMAGE: 'vs2017-win2016'
           TOOLSET: msvc-14.1

--- a/example/websocket/server/chat-multi/chat_client.html
+++ b/example/websocket/server/chat-multi/chat_client.html
@@ -51,7 +51,7 @@
     };
     sendMessage.onkeyup = function(ev) {
       ev.preventDefault();
-      if (event.keyCode === 13) {
+      if (ev.keyCode === 13) {
         send.click();
       }
     }

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 257
+#define BOOST_BEAST_VERSION 258
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/detail/frame.hpp
+++ b/include/boost/beast/websocket/detail/frame.hpp
@@ -215,9 +215,9 @@ read_close(
 
     std::uint16_t code_be;
     cr.reason.resize(n - 2);
-    std::array<net::mutable_buffer, 2> out_bufs{
+    std::array<net::mutable_buffer, 2> out_bufs{{
         net::mutable_buffer(&code_be, sizeof(code_be)),
-        net::mutable_buffer(&cr.reason[0], n - 2)};
+        net::mutable_buffer(&cr.reason[0], n - 2)}};
 
     net::buffer_copy(out_bufs, bs);
 

--- a/test/beast/http/message_fuzz.hpp
+++ b/test/beast/http/message_fuzz.hpp
@@ -26,18 +26,16 @@ escaped_string(string_view s)
 {
     std::string out;
     out.reserve(s.size());
-    char const* p = s.data();
-    while(p != s.end())
+    for(char c : s)
     {
-        if(*p == '\r')
+        if(c == '\r')
             out.append("\\r");
-        else if(*p == '\n')
+        else if(c == '\n')
             out.append("\\n");
-        else if(*p == '\t')
+        else if(c == '\t')
             out.append("\\t");
         else
-            out.append(p, 1);
-        ++p;
+            out.append(&c, 1);
     }
     return out;
 }

--- a/test/beast/http/parser.cpp
+++ b/test/beast/http/parser.cpp
@@ -13,7 +13,6 @@
 #include "test_parser.hpp"
 
 #include <boost/beast/_experimental/unit_test/suite.hpp>
-#include <boost/beast/test/yield_to.hpp>
 #include <boost/beast/core/buffer_traits.hpp>
 #include <boost/beast/core/buffers_suffix.hpp>
 #include <boost/beast/core/flat_buffer.hpp>
@@ -30,7 +29,6 @@ namespace http {
 
 class parser_test
     : public beast::unit_test::suite
-    , public beast::test::enable_yield_to
 {
 public:
     template<bool isRequest>


### PR DESCRIPTION
* Fix separate compilation in CI
* Fix clang inititalization warning in websocket
* Remove redundant use of `yield_to` in parser tests
* Add VS 2019 AzP CI matrix item
* Clean up typo in chat websocket javascript client