### PR TITLE
Version 260

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 260:
 
 * More split compilation in rfc7230.hpp
 * Qualify calls to `beast::iequals` in basic_parser.ipp
+* More split compilation in websocket/detail/mask.hpp
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 260:
 
 * More split compilation in rfc7230.hpp
+* Qualify calls to `beast::iequals` in basic_parser.ipp
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 260:
 * Cleanup transitive includes in beast/core/detail/type_traits.hpp
 * Simplify generation of sec-websocket-key
 * Move detail::base64 helpers to tests
+* Remove redundant includes in core
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 260:
 * More split compilation in websocket/detail/mask.hpp
 * Cleanup transitive includes in beast/core/detail/type_traits.hpp
 * Simplify generation of sec-websocket-key
+* Move detail::base64 helpers to tests
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 260:
 * More split compilation in rfc7230.hpp
 * Qualify calls to `beast::iequals` in basic_parser.ipp
 * More split compilation in websocket/detail/mask.hpp
+* Cleanup transitive includes in beast/core/detail/type_traits.hpp
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 260:
+
+* More split compilation in rfc7230.hpp
+
+--------------------------------------------------------------------------------
+
 Version 259:
 
 * Reduce the number of instantiations of filter_token_list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 260:
 * Qualify calls to `beast::iequals` in basic_parser.ipp
 * More split compilation in websocket/detail/mask.hpp
 * Cleanup transitive includes in beast/core/detail/type_traits.hpp
+* Simplify generation of sec-websocket-key
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endfunction()
 #
 #-------------------------------------------------------------------------------
 
-project (Beast VERSION 259)
+project (Beast VERSION 260)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/include/boost/beast/_experimental/test/impl/stream.hpp
+++ b/include/boost/beast/_experimental/test/impl/stream.hpp
@@ -13,7 +13,7 @@
 #include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/buffer_traits.hpp>
 #include <boost/beast/core/detail/service_base.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
+#include <boost/beast/core/detail/is_invocable.hpp>
 #include <mutex>
 #include <stdexcept>
 #include <vector>

--- a/include/boost/beast/core/detail/base64.hpp
+++ b/include/boost/beast/core/detail/base64.hpp
@@ -12,7 +12,6 @@
 
 #include <boost/beast/core/string.hpp>
 #include <cctype>
-#include <string>
 #include <utility>
 
 namespace boost {
@@ -77,26 +76,6 @@ std::pair<std::size_t, std::size_t>
 decode(void* dest, char const* src, std::size_t len);
 
 } // base64
-
-BOOST_BEAST_DECL
-std::string
-base64_encode(std::uint8_t const* data, std::size_t len);
-
-BOOST_BEAST_DECL
-std::string
-base64_encode(string_view s);
-
-template<class = void>
-std::string
-base64_decode(string_view data)
-{
-    std::string dest;
-    dest.resize(base64::decoded_size(data.size()));
-    auto const result = base64::decode(
-        &dest[0], data.data(), data.size());
-    dest.resize(result.first);
-    return dest;
-}
 
 } // detail
 } // beast

--- a/include/boost/beast/core/detail/base64.ipp
+++ b/include/boost/beast/core/detail/base64.ipp
@@ -195,24 +195,6 @@ decode(void* dest, char const* src, std::size_t len)
 
 } // base64
 
-std::string
-base64_encode(
-    std::uint8_t const* data,
-    std::size_t len)
-{
-    std::string dest;
-    dest.resize(base64::encoded_size(len));
-    dest.resize(base64::encode(&dest[0], data, len));
-    return dest;
-}
-
-std::string
-base64_encode(string_view s)
-{
-    return base64_encode (reinterpret_cast <
-        std::uint8_t const*> (s.data()), s.size());
-}
-
 } // detail
 } // beast
 } // boost

--- a/include/boost/beast/core/detail/ostream.hpp
+++ b/include/boost/beast/core/detail/ostream.hpp
@@ -12,7 +12,6 @@
 
 #include <boost/beast/core/buffers_prefix.hpp>
 #include <boost/beast/core/buffers_range.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/asio/buffer.hpp>
 #include <memory>

