### PR TITLE
Version 259

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Version 259:
 * Improve performance of `http::string_to_verb`
 * Replace uses of `net::coroutine` with `asio::coroutine`
 * Replace uses of `net::spawn` with `asio::spawn`
+* Use `beast::read_size` in `detail::read`
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Version 259:
 * Enable split compilation in http::basic_fields
 * Remove redundant instation of `static_string` in websocket
 * Remove redundant use of `asio::coroutine` in `flat_stream`
+* Remove unused includes from `test::stream`
+
 --------------------------------------------------------------------------------
 
 Version 258:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 259:
 * Remove the use of `static_string` from `http::fields`
 * Add gcc-9 to AzP CI test matrix
 * Enable split compilation in http::basic_fields
+* Remove redundant instation of `static_string` in websocket
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 259:
 
 * Reduce the number of instantiations of filter_token_list
 * Remove the use of `static_string` from `http::fields`
+* Add gcc-9 to AzP CI test matrix
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 259:
 
 * Reduce the number of instantiations of filter_token_list
+* Remove the use of `static_string` from `http::fields`
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version 259:
 * Move `char_buffer` into a separate file
 * Fix coverage collection in AzP CI
 * Improve performance of `http::string_to_verb`
+* Replace uses of `net::coroutine` with `asio::coroutine`
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Version 259:
 * Remove redundant use of `asio::coroutine` in `flat_stream`
 * Remove unused includes from `test::stream`
 * Move `char_buffer` into a separate file
+* Fix coverage collection in AzP CI
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version 259:
 * Fix coverage collection in AzP CI
 * Improve performance of `http::string_to_verb`
 * Replace uses of `net::coroutine` with `asio::coroutine`
+* Replace uses of `net::spawn` with `asio::spawn`
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Version 259:
 * Remove redundant instation of `static_string` in websocket
 * Remove redundant use of `asio::coroutine` in `flat_stream`
 * Remove unused includes from `test::stream`
+* Move `char_buffer` into a separate file
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 259:
+
+* Reduce the number of instantiations of filter_token_list
+
+--------------------------------------------------------------------------------
+
 Version 258:
 
 * Fix separate compilation in CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version 259:
 * Remove unused includes from `test::stream`
 * Move `char_buffer` into a separate file
 * Fix coverage collection in AzP CI
+* Improve performance of `http::string_to_verb`
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Version 259:
 * Add gcc-9 to AzP CI test matrix
 * Enable split compilation in http::basic_fields
 * Remove redundant instation of `static_string` in websocket
-
+* Remove redundant use of `asio::coroutine` in `flat_stream`
 --------------------------------------------------------------------------------
 
 Version 258:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 259:
 * Reduce the number of instantiations of filter_token_list
 * Remove the use of `static_string` from `http::fields`
 * Add gcc-9 to AzP CI test matrix
+* Enable split compilation in http::basic_fields
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endfunction()
 #
 #-------------------------------------------------------------------------------
 
-project (Beast VERSION 258)
+project (Beast VERSION 259)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,42 @@ jobs:
       options: --privileged
     strategy:
       matrix:
+        GCC 9 C++17 Release:
+          TOOLSET: gcc
+          CXX: g++-9
+          PACKAGES: g++-9
+          VARIANT: release
+          B2_FLAGS: <define>BOOST_BEAST_USE_STD_STRING_VIEW
+          CXXSTD: 17
+          B2_TARGETS: libs/beast/test//run-fat-tests libs/beast/example
+        GCC 9 C++11 HEADER_ONLY NO_DEPRECATED:
+          TOOLSET: gcc
+          CXX: g++-9
+          PACKAGES: g++-9
+          VARIANT: release
+          B2_FLAGS: <boost.beast.separate-compilation>off <boost.beast.allow-deprecated>off
+          CXXSTD: 11
+          B2_TARGETS: libs/beast/test//run-fat-tests
+        GCC 9 C++11 UBASAN:
+          TOOLSET: gcc
+          CXX: g++-9
+          PACKAGES: g++-9
+          VARIANT: debug
+          B2_FLAGS: <address-sanitizer>norecover <undefined-sanitizer>norecover
+          # use GOLD to workaround UBSAN linker issue in gcc 7/8
+          # https://stackoverflow.com/questions/50024731/ld-unrecognized-option-push-state-no-as-needed
+          CXX_FLAGS: <cxxflags>"-msse4.2 -funsigned-char -fno-omit-frame-pointer" <linkflags>-fuse-ld=gold
+          CXXSTD: 11
+          B2_TARGETS: libs/beast/test//run-fat-tests
+        GCC 9 C++11 TSAN:
+          TOOLSET: gcc
+          CXX: g++-9
+          PACKAGES: g++-9
+          VARIANT: release
+          B2_FLAGS: <thread-sanitizer>norecover
+          CXX_FLAGS: <cxxflags>"-msse4.2 -funsigned-char -fno-omit-frame-pointer"
+          CXXSTD: 11
+          B2_TARGETS: libs/beast/test//run-fat-tests
         GCC 8 C++17 Release:
           TOOLSET: gcc
           CXX: g++-8

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
       - bash: |
             set -e
             cd ../boost-root
-            ./b2 libs/beast/test//run-fat-tests toolset=gcc coverage=all link=static cxxstd=11 -j2
+            ./b2 libs/beast/test//run-fat-tests toolset=gcc coverage=on link=static cxxstd=11 -j2
             libs/beast/tools/coverage.sh
         env:
             CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/doc/qbk/03_core/1_refresher.qbk
+++ b/doc/qbk/03_core/1_refresher.qbk
@@ -290,7 +290,7 @@ in place of the completion handler. The same `async_write` function overload
 can work with a
 [@https://en.wikipedia.org/wiki/Fiber_(computer_science) ['fiber]]
 launched with
-[@boost:/doc/html/boost_asio/reference/spawn/overload1.html `net::spawn`]:
+[@boost:/doc/html/boost_asio/reference/spawn/overload1.html `asio::spawn`]:
 
 [code_core_1_refresher_5s]
 

--- a/example/echo-op/echo_op.cpp
+++ b/example/echo-op/echo_op.cpp
@@ -41,7 +41,7 @@ async_echo (AsyncStream& stream, DynamicBuffer& buffer, CompletionToken&& token)
     This function is used to asynchronously read a line ending
     in a newline (`"\n"`) from the stream, and then write
     it back.
-    
+
     This call always returns immediately. The asynchronous operation
     will continue until one of the following conditions is true:
 
@@ -76,7 +76,7 @@ async_echo (AsyncStream& stream, DynamicBuffer& buffer, CompletionToken&& token)
         beast::error_code error      // Result of operation.
     );
     @endcode
-    
+
     Regardless of whether the asynchronous operation completes immediately or
     not, the handler will not be invoked from within this function. Invocation
     of the handler will be performed in a manner equivalent to using