--- a/include/boost/beast/core/detail/sha1.hpp
+++ b/include/boost/beast/core/detail/sha1.hpp
@@ -11,10 +11,7 @@
 #define BOOST_BEAST_DETAIL_SHA1_HPP
 
 #include <boost/beast/core/detail/config.hpp>
-
-#include <algorithm>
 #include <cstdint>
-#include <cstring>
 
 // Based on https://github.com/vog/sha1
 /*

--- a/include/boost/beast/core/detail/sha1.ipp
+++ b/include/boost/beast/core/detail/sha1.ipp
@@ -12,7 +12,6 @@
 
 #include <boost/beast/core/detail/sha1.hpp>
 
-#include <algorithm>
 #include <cstdint>
 #include <cstring>
 

--- a/include/boost/beast/core/detail/string.hpp
+++ b/include/boost/beast/core/detail/string.hpp
@@ -17,12 +17,18 @@ namespace beast {
 
 namespace detail {
 
+// Pulling in the UDL directly breaks in some places on MSVC,
+// so introduce a namespace for this purprose.
+namespace string_literals {
+
 inline
 string_view
 operator"" _sv(char const* p, std::size_t n)
 {
     return string_view{p, n};
 }
+
+} // string_literals
 
 inline
 char

--- a/include/boost/beast/core/detail/type_traits.hpp
+++ b/include/boost/beast/core/detail/type_traits.hpp
@@ -10,16 +10,9 @@
 #ifndef BOOST_BEAST_DETAIL_TYPE_TRAITS_HPP
 #define BOOST_BEAST_DETAIL_TYPE_TRAITS_HPP
 
-#include <boost/beast/core/error.hpp>
-#include <boost/beast/core/detail/is_invocable.hpp>
-#include <boost/asio/buffer.hpp>
-#include <boost/mp11/function.hpp>
 #include <boost/type_traits/make_void.hpp>
-#include <iterator>
-#include <tuple>
 #include <type_traits>
-#include <string>
-#include <utility>
+#include <new>
 
 namespace boost {
 namespace beast {
@@ -79,12 +72,6 @@ struct aligned_union
 template<std::size_t Len, class... Ts>
 using aligned_union_t =
     typename aligned_union<Len, Ts...>::type;
-
-//------------------------------------------------------------------------------
-
-template<class T>
-void
-accept_rv(T){}
 
 //------------------------------------------------------------------------------
 

--- a/include/boost/beast/core/impl/basic_stream.hpp
+++ b/include/boost/beast/core/impl/basic_stream.hpp
@@ -13,7 +13,6 @@
 #include <boost/beast/core/async_base.hpp>
 #include <boost/beast/core/buffer_traits.hpp>
 #include <boost/beast/core/buffers_prefix.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/beast/websocket/teardown.hpp>
 #include <boost/asio/coroutine.hpp>
 #include <boost/assert.hpp>

--- a/include/boost/beast/core/impl/buffered_read_stream.hpp
+++ b/include/boost/beast/core/impl/buffered_read_stream.hpp
@@ -15,7 +15,7 @@
 #include <boost/beast/core/error.hpp>
 #include <boost/beast/core/read_size.hpp>
 #include <boost/beast/core/stream_traits.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
+#include <boost/beast/core/detail/is_invocable.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/throw_exception.hpp>
 

--- a/include/boost/beast/core/impl/buffers_adaptor.hpp
+++ b/include/boost/beast/core/impl/buffers_adaptor.hpp
@@ -11,7 +11,6 @@
 #define BOOST_BEAST_IMPL_BUFFERS_ADAPTOR_HPP
 
 #include <boost/beast/core/buffer_traits.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/config/workaround.hpp>
 #include <boost/throw_exception.hpp>

--- a/include/boost/beast/core/impl/buffers_cat.hpp
+++ b/include/boost/beast/core/impl/buffers_cat.hpp
@@ -11,7 +11,6 @@
 #define BOOST_BEAST_IMPL_BUFFERS_CAT_HPP
 
 #include <boost/beast/core/detail/tuple.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/beast/core/detail/variant.hpp>
 #include <boost/asio/buffer.hpp>
 #include <cstdint>

--- a/include/boost/beast/core/impl/multi_buffer.hpp
+++ b/include/boost/beast/core/impl/multi_buffer.hpp
@@ -11,7 +11,6 @@
 #define BOOST_BEAST_IMPL_MULTI_BUFFER_HPP
 
 #include <boost/beast/core/buffer_traits.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/config/workaround.hpp>
 #include <boost/core/exchange.hpp>
 #include <boost/assert.hpp>
@@ -529,7 +528,7 @@ template<class Allocator>
 basic_multi_buffer<Allocator>::
 basic_multi_buffer(
     basic_multi_buffer&& other,
-    Allocator const& alloc) 
+    Allocator const& alloc)
     : boost::empty_value<
         base_alloc_type>(boost::empty_init_t(), alloc)
     , max_(other.max_)

--- a/include/boost/beast/core/impl/static_buffer.hpp
+++ b/include/boost/beast/core/impl/static_buffer.hpp
@@ -11,10 +11,6 @@
 #define BOOST_BEAST_IMPL_STATIC_BUFFER_HPP
 
 #include <boost/asio/buffer.hpp>
-#include <boost/throw_exception.hpp>
-#include <algorithm>
-#include <cstring>
-#include <iterator>
 #include <stdexcept>
 
 namespace boost {

--- a/include/boost/beast/core/impl/static_buffer.hpp
+++ b/include/boost/beast/core/impl/static_buffer.hpp
@@ -10,7 +10,6 @@
 #ifndef BOOST_BEAST_IMPL_STATIC_BUFFER_HPP
 #define BOOST_BEAST_IMPL_STATIC_BUFFER_HPP
 
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/throw_exception.hpp>
 #include <algorithm>

--- a/include/boost/beast/core/impl/static_buffer.ipp
+++ b/include/boost/beast/core/impl/static_buffer.ipp
@@ -11,7 +11,6 @@
 #define BOOST_BEAST_IMPL_STATIC_BUFFER_IPP
 
 #include <boost/beast/core/static_buffer.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/throw_exception.hpp>
 #include <algorithm>

--- a/include/boost/beast/core/impl/static_buffer.ipp
+++ b/include/boost/beast/core/impl/static_buffer.ipp
@@ -13,9 +13,6 @@
 #include <boost/beast/core/static_buffer.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/throw_exception.hpp>
-#include <algorithm>
-#include <cstring>
-#include <iterator>
 #include <stdexcept>
 
 namespace boost {

--- a/include/boost/beast/core/impl/static_string.hpp
+++ b/include/boost/beast/core/impl/static_string.hpp
@@ -11,7 +11,6 @@
 #define BOOST_BEAST_IMPL_STATIC_STRING_HPP
 
 #include <boost/beast/core/detail/static_string.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/throw_exception.hpp>
 
 namespace boost {

--- a/include/boost/beast/core/span.hpp
+++ b/include/boost/beast/core/span.hpp
@@ -186,21 +186,21 @@ public:
     {
         return data_;
     }
-                
+
     /// Returns an iterator to the beginning of the span
     const_iterator
     cbegin() const
     {
         return data_;
     }
-       
+
     /// Returns an iterator to one past the end of the span
     const_iterator
     end() const
     {
         return data_ + size_;
     }
-        
+
     /// Returns an iterator to one past the end of the span
     const_iterator
     cend() const

--- a/include/boost/beast/core/static_buffer.hpp
+++ b/include/boost/beast/core/static_buffer.hpp
@@ -13,11 +13,7 @@
 #include <boost/beast/core/detail/config.hpp>
 #include <boost/beast/core/detail/buffers_pair.hpp>
 #include <boost/asio/buffer.hpp>
-#include <boost/assert.hpp>
-#include <algorithm>
-#include <array>
 #include <cstddef>
-#include <cstring>
 
 namespace boost {
 namespace beast {
@@ -134,7 +130,7 @@ public:
     BOOST_BEAST_DECL
     const_buffers_type
     data() const noexcept;
-    
+
     /// Returns a constant buffer sequence representing the readable bytes
     const_buffers_type
     cdata() const noexcept
@@ -148,7 +144,7 @@ public:
     data() noexcept;
 
     /** Returns a mutable buffer sequence representing writable bytes.
-    
+
         Returns a mutable buffer sequence representing the writable
         bytes containing exactly `n` bytes of storage. Memory may be
         reallocated as needed.

--- a/include/boost/beast/core/string_param.hpp
+++ b/include/boost/beast/core/string_param.hpp
@@ -14,7 +14,6 @@
 #include <boost/beast/core/string.hpp>
 #include <boost/beast/core/static_string.hpp>
 #include <boost/beast/core/detail/static_ostream.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/optional.hpp>
 
 namespace boost {

--- a/include/boost/beast/http/impl/basic_parser.ipp
+++ b/include/boost/beast/http/impl/basic_parser.ipp
@@ -16,6 +16,7 @@
 #include <boost/beast/core/buffer_traits.hpp>
 #include <boost/beast/core/detail/clamp.hpp>
 #include <boost/beast/core/detail/config.hpp>
+#include <boost/beast/core/detail/string.hpp>
 #include <boost/asio/buffer.hpp>
 #include <algorithm>
 #include <utility>
@@ -746,6 +747,7 @@ basic_parser<isRequest>::
 do_field(field f,
     string_view value, error_code& ec)
 {
+    using namespace beast::detail::string_literals;
     // Connection
     if(f == field::connection ||
         f == field::proxy_connection)
@@ -759,19 +761,19 @@ do_field(field f,
         }
         for(auto const& s : list)
         {
-            if(iequals({"close", 5}, s))
+            if(beast::iequals("close"_sv, s))
             {
                 f_ |= flagConnectionClose;
                 continue;
             }
 
-            if(iequals({"keep-alive", 10}, s))
+            if(beast::iequals("keep-alive"_sv, s))
             {
                 f_ |= flagConnectionKeepAlive;
                 continue;
             }
 
-            if(iequals({"upgrade", 7}, s))
+            if(beast::iequals("upgrade"_sv, s))
             {
                 f_ |= flagConnectionUpgrade;
                 continue;
@@ -832,9 +834,9 @@ do_field(field f,
         ec = {};
         auto const v = token_list{value};
         auto const p = std::find_if(v.begin(), v.end(),
-            [&](typename token_list::value_type const& s)
+            [&](string_view const& s)
             {
-                return iequals({"chunked", 7}, s);
+                return beast::iequals("chunked"_sv, s);
             });
         if(p == v.end())
             return;

--- a/include/boost/beast/http/impl/fields.hpp
+++ b/include/boost/beast/http/impl/fields.hpp
@@ -577,7 +577,7 @@ insert(field name,
     }
     auto const last = std::prev(before);
     // VFALCO is it worth comparing `field name` first?
-    if(! iequals(sname, last->name_string()))
+    if(! beast::iequals(sname, last->name_string()))
     {
         BOOST_ASSERT(count(sname) == 0);
         set_.insert_before(before, e);
@@ -818,7 +818,7 @@ get_chunked_impl() const
     {
         auto const next = std::next(it);
         if(next == te.end())
-            return iequals(*it, "chunked");
+            return beast::iequals(*it, "chunked");
         it = next;
     }
     return false;
@@ -901,7 +901,7 @@ set_chunked_impl(bool value)
             auto const next = std::next(itt);
             if(next == te.end())
             {
-                if(iequals(*itt, "chunked"))
+                if(beast::iequals(*itt, "chunked"))
                     return; // already set
                 break;
             }
@@ -1001,7 +1001,7 @@ set_element(element& e)
 {
     auto it = set_.lower_bound(
         e.name_string(), key_compare{});
-    if(it == set_.end() || ! iequals(
+    if(it == set_.end() || ! beast::iequals(
         e.name_string(), it->name_string()))
     {
         set_.insert_before(it, e);
@@ -1017,7 +1017,7 @@ set_element(element& e)
         delete_element(*it);
         it = next;
         if(it == set_.end() ||
-            ! iequals(e.name_string(), it->name_string()))
+            ! beast::iequals(e.name_string(), it->name_string()))
             break;
     }
     set_.insert_before(it, e);

--- a/include/boost/beast/http/impl/message.hpp
+++ b/include/boost/beast/http/impl/message.hpp
@@ -11,7 +11,6 @@
 #define BOOST_BEAST_HTTP_IMPL_MESSAGE_HPP
 
 #include <boost/beast/core/error.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/assert.hpp>
 #include <boost/throw_exception.hpp>
 #include <stdexcept>

--- a/include/boost/beast/http/impl/rfc7230.hpp
+++ b/include/boost/beast/http/impl/rfc7230.hpp
@@ -244,27 +244,6 @@ cend() const ->
     return const_iterator{s_.end(), s_.end()};
 }
 
-template<class T>
-auto
-ext_list::
-find(T const& s) ->
-    const_iterator
-{
-    return std::find_if(begin(), end(),
-        [&s](value_type const& v)
-        {
-            return iequals(s, v.first);
-        });
-}
-
-template<class T>
-bool
-ext_list::
-exists(T const& s)
-{
-    return find(s) != end();
-}
-
 
 //------------------------------------------------------------------------------
 
@@ -376,19 +355,6 @@ cend() const ->
     const_iterator
 {
     return const_iterator{s_.end(), s_.end()};
-}
-
-template<class T>
-bool
-token_list::
-exists(T const& s)
-{
-    return std::find_if(begin(), end(),
-        [&s](value_type const& v)
-        {
-            return iequals(s, v);
-        }
-    ) != end();
 }
 
 template<class Policy>

--- a/include/boost/beast/http/impl/rfc7230.ipp
+++ b/include/boost/beast/http/impl/rfc7230.ipp
@@ -11,6 +11,7 @@
 #define BOOST_BEAST_HTTP_IMPL_RFC7230_IPP
 
 #include <boost/beast/http/rfc7230.hpp>
+#include <algorithm>
 
 namespace boost {
 namespace beast {
@@ -123,6 +124,24 @@ increment()
     }
 }
 
+auto
+ext_list::
+find(string_view const& s) -> const_iterator
+{
+    return std::find_if(begin(), end(),
+        [&s](value_type const& v)
+        {
+            return beast::iequals(s, v.first);
+        });
+}
+
+bool
+ext_list::
+exists(string_view const& s)
+{
+    return find(s) != end();
+}
+
 void
 token_list::const_iterator::
 increment()
@@ -167,6 +186,18 @@ increment()
         need_comma = false;
         ++it_;
     }
+}
+
+bool
+token_list::
+exists(string_view const& s)
+{
+    return std::find_if(begin(), end(),
+        [&s](value_type const& v)
+        {
+            return beast::iequals(s, v);
+        }
+    ) != end();
 }
 
 } // http

--- a/include/boost/beast/http/impl/verb.ipp
+++ b/include/boost/beast/http/impl/verb.ipp
@@ -21,7 +21,7 @@ namespace http {
 string_view
 to_string(verb v)
 {
-    using beast::detail::operator "" _sv;
+    using namespace beast::detail::string_literals;
     switch(v)
     {
     case verb::delete_:       return "DELETE"_sv;
@@ -109,7 +109,7 @@ string_to_verb(string_view v)
     UNLOCK
     UNSUBSCRIBE
 */
-    using beast::detail::operator "" _sv;
+    using namespace beast::detail::string_literals;
     if(v.size() < 3)
         return verb::unknown;
     auto c = v[0];

--- a/include/boost/beast/http/impl/write.hpp
+++ b/include/boost/beast/http/impl/write.hpp
@@ -16,6 +16,7 @@
 #include <boost/beast/core/buffers_range.hpp>
 #include <boost/beast/core/make_printable.hpp>
 #include <boost/beast/core/stream_traits.hpp>
+#include <boost/beast/core/detail/is_invocable.hpp>
 #include <boost/asio/coroutine.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/asio/write.hpp>

--- a/include/boost/beast/http/rfc7230.hpp
+++ b/include/boost/beast/http/rfc7230.hpp
@@ -190,17 +190,17 @@ public:
         @return An iterator to the matching token, or `end()` if no
         token exists.
     */
-    template<class T>
+    BOOST_BEAST_DECL
     const_iterator
-    find(T const& s);
+    find(string_view const& s);
 
     /** Return `true` if a token is present in the list.
 
         @param s The token to find. A case-insensitive comparison is used.
     */
-    template<class T>
+    BOOST_BEAST_DECL
     bool
-    exists(T const& s);
+    exists(string_view const& s);
 };
 
 //------------------------------------------------------------------------------