@@ -161,10 +161,10 @@ async_echo(
 
     // This nested class implements the echo composed operation as a
     // stateful completion handler. We derive from `async_base` to
-    // take care of boilerplate and we derived from net::coroutine to
+    // take care of boilerplate and we derived from asio::coroutine to
     // allow the reenter and yield keywords to work.
 
-    struct echo_op : base_type, net::coroutine
+    struct echo_op : base_type, boost::asio::coroutine
     {
         AsyncStream& stream_;
         DynamicBuffer& buffer_;

--- a/example/http/client/coro-ssl/http_client_coro_ssl.cpp
+++ b/example/http/client/coro-ssl/http_client_coro_ssl.cpp
@@ -162,7 +162,7 @@ int main(int argc, char** argv)
     ctx.set_verify_mode(ssl::verify_peer);
 
     // Launch the asynchronous operation
-    net::spawn(ioc, std::bind(
+    boost::asio::spawn(ioc, std::bind(
         &do_session,
         std::string(host),
         std::string(port),

--- a/example/http/client/coro/http_client_coro.cpp
+++ b/example/http/client/coro/http_client_coro.cpp
@@ -127,7 +127,7 @@ int main(int argc, char** argv)
     net::io_context ioc;
 
     // Launch the asynchronous operation
-    net::spawn(ioc, std::bind(
+    boost::asio::spawn(ioc, std::bind(
         &do_session,
         std::string(host),
         std::string(port),

--- a/example/http/server/coro-ssl/http_server_coro_ssl.cpp
+++ b/example/http/server/coro-ssl/http_server_coro_ssl.cpp
@@ -371,7 +371,7 @@ do_listen(
         if(ec)
             fail(ec, "accept");
         else
-            net::spawn(
+            boost::asio::spawn(
                 acceptor.get_executor(),
                 std::bind(
                     &do_session,
@@ -408,7 +408,7 @@ int main(int argc, char* argv[])
     load_server_certificate(ctx);
 
     // Spawn a listening port
-    net::spawn(ioc,
+    boost::asio::spawn(ioc,
         std::bind(
             &do_listen,
             std::ref(ioc),

--- a/example/http/server/coro/http_server_coro.cpp
+++ b/example/http/server/coro/http_server_coro.cpp
@@ -334,7 +334,7 @@ do_listen(
         if(ec)
             fail(ec, "accept");
         else
-            net::spawn(
+            boost::asio::spawn(
                 acceptor.get_executor(),
                 std::bind(
                     &do_session,
@@ -364,7 +364,7 @@ int main(int argc, char* argv[])
     net::io_context ioc{threads};
 
     // Spawn a listening port
-    net::spawn(ioc,
+    boost::asio::spawn(ioc,
         std::bind(
             &do_listen,
             std::ref(ioc),

--- a/example/http/server/stackless-ssl/http_server_stackless_ssl.cpp
+++ b/example/http/server/stackless-ssl/http_server_stackless_ssl.cpp
@@ -238,7 +238,7 @@ fail(beast::error_code ec, char const* what)
 
 // Handles an HTTP server connection
 class session
-    : public net::coroutine
+    : public boost::asio::coroutine
     , public std::enable_shared_from_this<session>
 {
     // This is the C++11 equivalent of a generic lambda.
@@ -398,7 +398,7 @@ public:
 
 // Accepts incoming connections and launches the sessions
 class listener
-    : public net::coroutine
+    : public boost::asio::coroutine
     , public std::enable_shared_from_this<listener>
 {
     net::io_context& ioc_;

--- a/example/http/server/stackless/http_server_stackless.cpp
+++ b/example/http/server/stackless/http_server_stackless.cpp
@@ -214,7 +214,7 @@ fail(beast::error_code ec, char const* what)
 
 // Handles an HTTP server connection
 class session
-    : public net::coroutine
+    : public boost::asio::coroutine
     , public std::enable_shared_from_this<session>
 {
     // This is the C++11 equivalent of a generic lambda.
@@ -344,7 +344,7 @@ public:
 
 // Accepts incoming connections and launches the sessions
 class listener
-    : public net::coroutine
+    : public boost::asio::coroutine
     , public std::enable_shared_from_this<listener>
 {
     net::io_context& ioc_;
@@ -407,7 +407,7 @@ public:
 private:
 
     #include <boost/asio/yield.hpp>
-    
+
     void
     loop(beast::error_code ec = {})
     {

--- a/example/websocket/client/coro-ssl/websocket_client_coro_ssl.cpp
+++ b/example/websocket/client/coro-ssl/websocket_client_coro_ssl.cpp
@@ -153,7 +153,7 @@ int main(int argc, char** argv)
     load_root_certificates(ctx);
 
     // Launch the asynchronous operation
-    net::spawn(ioc, std::bind(
+    boost::asio::spawn(ioc, std::bind(
         &do_session,
         std::string(host),
         std::string(port),

--- a/example/websocket/client/coro/websocket_client_coro.cpp
+++ b/example/websocket/client/coro/websocket_client_coro.cpp
@@ -132,7 +132,7 @@ int main(int argc, char** argv)
     net::io_context ioc;
 
     // Launch the asynchronous operation
-    net::spawn(ioc, std::bind(
+    boost::asio::spawn(ioc, std::bind(
         &do_session,
         std::string(host),
         std::string(port),

--- a/example/websocket/server/coro-ssl/websocket_server_coro_ssl.cpp
+++ b/example/websocket/server/coro-ssl/websocket_server_coro_ssl.cpp
@@ -148,7 +148,7 @@ do_listen(
         if(ec)
             fail(ec, "accept");
         else
-            net::spawn(
+            boost::asio::spawn(
                 acceptor.get_executor(),
                 std::bind(
                     &do_session,
@@ -183,7 +183,7 @@ int main(int argc, char* argv[])
     load_server_certificate(ctx);
 
     // Spawn a listening port
-    net::spawn(ioc,
+    boost::asio::spawn(ioc,
         std::bind(
             &do_listen,
             std::ref(ioc),

--- a/example/websocket/server/coro/websocket_server_coro.cpp
+++ b/example/websocket/server/coro/websocket_server_coro.cpp
@@ -129,7 +129,7 @@ do_listen(
         if(ec)
             fail(ec, "accept");
         else
-            net::spawn(
+            boost::asio::spawn(
                 acceptor.get_executor(),
                 std::bind(
                     &do_session,
@@ -158,7 +158,7 @@ int main(int argc, char* argv[])
     net::io_context ioc(threads);
 
     // Spawn a listening port
-    net::spawn(ioc,
+    boost::asio::spawn(ioc,
         std::bind(
             &do_listen,
             std::ref(ioc),

--- a/example/websocket/server/fast/websocket_server_fast.cpp
+++ b/example/websocket/server/fast/websocket_server_fast.cpp
@@ -100,7 +100,7 @@ do_sync_session(websocket::stream<beast::tcp_stream>& ws)
     for(;;)
     {
         beast::flat_buffer buffer;
-        
+
         ws.read(buffer, ec);
         if(ec == websocket::error::closed)
             break;
@@ -405,7 +405,7 @@ do_coro_listen(
             continue;
         }
 
-        net::spawn(
+        boost::asio::spawn(
             acceptor.get_executor(),
             std::bind(
                 &do_coro_session,
@@ -456,7 +456,7 @@ int main(int argc, char* argv[])
             static_cast<unsigned short>(port + 1u)})->run();
 
     // Create coro port
-    net::spawn(ioc,
+    boost::asio::spawn(ioc,
         std::bind(
             &do_coro_listen,
             std::ref(ioc),

--- a/example/websocket/server/stackless-ssl/websocket_server_stackless_ssl.cpp
+++ b/example/websocket/server/stackless-ssl/websocket_server_stackless_ssl.cpp
@@ -48,7 +48,7 @@ fail(beast::error_code ec, char const* what)
 
 // Echoes back all received WebSocket messages
 class session
-    : public net::coroutine
+    : public boost::asio::coroutine
     , public std::enable_shared_from_this<session>
 {
     websocket::stream<beast::ssl_stream<beast::tcp_stream>> ws_;
@@ -164,7 +164,7 @@ public:
 
 // Accepts incoming connections and launches the sessions
 class listener
-    : public net::coroutine
+    : public boost::asio::coroutine
     , public std::enable_shared_from_this<listener>
 {
     net::io_context& ioc_;

--- a/example/websocket/server/stackless/websocket_server_stackless.cpp
+++ b/example/websocket/server/stackless/websocket_server_stackless.cpp
@@ -43,7 +43,7 @@ fail(beast::error_code ec, char const* what)
 
 // Echoes back all received WebSocket messages
 class session
-    : public net::coroutine
+    : public boost::asio::coroutine
     , public std::enable_shared_from_this<session>
 {
     websocket::stream<beast::tcp_stream> ws_;
@@ -65,7 +65,7 @@ public:
     }
 
     #include <boost/asio/yield.hpp>
-    
+
     void
     loop(
         beast::error_code ec,
@@ -141,7 +141,7 @@ public:
 
 // Accepts incoming connections and launches the sessions
 class listener
-    : public net::coroutine
+    : public boost::asio::coroutine
     , public std::enable_shared_from_this<listener>
 {
     net::io_context& ioc_;
@@ -202,7 +202,7 @@ public:
 private:
 
     #include <boost/asio/yield.hpp>
-    
+
     void
     loop(beast::error_code ec = {})
     {

--- a/include/boost/beast/_experimental/http/impl/icy_stream.hpp
+++ b/include/boost/beast/_experimental/http/impl/icy_stream.hpp
@@ -35,7 +35,7 @@ is_icy(ConstBufferSequence const& buffers)
     char buf[3];
     auto const n = net::buffer_copy(
         net::mutable_buffer(buf, 3),
-        buffers);   
+        buffers);
     if(n >= 1 && buf[0] != 'I')
         return false;
     if(n >= 2 && buf[1] != 'C')
@@ -57,7 +57,7 @@ template<class Buffers, class Handler>
 class read_op
     : public beast::async_base<Handler,
         beast::executor_type<icy_stream>>
-    , public net::coroutine
+    , public asio::coroutine
 {
     icy_stream& s_;
     Buffers b_;

--- a/include/boost/beast/_experimental/test/impl/stream.hpp
+++ b/include/boost/beast/_experimental/test/impl/stream.hpp
@@ -12,7 +12,6 @@
 
 #include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/buffer_traits.hpp>
-#include <boost/beast/core/buffers_prefix.hpp>
 #include <boost/beast/core/detail/service_base.hpp>
 #include <boost/beast/core/detail/type_traits.hpp>
 #include <mutex>

--- a/include/boost/beast/_experimental/test/impl/stream.ipp
+++ b/include/boost/beast/_experimental/test/impl/stream.ipp
@@ -13,7 +13,6 @@
 #include <boost/beast/_experimental/test/stream.hpp>
 #include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/buffer_traits.hpp>
-#include <boost/beast/core/buffers_prefix.hpp>
 #include <boost/make_shared.hpp>
 #include <stdexcept>
 #include <vector>
@@ -278,7 +277,7 @@ str() const
     auto const bs = in_->b.data();
     if(buffer_bytes(bs) == 0)
         return {};
-    auto const b = beast::buffers_front(bs);
+    net::const_buffer const b = *net::buffer_sequence_begin(bs);
     return {static_cast<char const*>(b.data()), b.size()};
 }
 

--- a/include/boost/beast/core/detail/char_buffer.hpp
+++ b/include/boost/beast/core/detail/char_buffer.hpp
@@ -1,0 +1,78 @@
+//
+// Copyright (c) 2019 Damian Jarek(damian.jarek93@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_CORE_DETAIL_CHAR_BUFFER_HPP
+#define BOOST_BEAST_CORE_DETAIL_CHAR_BUFFER_HPP
+
+#include <boost/config.hpp>
+#include <cstddef>
+#include <cstring>
+#include <cstdint>
+
+namespace boost {
+namespace beast {
+namespace detail {
+
+template <std::size_t N>
+class char_buffer
+{
+public:
+    bool try_push_back(char c)
+    {
+        if (size_ == N)
+            return false;
+        buf_[size_++] = c;
+        return true;
+    }
+
+    bool try_append(char const* first, char const* last)
+    {
+        std::size_t const n = last - first;
+        if (n > N - size_)
+            return false;
+        std::memmove(&buf_[size_], first, n);
+        size_ += n;
+        return true;
+    }
+
+    void clear() noexcept
+    {
+        size_ = 0;
+    }
+
+    char* data() noexcept
+    {
+        return buf_;
+    }
+
+    char const* data() const noexcept
+    {
+        return buf_;
+    }
+
+    std::size_t size() const noexcept
+    {
+        return size_;
+    }
+
+    bool empty() const noexcept
+    {
+        return size_ == 0;
+    }
+
+private:
+    std::size_t size_= 0;
+    char buf_[N];
+};
+
+} // detail
+} // beast
+} // boost
+
+#endif

--- a/include/boost/beast/core/detail/impl/read.hpp
+++ b/include/boost/beast/core/detail/impl/read.hpp
@@ -37,7 +37,7 @@ template<
     class Condition,
     class Handler>
 class read_op
-    : public net::coroutine
+    : public asio::coroutine
     , public async_base<
         Handler, beast::executor_type<Stream>>
 {

--- a/include/boost/beast/core/detail/impl/read.hpp
+++ b/include/boost/beast/core/detail/impl/read.hpp
@@ -13,6 +13,7 @@
 #include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/async_base.hpp>
 #include <boost/beast/core/flat_static_buffer.hpp>
+#include <boost/beast/core/read_size.hpp>
 #include <boost/asio/basic_stream_socket.hpp>
 #include <boost/asio/coroutine.hpp>
 #include <boost/throw_exception.hpp>
@@ -73,18 +74,12 @@ public:
         std::size_t bytes_transferred,
         bool cont = true)
     {
-        std::size_t max_size;
         std::size_t max_prepare;
         BOOST_ASIO_CORO_REENTER(*this)
         {
             for(;;)
             {
-                max_size = cond_(ec, total_, b_);
-                max_prepare = std::min<std::size_t>(
-                    std::max<std::size_t>(
-                        512, b_.capacity() - b_.size()),
-                    std::min<std::size_t>(
-                        max_size, b_.max_size() - b_.size()));
+                max_prepare = beast::read_size(b_, cond_(ec, total_, b_));
                 if(max_prepare == 0)
                     break;
                 BOOST_ASIO_CORO_YIELD
@@ -201,16 +196,10 @@ read(
         "CompletionCondition type requirements not met");
     ec = {};
     std::size_t total = 0;
-    std::size_t max_size;
     std::size_t max_prepare;
     for(;;)
     {
-        max_size = cond(ec, total, buffer);
-        max_prepare = std::min<std::size_t>(
-            std::max<std::size_t>(
-                512, buffer.capacity() - buffer.size()),
-            std::min<std::size_t>(
-                max_size, buffer.max_size() - buffer.size()));
+        max_prepare =  beast::read_size(buffer, cond(ec, total, buffer));
         if(max_prepare == 0)
             break;
         std::size_t const bytes_transferred =

--- a/include/boost/beast/core/detail/impl/temporary_buffer.ipp
+++ b/include/boost/beast/core/detail/impl/temporary_buffer.ipp
@@ -1,0 +1,67 @@
+//
+// Copyright (c) 2019 Damian Jarek(damian.jarek93@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_DETAIL_IMPL_TEMPORARY_BUFFER_IPP
+#define BOOST_BEAST_DETAIL_IMPL_TEMPORARY_BUFFER_IPP
+
+#include <boost/beast/core/detail/temporary_buffer.hpp>
+#include <boost/beast/core/detail/clamp.hpp>
+#include <boost/core/exchange.hpp>
+
+#include <memory>
+#include <cstring>
+
+namespace boost {
+namespace beast {
+namespace detail {
+
+
+void
+temporary_buffer::append(string_view sv)
+{
+    grow(sv.size());
+    unchecked_append(sv);
+}
+
+void
+temporary_buffer::append(string_view sv1, string_view sv2)
+{
+    grow(sv1.size() + sv2.size());
+    unchecked_append(sv1);
+    unchecked_append(sv2);
+}
+
+void
+temporary_buffer::unchecked_append(string_view sv)
+{
+    auto n = sv.size();
+    std::memcpy(&data_[size_], sv.data(), n);
+    size_ += n;
+}
+
+void
+temporary_buffer::grow(std::size_t sv_size)
+{
+    if (capacity_ - size_ >= sv_size)
+    {
+        return;
+    }
+
+    auto const new_cap = (sv_size + size_) * 2u;
+    BOOST_ASSERT(!detail::sum_exceeds(sv_size, size_, new_cap));
+    char* const p = new char[new_cap];
+    std::memcpy(p, data_, size_);
+    deallocate(boost::exchange(data_, p));
+    capacity_ = new_cap;
+}
+} // detail
+} // beast
+} // boost
+
+#endif

--- a/include/boost/beast/core/detail/string.hpp
+++ b/include/boost/beast/core/detail/string.hpp
@@ -1,0 +1,57 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_DETAIL_STRING_HPP
+#define BOOST_BEAST_DETAIL_STRING_HPP
+
+#include <boost/beast/core/detail/config.hpp>
+#include <boost/version.hpp>
+
+#if defined(BOOST_BEAST_USE_STD_STRING_VIEW)
+#include <string_view>
+#else
+#include <boost/utility/string_view.hpp>
+#endif
+
+namespace boost {
+namespace beast {
+
+namespace detail {
+
+#if defined(BOOST_BEAST_USE_STD_STRING_VIEW)
+  using string_view = std::string_view;
+
+  template<class CharT, class Traits>
+  using basic_string_view =
+      std::basic_string_view<CharT, Traits>;
+#else
+  using string_view = boost::string_view;
+
+  template<class CharT, class Traits>
+  using basic_string_view =
+      boost::basic_string_view<CharT, Traits>;
+#endif
+
+inline string_view operator "" _sv(char const* p, std::size_t n)
+{
+    return string_view{p, n};
+}
+
+inline
+char
+ascii_tolower(char c)
+{
+    return ((static_cast<unsigned>(c) - 65U) < 26) ?
+        c + 'a' - 'A' : c;
+}
+} // detail
+} // beast
+} // boost
+
+#endif

--- a/include/boost/beast/core/detail/temporary_buffer.hpp
+++ b/include/boost/beast/core/detail/temporary_buffer.hpp
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2019 Damian Jarek(damian.jarek93@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_DETAIL_TEMPORARY_BUFFER_HPP
+#define BOOST_BEAST_DETAIL_TEMPORARY_BUFFER_HPP
+
+#include <boost/beast/core/detail/config.hpp>
+#include <boost/beast/core/string.hpp>
+
+#include <memory>
+
+namespace boost {
+namespace beast {
+namespace detail {
+
+struct temporary_buffer
+{
+    temporary_buffer() = default;
+
+    temporary_buffer(temporary_buffer const&) = delete;
+    temporary_buffer(temporary_buffer&&) = delete;
+
+    temporary_buffer& operator=(temporary_buffer const&) = delete;
+    temporary_buffer& operator=(temporary_buffer&&) = delete;
+
+    ~temporary_buffer() noexcept
+    {
+        deallocate(data_);
+    }
+
+    BOOST_BEAST_DECL
+    void
+    append(string_view sv);
+
+    BOOST_BEAST_DECL
+    void
+    append(string_view sv1, string_view sv2);
+
+    string_view
+    view() const noexcept
+    {
+        return {data_, size_};
+    }
+
+    bool
+    empty() const noexcept
+    {
+        return size_ == 0;
+    }
+
+private:
+    BOOST_BEAST_DECL
+    void
+    unchecked_append(string_view sv);
+
+    BOOST_BEAST_DECL
+    void
+    grow(std::size_t sv_size);
+
+    void
+    deallocate(char* data) noexcept
+    {
+        if (data != buffer_)
+            delete[] data;
+    }
+
+    char buffer_[4096];
+    char* data_ = buffer_;
+    std::size_t capacity_ = sizeof(buffer_);
+    std::size_t size_ = 0;
+};
+
+} // detail
+} // beast
+} // boost
+
+#ifdef BOOST_BEAST_HEADER_ONLY
+#include <boost/beast/core/detail/impl/temporary_buffer.ipp>
+#endif
+
+#endif

--- a/include/boost/beast/core/impl/flat_stream.hpp
+++ b/include/boost/beast/core/impl/flat_stream.hpp
@@ -16,7 +16,6 @@
 #include <boost/beast/core/stream_traits.hpp>
 #include <boost/beast/websocket/teardown.hpp>
 #include <boost/asio/buffer.hpp>
-#include <boost/asio/coroutine.hpp>
 #include <memory>
 
 namespace boost {
@@ -30,7 +29,6 @@ template<class Handler>
 class write_op
     : public async_base<Handler,
         beast::executor_type<flat_stream>>
-    , public net::coroutine
 {
 public:
     template<

--- a/include/boost/beast/core/impl/read_size.hpp
+++ b/include/boost/beast/core/impl/read_size.hpp
@@ -46,7 +46,6 @@ read_size(DynamicBuffer& buffer,
     static_assert(
         net::is_dynamic_buffer<DynamicBuffer>::value,
         "DynamicBuffer type requirements not met");
-    BOOST_ASSERT(max_size >= 1);
     auto const size = buffer.size();
     auto const limit = buffer.max_size() - size;
     BOOST_ASSERT(size <= buffer.max_size());

--- a/include/boost/beast/core/impl/string.ipp
+++ b/include/boost/beast/core/impl/string.ipp
@@ -1,0 +1,71 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_IMPL_STRING_IPP
+#define BOOST_BEAST_IMPL_STRING_IPP
+
+#include <boost/beast/core/string.hpp>
+
+#include <algorithm>
+
+namespace boost {
+namespace beast {
+
+bool
+iequals(
+    beast::string_view lhs,
+    beast::string_view rhs)
+{
+    auto n = lhs.size();
+    if(rhs.size() != n)
+        return false;
+    auto p1 = lhs.data();
+    auto p2 = rhs.data();
+    char a, b;
+    // fast loop
+    while(n--)
+    {
+        a = *p1++;
+        b = *p2++;
+        if(a != b)
+            goto slow;
+    }
+    return true;
+slow:
+    do
+    {
+        if(detail::ascii_tolower(a) != detail::ascii_tolower(b))
+            return false;
+        a = *p1++;
+        b = *p2++;
+    }
+    while(n--);
+    return true;
+}
+
+bool
+iless::operator()(
+        string_view lhs,
+        string_view rhs) const
+{
+    using std::begin;
+    using std::end;
+    return std::lexicographical_compare(
+        begin(lhs), end(lhs), begin(rhs), end(rhs),
+        [](char c1, char c2)
+        {
+            return detail::ascii_tolower(c1) < detail::ascii_tolower(c2);
+        }
+    );
+}
+
+} // beast
+} // boost
+
+#endif

--- a/include/boost/beast/core/string.hpp
+++ b/include/boost/beast/core/string.hpp
@@ -10,82 +10,17 @@
 #ifndef BOOST_BEAST_STRING_HPP
 #define BOOST_BEAST_STRING_HPP
 
-#include <boost/beast/core/detail/config.hpp>
-#include <boost/version.hpp>
-
-#if defined(BOOST_BEAST_USE_STD_STRING_VIEW)
-#include <string_view>
-#else
-#include <boost/utility/string_view.hpp>
-#endif
-
-#include <algorithm>
+#include <boost/beast/core/detail/string.hpp>
 
 namespace boost {
 namespace beast {
 
-#if defined(BOOST_BEAST_USE_STD_STRING_VIEW)
-  /// The type of string view used by the library
-  using string_view = std::string_view;
+/// The type of string view used by the library
+using detail::string_view;
 
-  /// The type of basic string view used by the library
-  template<class CharT, class Traits>
-  using basic_string_view =
-      std::basic_string_view<CharT, Traits>;
-#else
-  /// The type of string view used by the library
-  using string_view = boost::string_view;
-
-  /// The type of basic string view used by the library
-  template<class CharT, class Traits>
-  using basic_string_view =
-      boost::basic_string_view<CharT, Traits>;
-#endif
-
-namespace detail {
-
-inline
-char
-ascii_tolower(char c)
-{
-    return ((static_cast<unsigned>(c) - 65U) < 26) ?
-        c + 'a' - 'A' : c;
-}
-
-template<class = void>
-bool
-iequals(
-    beast::string_view lhs,
-    beast::string_view rhs)
-{
-    auto n = lhs.size();
-    if(rhs.size() != n)
-        return false;
-    auto p1 = lhs.data();
-    auto p2 = rhs.data();
-    char a, b;
-    // fast loop
-    while(n--)
-    {
-        a = *p1++;
-        b = *p2++;
-        if(a != b)
-            goto slow;
-    }
-    return true;
-slow:
-    do
-    {
-        if(ascii_tolower(a) != ascii_tolower(b))
-            return false;
-        a = *p1++;
-        b = *p2++;
-    }
-    while(n--);
-    return true;
-}
-
-} // detail
+/// The type of basic string view used by the library
+template<class CharT, class Traits>
+using basic_string_view = detail::basic_string_view<CharT, Traits>;
 
 /** Returns `true` if two strings are equal, using a case-insensitive comparison.
 
@@ -95,14 +30,11 @@ slow:
 
     @param rhs The string on the right side of the equality
 */
-inline
+BOOST_BEAST_DECL
 bool
 iequals(
     beast::string_view lhs,
-    beast::string_view rhs)
-{
-    return detail::iequals(lhs, rhs);
-}
+    beast::string_view rhs);
 
 /** A case-insensitive less predicate for strings.
 
@@ -110,21 +42,11 @@ iequals(
 */
 struct iless
 {
+    BOOST_BEAST_DECL
     bool
     operator()(
         string_view lhs,
-        string_view rhs) const
-    {
-        using std::begin;
-        using std::end;
-        return std::lexicographical_compare(
-            begin(lhs), end(lhs), begin(rhs), end(rhs),
-            [](char c1, char c2)
-            {
-                return detail::ascii_tolower(c1) < detail::ascii_tolower(c2);
-            }
-        );
-    }
+        string_view rhs) const;
 };
 
 /** A case-insensitive equality predicate for strings.
@@ -144,5 +66,9 @@ struct iequal
 
 } // beast
 } // boost
+
+#ifdef BOOST_BEAST_HEADER_ONLY
+#include <boost/beast/core/impl/string.ipp>
+#endif
 
 #endif

--- a/include/boost/beast/http/detail/basic_parser.hpp
+++ b/include/boost/beast/http/detail/basic_parser.hpp
@@ -11,6 +11,7 @@
 #define BOOST_BEAST_HTTP_DETAIL_BASIC_PARSER_HPP
 
 #include <boost/beast/core/string.hpp>
+#include <boost/beast/core/detail/char_buffer.hpp>
 #include <boost/beast/http/error.hpp>
 #include <boost/beast/http/detail/rfc7230.hpp>
 #include <boost/config.hpp>
@@ -22,59 +23,6 @@ namespace boost {
 namespace beast {
 namespace http {
 namespace detail {
-
-template <std::size_t N>
-class char_buffer
-{
-public:
-    bool try_push_back(char c)
-    {
-        if (size_ == N)
-            return false;
-        buf_[size_++] = c;
-        return true;
-    }
-
-    bool try_append(char const* first, char const* last)
-    {
-        std::size_t const n = last - first;
-        if (n > N - size_)
-            return false;
-        std::memmove(&buf_[size_], first, n);
-        size_ += n;
-        return true;
-    }
-
-    void clear() noexcept
-    {
-        size_ = 0;
-    }
-
-    char* data() noexcept
-    {
-        return buf_;
-    }
-
-    char const* data() const noexcept
-    {
-        return buf_;
-    }
-
-    std::size_t size() const noexcept
-    {
-        return size_;
-    }
-
-    bool empty() const noexcept
-    {
-        return size_ == 0;
-    }
-
-private:
-    std::size_t size_= 0;
-    char buf_[N];
-};
-
 
 struct basic_parser_base
 {
@@ -234,7 +182,7 @@ struct basic_parser_base
         char const* last,
         string_view& name,
         string_view& value,
-        char_buffer<max_obs_fold>& buf,
+        beast::detail::char_buffer<max_obs_fold>& buf,
         error_code& ec);
 
     BOOST_BEAST_DECL

--- a/include/boost/beast/http/detail/basic_parser.ipp
+++ b/include/boost/beast/http/detail/basic_parser.ipp
@@ -495,7 +495,7 @@ parse_field(
     char const* last,
     string_view& name,
     string_view& value,
-    char_buffer<max_obs_fold>& buf,
+    beast::detail::char_buffer<max_obs_fold>& buf,
     error_code& ec)
 {
 /*  header-field    = field-name ":" OWS field-value OWS

--- a/include/boost/beast/http/fields.hpp
+++ b/include/boost/beast/http/fields.hpp
@@ -62,8 +62,6 @@ class basic_fields
 
     friend class fields_test; // for `header`
 
-    static std::size_t constexpr max_static_buffer = 4096;
-
     struct element;
 
     using off_t = std::uint16_t;
@@ -72,7 +70,7 @@ public:
     /// The type of allocator used.
     using allocator_type = Allocator;
 
-    /// The type of element used to represent a field 
+    /// The type of element used to represent a field
     class value_type
     {
         friend class basic_fields;

--- a/include/boost/beast/http/impl/basic_parser.ipp
+++ b/include/boost/beast/http/impl/basic_parser.ipp
@@ -404,7 +404,7 @@ parse_fields(char const*& in,
     string_view name;
     string_view value;
     // https://stackoverflow.com/questions/686217/maximum-on-http-header-values
-    detail::char_buffer<max_obs_fold> buf;
+    beast::detail::char_buffer<max_obs_fold> buf;
     auto p = in;
     for(;;)
     {

--- a/include/boost/beast/http/impl/fields.ipp
+++ b/include/boost/beast/http/impl/fields.ipp
@@ -1,0 +1,138 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_HTTP_IMPL_FIELDS_IPP
+#define BOOST_BEAST_HTTP_IMPL_FIELDS_IPP
+
+#include <boost/beast/http/fields.hpp>
+
+namespace boost {
+namespace beast {
+namespace http {
+namespace detail {
+
+// `basic_fields` assumes that `std::size_t` is larger than `uint16_t`, so we
+// verify it explicitly here, so that users that use split compilation don't
+// need to pay the (fairly small) price for this sanity check
+BOOST_STATIC_ASSERT((std::numeric_limits<std::size_t>::max)() >=
+    (std::numeric_limits<std::uint32_t>::max)());
+
+// Filter a token list
+//
+inline
+void
+filter_token_list(
+    beast::detail::temporary_buffer& s,
+    string_view value,
+    iequals_predicate const& pred)
+{
+    token_list te{value};
+    auto it = te.begin();
+    auto last = te.end();
+    if(it == last)
+        return;
+    while(pred(*it))
+        if(++it == last)
+            return;
+    s.append(*it);
+    while(++it != last)
+    {
+        if(! pred(*it))
+        {
+            s.append(", ", *it);
+        }
+    }
+}
+
+void
+filter_token_list_last(
+    beast::detail::temporary_buffer& s,
+    string_view value,
+    iequals_predicate const& pred)
+{
+    token_list te{value};
+    if(te.begin() != te.end())
+    {
+        auto it = te.begin();
+        auto next = std::next(it);
+        if(next == te.end())
+        {
+            if(! pred(*it))
+                s.append(*it);
+            return;
+        }
+        s.append(*it);
+        for(;;)
+        {
+            it = next;
+            next = std::next(it);
+            if(next == te.end())
+            {
+                if(! pred(*it))
+                {
+                    s.append(", ", *it);
+                }
+                return;
+            }
+            s.append(", ", *it);
+        }
+    }
+}
+
+void
+keep_alive_impl(
+    beast::detail::temporary_buffer& s, string_view value,
+    unsigned version, bool keep_alive)
+{
+    if(version < 11)
+    {
+        if(keep_alive)
+        {
+            // remove close
+            filter_token_list(s, value, iequals_predicate{"close"});
+            // add keep-alive
+            if(s.empty())
+                s.append("keep-alive");
+            else if(! token_list{value}.exists("keep-alive"))
+                s.append(", keep-alive");
+        }
+        else
+        {
+            // remove close and keep-alive
+            filter_token_list(s, value,
+                iequals_predicate{"close", "keep-alive"});
+        }
+    }
+    else
+    {
+        if(keep_alive)
+        {
+            // remove close and keep-alive
+            filter_token_list(s, value,
+                iequals_predicate{"close", "keep-alive"});
+        }
+        else
+        {
+            // remove keep-alive
+            filter_token_list(s, value, iequals_predicate{"keep-alive"});
+            // add close
+            if(s.empty())
+                s.append("close");
+            else if(! token_list{value}.exists("close"))
+                s.append(", close");
+        }
+    }
+}
+
+} // detail
+} // http
+} // beast
+} // boost
+
+#endif // BOOST_BEAST_HTTP_IMPL_FIELDS_IPP

--- a/include/boost/beast/http/impl/read.hpp
+++ b/include/boost/beast/http/impl/read.hpp
@@ -164,7 +164,7 @@ template<
 class read_msg_op
     : public beast::stable_async_base<
         Handler, beast::executor_type<Stream>>
-    , public net::coroutine
+    , public asio::coroutine
 {
     using parser_type =
         parser<isRequest, Body, Allocator>;

--- a/include/boost/beast/http/impl/verb.ipp
+++ b/include/boost/beast/http/impl/verb.ipp
@@ -21,50 +21,51 @@ namespace http {
 string_view
 to_string(verb v)
 {
+    using beast::detail::operator "" _sv;
     switch(v)
     {
-    case verb::delete_:       return "DELETE";
-    case verb::get:           return "GET";
-    case verb::head:          return "HEAD";
-    case verb::post:          return "POST";
-    case verb::put:           return "PUT";
-    case verb::connect:       return "CONNECT";
-    case verb::options:       return "OPTIONS";
-    case verb::trace:         return "TRACE";
+    case verb::delete_:       return "DELETE"_sv;
+    case verb::get:           return "GET"_sv;
+    case verb::head:          return "HEAD"_sv;
+    case verb::post:          return "POST"_sv;
+    case verb::put:           return "PUT"_sv;
+    case verb::connect:       return "CONNECT"_sv;
+    case verb::options:       return "OPTIONS"_sv;
+    case verb::trace:         return "TRACE"_sv;
 
-    case verb::copy:          return "COPY";
-    case verb::lock:          return "LOCK";
-    case verb::mkcol:         return "MKCOL";
-    case verb::move:          return "MOVE";
-    case verb::propfind:      return "PROPFIND";
-    case verb::proppatch:     return "PROPPATCH";
-    case verb::search:        return "SEARCH";
-    case verb::unlock:        return "UNLOCK";
-    case verb::bind:          return "BIND";
-    case verb::rebind:        return "REBIND";
-    case verb::unbind:        return "UNBIND";
-    case verb::acl:           return "ACL";
+    case verb::copy:          return "COPY"_sv;
+    case verb::lock:          return "LOCK"_sv;
+    case verb::mkcol:         return "MKCOL"_sv;
+    case verb::move:          return "MOVE"_sv;
+    case verb::propfind:      return "PROPFIND"_sv;
+    case verb::proppatch:     return "PROPPATCH"_sv;
+    case verb::search:        return "SEARCH"_sv;
+    case verb::unlock:        return "UNLOCK"_sv;
+    case verb::bind:          return "BIND"_sv;
+    case verb::rebind:        return "REBIND"_sv;
+    case verb::unbind:        return "UNBIND"_sv;
+    case verb::acl:           return "ACL"_sv;
 
-    case verb::report:        return "REPORT";
-    case verb::mkactivity:    return "MKACTIVITY";
-    case verb::checkout:      return "CHECKOUT";
-    case verb::merge:         return "MERGE";
+    case verb::report:        return "REPORT"_sv;
+    case verb::mkactivity:    return "MKACTIVITY"_sv;
+    case verb::checkout:      return "CHECKOUT"_sv;
+    case verb::merge:         return "MERGE"_sv;
 
-    case verb::msearch:       return "M-SEARCH";
-    case verb::notify:        return "NOTIFY";
-    case verb::subscribe:     return "SUBSCRIBE";
-    case verb::unsubscribe:   return "UNSUBSCRIBE";
+    case verb::msearch:       return "M-SEARCH"_sv;
+    case verb::notify:        return "NOTIFY"_sv;
+    case verb::subscribe:     return "SUBSCRIBE"_sv;
+    case verb::unsubscribe:   return "UNSUBSCRIBE"_sv;
 
-    case verb::patch:         return "PATCH";
-    case verb::purge:         return "PURGE";
+    case verb::patch:         return "PATCH"_sv;
+    case verb::purge:         return "PURGE"_sv;
 
-    case verb::mkcalendar:    return "MKCALENDAR";
+    case verb::mkcalendar:    return "MKCALENDAR"_sv;
 
-    case verb::link:          return "LINK";
-    case verb::unlink:        return "UNLINK";
-    
+    case verb::link:          return "LINK"_sv;
+    case verb::unlink:        return "UNLINK"_sv;
+
     case verb::unknown:
-        return "<unknown>";
+        return "<unknown>"_sv;
     }
 
     BOOST_THROW_EXCEPTION(std::invalid_argument{"unknown verb"});
@@ -108,34 +109,20 @@ string_to_verb(string_view v)
     UNLOCK
     UNSUBSCRIBE
 */
+    using beast::detail::operator "" _sv;
     if(v.size() < 3)
         return verb::unknown;
-    // s must be null terminated
-    auto const eq =
-        [](string_view sv, char const* s)
-        {
-            auto p = sv.data();
-            for(;;)
-            {
-                if(*s != *p)
-                    return false;
-                ++s;
-                ++p;
-                if(! *s)
-                    return p == (sv.data() + sv.size());
-            }
-        };
     auto c = v[0];
     v.remove_prefix(1);
     switch(c)
     {
     case 'A':
-        if(v == "CL")
+        if(v == "CL"_sv)
             return verb::acl;
         break;
 
     case 'B':
-        if(v == "IND")
+        if(v == "IND"_sv)
             return verb::bind;
         break;
 
@@ -145,14 +132,14 @@ string_to_verb(string_view v)
         switch(c)
         {
         case 'H':
-            if(eq(v, "ECKOUT"))
+            if(v == "ECKOUT"_sv)
                 return verb::checkout;
             break;
 
         case 'O':
-            if(eq(v, "NNECT"))
+            if(v == "NNECT"_sv)
                 return verb::connect;
-            if(eq(v, "PY"))
+            if(v == "PY"_sv)
                 return verb::copy;
             BOOST_FALLTHROUGH;
 
@@ -162,24 +149,24 @@ string_to_verb(string_view v)
         break;
 
     case 'D':
-        if(eq(v, "ELETE"))
+        if(v == "ELETE"_sv)
             return verb::delete_;
         break;
 
     case 'G':
-        if(eq(v, "ET"))
+        if(v == "ET"_sv)
             return verb::get;
         break;
 
     case 'H':
-        if(eq(v, "EAD"))
+        if(v == "EAD"_sv)
             return verb::head;
         break;
 
     case 'L':
-        if(eq(v, "INK"))
+        if(v == "INK"_sv)
             return verb::link;
-        if(eq(v, "OCK"))
+        if(v == "OCK"_sv)
             return verb::lock;
         break;
 
@@ -189,31 +176,31 @@ string_to_verb(string_view v)
         switch(c)
         {
         case '-':
-            if(eq(v, "SEARCH"))
+            if(v == "SEARCH"_sv)
                 return verb::msearch;
             break;
 
         case 'E':
-            if(eq(v, "RGE"))
+            if(v == "RGE"_sv)
                 return verb::merge;
             break;
 
         case 'K':
-            if(eq(v, "ACTIVITY"))
+            if(v == "ACTIVITY"_sv)
                 return verb::mkactivity;
             if(v[0] == 'C')
             {
                 v.remove_prefix(1);
-                if(eq(v, "ALENDAR"))
+                if(v == "ALENDAR"_sv)
                     return verb::mkcalendar;
-                if(eq(v, "OL"))
+                if(v == "OL"_sv)
                     return verb::mkcol;
                 break;
             }
             break;
-        
+
         case 'O':
-            if(eq(v, "VE"))
+            if(v == "VE"_sv)
                 return verb::move;
             BOOST_FALLTHROUGH;
 
@@ -223,12 +210,12 @@ string_to_verb(string_view v)
         break;
 
     case 'N':
-        if(eq(v, "OTIFY"))
+        if(v == "OTIFY"_sv)
             return verb::notify;
         break;
 
     case 'O':
-        if(eq(v, "PTIONS"))
+        if(v == "PTIONS"_sv)
             return verb::options;
         break;
 
@@ -238,26 +225,26 @@ string_to_verb(string_view v)
         switch(c)
         {
         case 'A':
-            if(eq(v, "TCH"))
+            if(v == "TCH"_sv)
                 return verb::patch;
             break;
 
         case 'O':
-            if(eq(v, "ST"))
+            if(v == "ST"_sv)
                 return verb::post;
             break;
 
         case 'R':
-            if(eq(v, "OPFIND"))
+            if(v == "OPFIND"_sv)
                 return verb::propfind;
-            if(eq(v, "OPPATCH"))
+            if(v == "OPPATCH"_sv)
                 return verb::proppatch;
             break;
 
         case 'U':
-            if(eq(v, "RGE"))
+            if(v == "RGE"_sv)
                 return verb::purge;
-            if(eq(v, "T"))
+            if(v == "T"_sv)
                 return verb::put;
             BOOST_FALLTHROUGH;
 
@@ -270,21 +257,21 @@ string_to_verb(string_view v)
         if(v[0] != 'E')
             break;
         v.remove_prefix(1);
-        if(eq(v, "BIND"))
+        if(v == "BIND"_sv)
             return verb::rebind;
-        if(eq(v, "PORT"))
+        if(v == "PORT"_sv)
             return verb::report;
         break;
 
     case 'S':
-        if(eq(v, "EARCH"))
+        if(v == "EARCH"_sv)
             return verb::search;
-        if(eq(v, "UBSCRIBE"))
+        if(v == "UBSCRIBE"_sv)
             return verb::subscribe;
         break;
 
     case 'T':
-        if(eq(v, "RACE"))
+        if(v == "RACE"_sv)
             return verb::trace;
         break;
 
@@ -292,13 +279,13 @@ string_to_verb(string_view v)
         if(v[0] != 'N')
             break;
         v.remove_prefix(1);
-        if(eq(v, "BIND"))
+        if(v == "BIND"_sv)
             return verb::unbind;
-        if(eq(v, "LINK"))
+        if(v == "LINK"_sv)
             return verb::unlink;
-        if(eq(v, "LOCK"))
+        if(v == "LOCK"_sv)
             return verb::unlock;
-        if(eq(v, "SUBSCRIBE"))
+        if(v == "SUBSCRIBE"_sv)
             return verb::unsubscribe;
         break;
 

--- a/include/boost/beast/http/impl/write.hpp
+++ b/include/boost/beast/http/impl/write.hpp
@@ -159,7 +159,7 @@ template<
 class write_op
     : public beast::async_base<
         Handler, beast::executor_type<Stream>>
-    , public net::coroutine
+    , public asio::coroutine
 {
     Stream& s_;
     serializer<isRequest, Body, Fields>& sr_;

--- a/include/boost/beast/src.hpp
+++ b/include/boost/beast/src.hpp
@@ -31,6 +31,7 @@ the program, with the macro BOOST_BEAST_SEPARATE_COMPILATION defined.
 
 #include <boost/beast/core/detail/base64.ipp>
 #include <boost/beast/core/detail/sha1.ipp>
+#include <boost/beast/core/detail/impl/temporary_buffer.ipp>
 #include <boost/beast/core/impl/error.ipp>
 #include <boost/beast/core/impl/file_posix.ipp>
 #include <boost/beast/core/impl/file_stdio.ipp>
@@ -44,6 +45,7 @@ the program, with the macro BOOST_BEAST_SEPARATE_COMPILATION defined.
 #include <boost/beast/http/impl/basic_parser.ipp>
 #include <boost/beast/http/impl/error.ipp>
 #include <boost/beast/http/impl/field.ipp>
+#include <boost/beast/http/impl/fields.ipp>
 #include <boost/beast/http/impl/rfc7230.ipp>
 #include <boost/beast/http/impl/status.ipp>
 #include <boost/beast/http/impl/verb.ipp>

--- a/include/boost/beast/src.hpp
+++ b/include/boost/beast/src.hpp
@@ -39,6 +39,7 @@ the program, with the macro BOOST_BEAST_SEPARATE_COMPILATION defined.
 #include <boost/beast/core/impl/flat_static_buffer.ipp>
 #include <boost/beast/core/impl/saved_handler.ipp>
 #include <boost/beast/core/impl/static_buffer.ipp>
+#include <boost/beast/core/impl/string.ipp>
 
 #include <boost/beast/http/detail/basic_parser.ipp>
 #include <boost/beast/http/detail/rfc7230.ipp>

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 258
+#define BOOST_BEAST_VERSION 259
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/detail/hybi13.ipp
+++ b/include/boost/beast/websocket/detail/hybi13.ipp
@@ -47,11 +47,12 @@ make_sec_ws_accept(
     string_view key)
 {
     BOOST_ASSERT(key.size() <= sec_ws_key_type::max_size_n);
-    auto const& guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+    using beast::detail::operator "" _sv;
+    auto const guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"_sv;
     beast::detail::sha1_context ctx;
     beast::detail::init(ctx);
     beast::detail::update(ctx, key.data(), key.size());
-    beast::detail::update(ctx, guid, sizeof(guid) - 1);
+    beast::detail::update(ctx, guid.data(), guid.size());
     char digest[beast::detail::sha1_context::digest_size];
     beast::detail::finish(ctx, &digest[0]);
     accept.resize(accept.max_size());

--- a/include/boost/beast/websocket/detail/hybi13.ipp
+++ b/include/boost/beast/websocket/detail/hybi13.ipp
@@ -47,11 +47,11 @@ make_sec_ws_accept(
     string_view key)
 {
     BOOST_ASSERT(key.size() <= sec_ws_key_type::max_size_n);
-    static_string<sec_ws_key_type::max_size_n + 36> m(key);
-    m.append("258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+    auto const& guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
     beast::detail::sha1_context ctx;
     beast::detail::init(ctx);
-    beast::detail::update(ctx, m.data(), m.size());
+    beast::detail::update(ctx, key.data(), key.size());
+    beast::detail::update(ctx, guid, sizeof(guid) - 1);
     char digest[beast::detail::sha1_context::digest_size];
     beast::detail::finish(ctx, &digest[0]);
     accept.resize(accept.max_size());

--- a/include/boost/beast/websocket/impl/accept.hpp
+++ b/include/boost/beast/websocket/impl/accept.hpp
@@ -167,7 +167,7 @@ template<class Handler>
 class stream<NextLayer, deflateSupported>::response_op
     : public beast::stable_async_base<
         Handler, beast::executor_type<stream>>
-    , public net::coroutine
+    , public asio::coroutine
 {
     boost::weak_ptr<impl_type> wp_;
     error_code result_; // must come before res_
@@ -242,7 +242,7 @@ template<class Handler, class Decorator>
 class stream<NextLayer, deflateSupported>::accept_op
     : public beast::stable_async_base<
         Handler, beast::executor_type<stream>>
-    , public net::coroutine
+    , public asio::coroutine
 {
     boost::weak_ptr<impl_type> wp_;
     http::request_parser<http::empty_body>& p_;

--- a/include/boost/beast/websocket/impl/close.hpp
+++ b/include/boost/beast/websocket/impl/close.hpp
@@ -38,7 +38,7 @@ template<class Handler>
 class stream<NextLayer, deflateSupported>::close_op
     : public beast::stable_async_base<
         Handler, beast::executor_type<stream>>
-    , public net::coroutine
+    , public asio::coroutine
 {
     boost::weak_ptr<impl_type> wp_;
     error_code ev_;

--- a/include/boost/beast/websocket/impl/handshake.hpp
+++ b/include/boost/beast/websocket/impl/handshake.hpp
@@ -37,7 +37,7 @@ template<class Handler>
 class stream<NextLayer, deflateSupported>::handshake_op
     : public beast::stable_async_base<Handler,
         beast::executor_type<stream>>
-    , public net::coroutine
+    , public asio::coroutine
 {
     struct data
     {

--- a/include/boost/beast/websocket/impl/ping.hpp
+++ b/include/boost/beast/websocket/impl/ping.hpp
@@ -35,7 +35,7 @@ template<class Handler>
 class stream<NextLayer, deflateSupported>::ping_op
     : public beast::stable_async_base<
         Handler, beast::executor_type<stream>>
-    , public net::coroutine
+    , public asio::coroutine
 {
     boost::weak_ptr<impl_type> wp_;
     detail::frame_buffer& fb_;
@@ -115,7 +115,7 @@ public:
 template<class NextLayer, bool deflateSupported>
 template<class Executor>
 class stream<NextLayer, deflateSupported>::idle_ping_op
-    : public net::coroutine
+    : public asio::coroutine
     , public boost::empty_value<Executor>
 {
     boost::weak_ptr<impl_type> wp_;

--- a/include/boost/beast/websocket/impl/read.hpp
+++ b/include/boost/beast/websocket/impl/read.hpp
@@ -48,7 +48,7 @@ template<class Handler, class MutableBufferSequence>
 class stream<NextLayer, deflateSupported>::read_some_op
     : public beast::async_base<
         Handler, beast::executor_type<stream>>
-    , public net::coroutine
+    , public asio::coroutine
 {
     boost::weak_ptr<impl_type> wp_;
     MutableBufferSequence bs_;
@@ -619,7 +619,7 @@ template<class Handler,  class DynamicBuffer>
 class stream<NextLayer, deflateSupported>::read_op
     : public beast::async_base<
         Handler, beast::executor_type<stream>>
-    , public net::coroutine
+    , public asio::coroutine
 {
     boost::weak_ptr<impl_type> wp_;
     DynamicBuffer& b_;

--- a/include/boost/beast/websocket/impl/teardown.hpp
+++ b/include/boost/beast/websocket/impl/teardown.hpp
@@ -33,7 +33,7 @@ class teardown_tcp_op
         Handler, beast::executor_type<
             net::basic_stream_socket<
                 Protocol, Executor>>>
-    , public net::coroutine
+    , public asio::coroutine
 {
     using socket_type =
         net::basic_stream_socket<Protocol, Executor>;

--- a/include/boost/beast/websocket/impl/write.hpp
+++ b/include/boost/beast/websocket/impl/write.hpp
@@ -41,7 +41,7 @@ template<class Handler, class Buffers>
 class stream<NextLayer, deflateSupported>::write_some_op
     : public beast::async_base<
         Handler, beast::executor_type<stream>>
-    , public net::coroutine
+    , public asio::coroutine
 {
     enum
     {

--- a/test/beast/http/fields.cpp
+++ b/test/beast/http/fields.cpp
@@ -24,6 +24,9 @@ namespace http {
 class fields_test : public beast::unit_test::suite
 {
 public:
+    static constexpr std::size_t max_static_buffer =
+        sizeof(http::detail::temporary_buffer);
+
     template<class T>
     class test_allocator
     {
@@ -685,8 +688,7 @@ public:
                     (! res.keep_alive() && ! v));
             };
 
-        BOOST_STATIC_ASSERT(fields::max_static_buffer == 4096);
-        std::string const big(4096 + 1, 'a');
+        std::string const big(max_static_buffer + 1, 'a');
 
         // HTTP/1.0
         res.version(10);
@@ -846,10 +848,10 @@ public:
 
         res.content_length(0);
         BEAST_EXPECT(res[field::content_length] == "0");
-        
+
         res.content_length(100);
         BEAST_EXPECT(res[field::content_length] == "100");
-        
+
         res.content_length(boost::none);
         BEAST_EXPECT(res.count(field::content_length) == 0);
 
@@ -857,12 +859,12 @@ public:
         res.content_length(0);
         BEAST_EXPECT(res[field::content_length] == "0");
         BEAST_EXPECT(res.count(field::transfer_encoding) == 0);
-        
+
         res.set(field::transfer_encoding, "chunked");
         res.content_length(100);
         BEAST_EXPECT(res[field::content_length] == "100");
         BEAST_EXPECT(res.count(field::transfer_encoding) == 0);
-        
+
         res.set(field::transfer_encoding, "chunked");
         res.content_length(boost::none);
         BEAST_EXPECT(res.count(field::content_length) == 0);
@@ -874,12 +876,12 @@ public:
             res.content_length(0);
             BEAST_EXPECT(res[field::content_length] == "0");
             BEAST_EXPECT(res[field::transfer_encoding] == s);
-        
+
             res.set(field::transfer_encoding, s);
             res.content_length(100);
             BEAST_EXPECT(res[field::content_length] == "100");
             BEAST_EXPECT(res[field::transfer_encoding] == s);
-        
+
             res.set(field::transfer_encoding, s);
             res.content_length(boost::none);
             BEAST_EXPECT(res.count(field::content_length) == 0);
@@ -889,12 +891,12 @@ public:
             res.content_length(0);
             BEAST_EXPECT(res[field::content_length] == "0");
             BEAST_EXPECT(res[field::transfer_encoding] == s);
-        
+
             res.set(field::transfer_encoding, s + ", chunked");
             res.content_length(100);
             BEAST_EXPECT(res[field::content_length] == "100");
             BEAST_EXPECT(res[field::transfer_encoding] == s);
-        
+
             res.set(field::transfer_encoding, s + ", chunked");
             res.content_length(boost::none);
             BEAST_EXPECT(res.count(field::content_length) == 0);
@@ -904,12 +906,12 @@ public:
             res.content_length(0);
             BEAST_EXPECT(res[field::content_length] == "0");
             BEAST_EXPECT(res[field::transfer_encoding] == "chunked, " + s);
-        
+
             res.set(field::transfer_encoding, "chunked, " + s);
             res.content_length(100);
             BEAST_EXPECT(res[field::content_length] == "100");
             BEAST_EXPECT(res[field::transfer_encoding] == "chunked, " + s);
-        
+
             res.set(field::transfer_encoding, "chunked, " + s);
             res.content_length(boost::none);
             BEAST_EXPECT(res.count(field::content_length) == 0);
@@ -918,8 +920,7 @@ public:
 
         check("foo");
 
-        BOOST_STATIC_ASSERT(fields::max_static_buffer == 4096);
-        std::string const big(4096 + 1, 'a');
+        std::string const big(max_static_buffer + 1, 'a');
 
         check(big);
     }

--- a/test/beast/http/fields.cpp
+++ b/test/beast/http/fields.cpp
@@ -25,7 +25,7 @@ class fields_test : public beast::unit_test::suite
 {
 public:
     static constexpr std::size_t max_static_buffer =
-        sizeof(http::detail::temporary_buffer);
+        sizeof(beast::detail::temporary_buffer);
 
     template<class T>
     class test_allocator

--- a/test/doc/core_1_refresher.cpp
+++ b/test/doc/core_1_refresher.cpp
@@ -73,7 +73,7 @@ snippets()
     }
     {
     //[code_core_1_refresher_5s
-        net::spawn(
+        asio::spawn(
             [&sock](net::yield_context yield)
             {
                 std::size_t bytes_transferred = net::async_write(sock,
@@ -375,7 +375,7 @@ async_write(
                 >::return_type
 {
 //[code_core_1_refresher_10
-    
+
     return net::async_initiate<
         CompletionToken,
         void(error_code, std::size_t)>(

--- a/test/extras/include/boost/beast/test/yield_to.hpp
+++ b/test/extras/include/boost/beast/test/yield_to.hpp
@@ -120,7 +120,7 @@ void
 enable_yield_to::
 spawn(F0&& f, FN&&... fn)
 {
-    net::spawn(ioc_,
+    asio::spawn(ioc_,
         [&](yield_context yield)
         {
             f(yield);


### PR DESCRIPTION
* Reduce the number of instantiations of filter_token_list
* Remove the use of `static_string` from `http::fields`
* Add gcc-9 to AzP CI test matrix
* Enable split compilation in http::basic_fields
* Remove redundant instation of `static_string` in websocket
* Remove redundant use of `asio::coroutine` in `flat_stream`
* Remove unused includes from `test::stream`
* Move `char_buffer` into a separate file
* Fix coverage collection in AzP CI
* Improve performance of `http::string_to_verb`