@@ -275,9 +275,9 @@ public:
 
         @param s The token to find. A case-insensitive comparison is used.
     */
-    template<class T>
+    BOOST_BEAST_DECL
     bool
-    exists(T const& s);
+    exists(string_view const& s);
 };
 
 /** A list of tokens in a comma separated HTTP field value.

--- a/include/boost/beast/http/string_body.hpp
+++ b/include/boost/beast/http/string_body.hpp
@@ -16,7 +16,6 @@
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/core/buffers_range.hpp>
 #include <boost/beast/core/detail/clamp.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/optional.hpp>
 #include <cstdint>

--- a/include/boost/beast/http/vector_body.hpp
+++ b/include/boost/beast/http/vector_body.hpp
@@ -15,7 +15,6 @@
 #include <boost/beast/http/error.hpp>
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/core/detail/clamp.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/optional.hpp>
 #include <cstdint>

--- a/include/boost/beast/src.hpp
+++ b/include/boost/beast/src.hpp
@@ -52,6 +52,7 @@ the program, with the macro BOOST_BEAST_SEPARATE_COMPILATION defined.
 #include <boost/beast/http/impl/verb.ipp>
 
 #include <boost/beast/websocket/detail/hybi13.ipp>
+#include <boost/beast/websocket/detail/mask.ipp>
 #include <boost/beast/websocket/detail/pmd_extension.ipp>
 #include <boost/beast/websocket/detail/prng.ipp>
 #include <boost/beast/websocket/detail/service.ipp>

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 259
+#define BOOST_BEAST_VERSION 260
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/detail/decorator.hpp
+++ b/include/boost/beast/websocket/detail/decorator.hpp
@@ -11,7 +11,6 @@
 #define BOOST_BEAST_WEBSOCKET_DETAIL_DECORATOR_HPP
 
 #include <boost/beast/websocket/rfc6455.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/core/exchange.hpp>
 #include <boost/type_traits/make_void.hpp>
 #include <algorithm>

--- a/include/boost/beast/websocket/detail/hybi13.ipp
+++ b/include/boost/beast/websocket/detail/hybi13.ipp
@@ -27,18 +27,12 @@ void
 make_sec_ws_key(sec_ws_key_type& key)
 {
     auto g = make_prng(true);
-    char a[16];
-    for(int i = 0; i < 16; i += 4)
-    {
-        auto const v = g();
-        a[i  ] =  v        & 0xff;
-        a[i+1] = (v >>  8) & 0xff;
-        a[i+2] = (v >> 16) & 0xff;
-        a[i+3] = (v >> 24) & 0xff;
-    }
+    std::uint32_t a[4];
+    for (auto& v : a)
+        v = g();
     key.resize(key.max_size());
     key.resize(beast::detail::base64::encode(
-        key.data(), &a[0], 16));
+        key.data(), &a[0], sizeof(a)));
 }
 
 void

--- a/include/boost/beast/websocket/detail/hybi13.ipp
+++ b/include/boost/beast/websocket/detail/hybi13.ipp
@@ -47,7 +47,7 @@ make_sec_ws_accept(
     string_view key)
 {
     BOOST_ASSERT(key.size() <= sec_ws_key_type::max_size_n);
-    using beast::detail::operator "" _sv;
+    using namespace beast::detail::string_literals;
     auto const guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"_sv;
     beast::detail::sha1_context ctx;
     beast::detail::init(ctx);

--- a/include/boost/beast/websocket/detail/mask.ipp
+++ b/include/boost/beast/websocket/detail/mask.ipp
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_WEBSOCKET_DETAIL_MASK_IPP
+#define BOOST_BEAST_WEBSOCKET_DETAIL_MASK_IPP
+
+#include <boost/beast/websocket/detail/mask.hpp>
+
+namespace boost {
+namespace beast {
+namespace websocket {
+namespace detail {
+
+void
+prepare_key(prepared_key& prepared, std::uint32_t key)
+{
+    prepared[0] = (key >>  0) & 0xff;
+    prepared[1] = (key >>  8) & 0xff;
+    prepared[2] = (key >> 16) & 0xff;
+    prepared[3] = (key >> 24) & 0xff;
+}
+
+inline
+void
+rol(prepared_key& v, std::size_t n)
+{
+    auto v0 = v;
+    for(std::size_t i = 0; i < v.size(); ++i )
+        v[i] = v0[(i + n) % v.size()];
+}
+
+// Apply mask in place
+//
+void
+mask_inplace(net::mutable_buffer const& b, prepared_key& key)
+{
+    auto n = b.size();
+    auto const mask = key; // avoid aliasing
+    auto p = static_cast<unsigned char*>(b.data());
+    while(n >= 4)
+    {
+        for(int i = 0; i < 4; ++i)
+            p[i] ^= mask[i];
+        p += 4;
+        n -= 4;
+    }
+    if(n > 0)
+    {
+        for(std::size_t i = 0; i < n; ++i)
+            p[i] ^= mask[i];
+        rol(key, n);
+    }
+}
+
+} // detail
+} // websocket
+} // beast
+} // boost
+
+#endif

--- a/include/boost/beast/websocket/detail/pmd_extension.ipp
+++ b/include/boost/beast/websocket/detail/pmd_extension.ipp
@@ -52,11 +52,11 @@ pmd_read_impl(pmd_offer& offer, http::ext_list const& list)
 
     for(auto const& ext : list)
     {
-        if(iequals(ext.first, "permessage-deflate"))
+        if(beast::iequals(ext.first, "permessage-deflate"))
         {
             for(auto const& param : ext.second)
             {
-                if(iequals(param.first,
+                if(beast::iequals(param.first,
                     "server_max_window_bits"))
                 {
                     if(offer.server_max_window_bits != 0)
@@ -84,7 +84,7 @@ pmd_read_impl(pmd_offer& offer, http::ext_list const& list)
                         return; // MUST decline
                     }
                 }
-                else if(iequals(param.first,
+                else if(beast::iequals(param.first,
                     "client_max_window_bits"))
                 {
                     if(offer.client_max_window_bits != 0)
@@ -112,7 +112,7 @@ pmd_read_impl(pmd_offer& offer, http::ext_list const& list)
                         offer.client_max_window_bits = -1;
                     }
                 }
-                else if(iequals(param.first,
+                else if(beast::iequals(param.first,
                     "server_no_context_takeover"))
                 {
                     if(offer.server_no_context_takeover)
@@ -131,7 +131,7 @@ pmd_read_impl(pmd_offer& offer, http::ext_list const& list)
                     }
                     offer.server_no_context_takeover = true;
                 }
-                else if(iequals(param.first,
+                else if(beast::iequals(param.first,
                     "client_no_context_takeover"))
                 {
                     if(offer.client_no_context_takeover)

--- a/include/boost/beast/websocket/impl/accept.hpp
+++ b/include/boost/beast/websocket/impl/accept.hpp
@@ -21,7 +21,6 @@
 #include <boost/beast/core/buffer_traits.hpp>
 #include <boost/beast/core/stream_traits.hpp>
 #include <boost/beast/core/detail/buffer.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/beast/version.hpp>
 #include <boost/asio/coroutine.hpp>
 #include <boost/asio/post.hpp>

--- a/include/boost/beast/websocket/impl/stream.hpp
+++ b/include/boost/beast/websocket/impl/stream.hpp
@@ -25,7 +25,6 @@
 #include <boost/beast/core/buffers_suffix.hpp>
 #include <boost/beast/core/flat_static_buffer.hpp>
 #include <boost/beast/core/detail/clamp.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/asio/bind_executor.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/assert.hpp>

--- a/include/boost/beast/websocket/impl/stream_impl.hpp
+++ b/include/boost/beast/websocket/impl/stream_impl.hpp
@@ -30,7 +30,6 @@
 #include <boost/beast/core/static_buffer.hpp>
 #include <boost/beast/core/stream_traits.hpp>
 #include <boost/beast/core/detail/clamp.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/beast/version.hpp>
 #include <boost/asio/bind_executor.hpp>
 #include <boost/asio/steady_timer.hpp>

--- a/include/boost/beast/websocket/impl/teardown.hpp
+++ b/include/boost/beast/websocket/impl/teardown.hpp
@@ -14,7 +14,7 @@
 #include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/stream_traits.hpp>
 #include <boost/beast/core/detail/bind_continuation.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
+#include <boost/beast/core/detail/is_invocable.hpp>
 #include <boost/asio/coroutine.hpp>
 #include <boost/asio/post.hpp>
 #include <memory>

--- a/include/boost/beast/websocket/option.hpp
+++ b/include/boost/beast/websocket/option.hpp
@@ -11,15 +11,6 @@
 #define BOOST_BEAST_WEBSOCKET_OPTION_HPP
 
 #include <boost/beast/core/detail/config.hpp>
-#include <boost/beast/websocket/rfc6455.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
-#include <boost/throw_exception.hpp>
-#include <algorithm>
-#include <cstdint>
-#include <functional>
-#include <stdexcept>
-#include <type_traits>
-#include <utility>
 
 namespace boost {
 namespace beast {

--- a/include/boost/beast/websocket/stream.hpp
+++ b/include/boost/beast/websocket/stream.hpp
@@ -23,7 +23,6 @@
 #include <boost/beast/core/role.hpp>
 #include <boost/beast/core/stream_traits.hpp>
 #include <boost/beast/core/string.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/beast/http/detail/type_traits.hpp>
 #include <boost/asio/async_result.hpp>
 #include <boost/asio/error.hpp>

--- a/include/boost/beast/zlib/detail/deflate_stream.hpp
+++ b/include/boost/beast/zlib/detail/deflate_stream.hpp
@@ -40,7 +40,6 @@
 #include <boost/beast/zlib/error.hpp>
 #include <boost/beast/zlib/zlib.hpp>
 #include <boost/beast/zlib/detail/ranges.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
 #include <boost/optional.hpp>

--- a/include/boost/beast/zlib/detail/deflate_stream.ipp
+++ b/include/boost/beast/zlib/detail/deflate_stream.ipp
@@ -39,7 +39,6 @@
 
 #include <boost/beast/zlib/detail/deflate_stream.hpp>
 #include <boost/beast/zlib/detail/ranges.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
 #include <boost/make_unique.hpp>

--- a/test/beast/core/_detail_base64.cpp
+++ b/test/beast/core/_detail_base64.cpp
@@ -11,6 +11,7 @@
 #include <boost/beast/core/detail/base64.hpp>
 
 #include <boost/beast/_experimental/unit_test/suite.hpp>
+#include <string>
 
 namespace boost {
 namespace beast {
@@ -19,6 +20,35 @@ namespace detail {
 class base64_test : public beast::unit_test::suite
 {
 public:
+    std::string
+    base64_encode(
+        std::uint8_t const* data,
+        std::size_t len)
+    {
+        std::string dest;
+        dest.resize(base64::encoded_size(len));
+        dest.resize(base64::encode(&dest[0], data, len));
+        return dest;
+    }
+
+    std::string
+    base64_encode(string_view s)
+    {
+        return base64_encode (reinterpret_cast <
+            std::uint8_t const*> (s.data()), s.size());
+    }
+
+    std::string
+    base64_decode(string_view data)
+    {
+        std::string dest;
+        dest.resize(base64::decoded_size(data.size()));
+        auto const result = base64::decode(
+            &dest[0], data.data(), data.size());
+        dest.resize(result.first);
+        return dest;
+    }
+
     void
     check (std::string const& in, std::string const& out)
     {

--- a/test/beast/core/buffer_traits.cpp
+++ b/test/beast/core/buffer_traits.cpp
@@ -11,7 +11,7 @@
 #include <boost/beast/core/buffer_traits.hpp>
 
 #include <boost/beast/_experimental/unit_test/suite.hpp>
-#include <boost/beast/core/detail/type_traits.hpp>
+#include <boost/beast/core/detail/is_invocable.hpp>
 #include <array>
 
 namespace boost {

--- a/test/beast/core/span.cpp
+++ b/test/beast/core/span.cpp
@@ -13,6 +13,8 @@
 #include <boost/beast/core/string.hpp>
 #include <boost/beast/_experimental/unit_test/suite.hpp>
 
+#include <vector>
+
 namespace boost {
 namespace beast {
 


### PR DESCRIPTION
* More split compilation in rfc7230.hpp
* Qualify calls to `beast::iequals` in basic_parser.ipp
* More split compilation in websocket/detail/mask.hpp
* Cleanup transitive includes in beast/core/detail/type_traits.hpp
* Simplify generation of sec-websocket-key