### PR TITLE
Version 261

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 261:
 
 * Deduplicate `websocket::read_size_hint` definition
 * Fix UB in websocket read tests
+* Remove redundant includes in websocket
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 261:
 * Fix UB in websocket read tests
 * Remove redundant includes in websocket
 * Use `std::shared_ptr` in `test::stream`
+* Simplify websocket::detail::prng
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 261:
 * Remove redundant includes in websocket
 * Use `std::shared_ptr` in `test::stream`
 * Simplify websocket::detail::prng
+* More split compilation in websocket/detail/frame.hpp
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 261:
 * Deduplicate `websocket::read_size_hint` definition
 * Fix UB in websocket read tests
 * Remove redundant includes in websocket
+* Use `std::shared_ptr` in `test::stream`
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 261:
 
 * Deduplicate `websocket::read_size_hint` definition
+* Fix UB in websocket read tests
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 261:
+
+* Deduplicate `websocket::read_size_hint` definition
+
+--------------------------------------------------------------------------------
+
 Version 260:
 
 * More split compilation in rfc7230.hpp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 261:
 * Use `std::shared_ptr` in `test::stream`
 * Simplify websocket::detail::prng
 * More split compilation in websocket/detail/frame.hpp
+* Detemplatize websocket frame parsing routines
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endfunction()
 #
 #-------------------------------------------------------------------------------
 
-project (Beast VERSION 260)
+project (Beast VERSION 261)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,14 @@ jobs:
           B2_FLAGS: <boost.beast.separate-compilation>off <boost.beast.allow-deprecated>off
           CXXSTD: 11
           B2_TARGETS: libs/beast/test//run-fat-tests
+        GCC 9 C++11 NO_DEPRECATED NO_TLS:
+          TOOLSET: gcc
+          CXX: g++-9
+          PACKAGES: g++-9
+          VARIANT: release
+          B2_FLAGS: <boost.beast.allow-deprecated>off <define>BOOST_NO_CXX11_THREAD_LOCAL
+          CXXSTD: 11
+          B2_TARGETS: libs/beast/test//run-fat-tests
         GCC 9 C++11 UBASAN:
           TOOLSET: gcc
           CXX: g++-9

--- a/include/boost/beast/_experimental/test/impl/stream.hpp
+++ b/include/boost/beast/_experimental/test/impl/stream.hpp
@@ -37,7 +37,7 @@ struct stream::service_impl
 class stream::service
     : public beast::detail::service_base<service>
 {
-    boost::shared_ptr<service_impl> sp_;
+    std::shared_ptr<service_impl> sp_;
 
     BOOST_BEAST_DECL
     void
@@ -54,7 +54,7 @@ public:
     make_impl(
         net::io_context& ctx,
         test::fail_count* fc) ->
-            boost::shared_ptr<state>;
+            std::shared_ptr<state>;
 };
 
 //------------------------------------------------------------------------------
@@ -70,7 +70,7 @@ class stream::read_op : public stream::read_op_base
     struct lambda
     {
         Handler h_;
-        boost::weak_ptr<state> wp_;
+        std::weak_ptr<state> wp_;
         Buffers b_;
         net::executor_work_guard<ex2_type> wg2_;
 
@@ -80,7 +80,7 @@ class stream::read_op : public stream::read_op_base
         template<class Handler_>
         lambda(
             Handler_&& h,
-            boost::shared_ptr<state> const& s,
+            std::shared_ptr<state> const& s,
             Buffers const& b)
             : h_(std::forward<Handler_>(h))
             , wp_(s)
@@ -129,7 +129,7 @@ public:
     template<class Handler_>
     read_op(
         Handler_&& h,
-        boost::shared_ptr<state> const& s,
+        std::shared_ptr<state> const& s,
         Buffers const& b)
         : fn_(std::forward<Handler_>(h), s, b)
         , wg1_(s->ioc.get_executor())
@@ -155,7 +155,7 @@ struct stream::run_read_op
     void
     operator()(
         ReadHandler&& h,
-        boost::shared_ptr<state> const& in,
+        std::shared_ptr<state> const& in,
         MutableBufferSequence const& buffers)
     {
         // If you get an error on the following line it means
@@ -188,8 +188,8 @@ struct stream::run_write_op
     void
     operator()(
         WriteHandler&& h,
-        boost::shared_ptr<state> in_,
-        boost::weak_ptr<state> out_,
+        std::shared_ptr<state> in_,
+        std::weak_ptr<state> out_,
         ConstBufferSequence const& buffers)
     {
         // If you get an error on the following line it means

--- a/include/boost/beast/_experimental/test/impl/stream.ipp
+++ b/include/boost/beast/_experimental/test/impl/stream.ipp
@@ -13,7 +13,6 @@
 #include <boost/beast/_experimental/test/stream.hpp>
 #include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/buffer_traits.hpp>
-#include <boost/make_shared.hpp>
 #include <stdexcept>
 #include <vector>
 
@@ -27,7 +26,7 @@ stream::
 service::
 service(net::execution_context& ctx)
     : beast::detail::service_base<service>(ctx)
-    , sp_(boost::make_shared<service_impl>())
+    , sp_(std::make_shared<service_impl>())
 {
 }
 
@@ -53,10 +52,10 @@ service::
 make_impl(
     net::io_context& ctx,
     test::fail_count* fc) ->
-    boost::shared_ptr<state>
+    std::shared_ptr<state>
 {
     auto& svc = net::use_service<service>(ctx);
-    auto sp = boost::make_shared<state>(ctx, svc.sp_, fc);
+    auto sp = std::make_shared<state>(ctx, svc.sp_, fc);
     std::lock_guard<std::mutex> g(svc.sp_->m_);
     svc.sp_->v_.push_back(sp.get());
     return sp;
@@ -77,7 +76,7 @@ remove(state& impl)
 //------------------------------------------------------------------------------
 
 void stream::initiate_read(
-    boost::shared_ptr<state> const& in_,
+    std::shared_ptr<state> const& in_,
     std::unique_ptr<stream::read_op_base>&& op,
     std::size_t buf_size)
 {
@@ -121,7 +120,7 @@ stream::
 state::
 state(
     net::io_context& ioc_,
-    boost::weak_ptr<service_impl> wp_,
+    std::weak_ptr<service_impl> wp_,
     fail_count* fc_)
     : ioc(ioc_)
     , wp(std::move(wp_))

--- a/include/boost/beast/_experimental/test/stream.hpp
+++ b/include/boost/beast/_experimental/test/stream.hpp
@@ -23,8 +23,6 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/assert.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
 #include <boost/throw_exception.hpp>
 #include <condition_variable>
 #include <limits>
@@ -110,8 +108,8 @@ class stream
 {
     struct state;
 
-    boost::shared_ptr<state> in_;
-    boost::weak_ptr<state> out_;
+    std::shared_ptr<state> in_;
+    std::weak_ptr<state> out_;
 
     enum class status
     {
@@ -133,7 +131,7 @@ class stream
         friend class stream;
 
         net::io_context& ioc;
-        boost::weak_ptr<service_impl> wp;
+        std::weak_ptr<service_impl> wp;
         std::mutex m;
         flat_buffer b;
         std::condition_variable cv;
@@ -150,7 +148,7 @@ class stream
         BOOST_BEAST_DECL
         state(
             net::io_context& ioc_,
-            boost::weak_ptr<service_impl> wp_,
+            std::weak_ptr<service_impl> wp_,
             fail_count* fc_);
 
 
@@ -180,7 +178,7 @@ class stream
     static
     void
     initiate_read(
-        boost::shared_ptr<state> const& in,
+        std::shared_ptr<state> const& in,
         std::unique_ptr<read_op_base>&& op,
         std::size_t buf_size);
 

--- a/include/boost/beast/core/detail/remap_post_to_defer.hpp
+++ b/include/boost/beast/core/detail/remap_post_to_defer.hpp
@@ -10,7 +10,6 @@
 #ifndef BOOST_BEAST_DETAIL_REMAP_POST_TO_DEFER_HPP
 #define BOOST_BEAST_DETAIL_REMAP_POST_TO_DEFER_HPP
 
-#include <boost/asio/bind_executor.hpp>
 #include <boost/asio/is_executor.hpp>
 #include <boost/core/empty_value.hpp>
 #include <type_traits>

--- a/include/boost/beast/src.hpp
+++ b/include/boost/beast/src.hpp
@@ -51,6 +51,7 @@ the program, with the macro BOOST_BEAST_SEPARATE_COMPILATION defined.
 #include <boost/beast/http/impl/status.ipp>
 #include <boost/beast/http/impl/verb.ipp>
 
+#include <boost/beast/websocket/detail/frame.ipp>
 #include <boost/beast/websocket/detail/hybi13.ipp>
 #include <boost/beast/websocket/detail/mask.ipp>
 #include <boost/beast/websocket/detail/pmd_extension.ipp>

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 260
+#define BOOST_BEAST_VERSION 261
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/detail/frame.ipp
+++ b/include/boost/beast/websocket/detail/frame.ipp
@@ -1,0 +1,169 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_WEBSOCKET_DETAIL_FRAME_IPP
+#define BOOST_BEAST_WEBSOCKET_DETAIL_FRAME_IPP
+
+#include <boost/beast/websocket/rfc6455.hpp>
+#include <boost/beast/websocket/detail/frame.hpp>
+#include <boost/beast/websocket/detail/utf8_checker.hpp>
+#include <boost/asio/buffer.hpp>
+#include <boost/assert.hpp>
+#include <boost/endian/conversion.hpp>
+#include <cstdint>
+
+namespace boost {
+namespace beast {
+namespace websocket {
+namespace detail {
+
+bool
+is_valid_close_code(std::uint16_t v)
+{
+    switch(v)
+    {
+    case close_code::normal:            // 1000
+    case close_code::going_away:        // 1001
+    case close_code::protocol_error:    // 1002
+    case close_code::unknown_data:      // 1003
+    case close_code::bad_payload:       // 1007
+    case close_code::policy_error:      // 1008
+    case close_code::too_big:           // 1009
+    case close_code::needs_extension:   // 1010
+    case close_code::internal_error:    // 1011
+    case close_code::service_restart:   // 1012
+    case close_code::try_again_later:   // 1013
+        return true;
+
+    // explicitly reserved
+    case close_code::reserved1:         // 1004
+    case close_code::no_status:         // 1005
+    case close_code::abnormal:          // 1006
+    case close_code::reserved2:         // 1014
+    case close_code::reserved3:         // 1015
+        return false;
+    }
+    // reserved
+    if(v >= 1016 && v <= 2999)
+        return false;
+    // not used
+    if(v <= 999)
+        return false;
+    return true;
+}
+
+//------------------------------------------------------------------------------
+
+void
+write(flat_static_buffer_base& db, frame_header const& fh)
+{
+    std::size_t n;
+    std::uint8_t b[14];
+    b[0] = (fh.fin ? 0x80 : 0x00) | static_cast<std::uint8_t>(fh.op);
+    if(fh.rsv1)
+        b[0] |= 0x40;
+    if(fh.rsv2)
+        b[0] |= 0x20;
+    if(fh.rsv3)
+        b[0] |= 0x10;
+    b[1] = fh.mask ? 0x80 : 0x00;
+    if(fh.len <= 125)
+    {
+        b[1] |= fh.len;
+        n = 2;
+    }
+    else if(fh.len <= 65535)
+    {
+        b[1] |= 126;
+        auto len_be = endian::native_to_big(
+            static_cast<std::uint16_t>(fh.len));
+        std::memcpy(&b[2], &len_be, sizeof(len_be));
+        n = 4;
+    }
+    else
+    {
+        b[1] |= 127;
+        auto len_be = endian::native_to_big(
+            static_cast<std::uint64_t>(fh.len));
+        std::memcpy(&b[2], &len_be, sizeof(len_be));
+        n = 10;
+    }
+    if(fh.mask)
+    {
+        auto key_le = endian::native_to_little(
+            static_cast<std::uint32_t>(fh.key));
+        std::memcpy(&b[n], &key_le, sizeof(key_le));
+        n += 4;
+    }
+    db.commit(net::buffer_copy(
+        db.prepare(n), net::buffer(b)));
+}
+
+void
+read_ping(ping_data& data, beast::buffers_prefix_view<beast::detail::buffers_pair<true>> const& bs)
+{
+    BOOST_ASSERT(buffer_bytes(bs) <= data.max_size());
+    data.resize(buffer_bytes(bs));
+    net::buffer_copy(net::mutable_buffer{
+        data.data(), data.size()}, bs);
+}
+
+void
+read_close(
+    close_reason& cr,
+    beast::buffers_prefix_view<beast::detail::buffers_pair<true>> const& bs,
+    error_code& ec)
+{
+    auto const n = buffer_bytes(bs);
+    BOOST_ASSERT(n <= 125);
+    if(n == 0)
+    {
+        cr = close_reason{};
+        ec = {};
+        return;
+    }
+    if(n == 1)
+    {
+        // invalid payload size == 1
+        ec = error::bad_close_size;
+        return;
+    }
+
+    std::uint16_t code_be;
+    cr.reason.resize(n - 2);
+    std::array<net::mutable_buffer, 2> out_bufs{{
+        net::mutable_buffer(&code_be, sizeof(code_be)),
+        net::mutable_buffer(&cr.reason[0], n - 2)}};
+
+    net::buffer_copy(out_bufs, bs);
+
+    cr.code = endian::big_to_native(code_be);
+    if(! is_valid_close_code(cr.code))
+    {
+        // invalid close code
+        ec = error::bad_close_code;
+        return;
+    }
+
+    if(n > 2 && !check_utf8(
+        cr.reason.data(), cr.reason.size()))
+    {
+        // not valid utf-8
+        ec = error::bad_close_payload;
+        return;
+    }
+    ec = {};
+}
+
+} // detail
+} // websocket
+} // beast
+} // boost
+
+#endif

--- a/include/boost/beast/websocket/detail/prng.ipp
+++ b/include/boost/beast/websocket/detail/prng.ipp
@@ -13,14 +13,10 @@
 #include <boost/beast/websocket/detail/prng.hpp>
 #include <boost/beast/core/detail/chacha.hpp>
 #include <boost/beast/core/detail/pcg.hpp>
-#include <boost/align/aligned_alloc.hpp>
-#include <boost/throw_exception.hpp>
 #include <atomic>
 #include <cstdlib>
 #include <mutex>
-#include <new>
 #include <random>
-#include <stdexcept>
 
 namespace boost {
 namespace beast {
@@ -59,264 +55,92 @@ prng_seed(std::seed_seq* ss)
 
 //------------------------------------------------------------------------------
 
-template<class T>
-class prng_pool
+inline
+std::uint32_t
+make_nonce()
 {
-    std::mutex m_;
-    T* head_ = nullptr;
-
-public:
-    static
-    prng_pool&
-    instance()
-    {
-        static prng_pool p;
-        return p;
-    }
-
-    ~prng_pool()
-    {
-        for(auto p = head_; p;)
-        {
-            auto next = p->next;
-            p->~T();
-            boost::alignment::aligned_free(p);
-            p = next;
-        }
-    }
-
-    prng::ref
-    acquire()
-    {
-        {
-            std::lock_guard<
-                std::mutex> g(m_);
-            if(head_)
-            {
-                auto p = head_;
-                head_ = head_->next;
-                return prng::ref(*p);
-            }
-        }
-        auto p = boost::alignment::aligned_alloc(
-            16, sizeof(T));
-        if(! p)
-            BOOST_THROW_EXCEPTION(std::bad_alloc{});
-        return prng::ref(*(::new(p) T()));
-    }
-
-    void
-    release(T& t)
-    {
-        std::lock_guard<
-            std::mutex> g(m_);
-        t.next = head_;
-        head_ = &t;
-    }
-};
-
-prng::ref
-make_prng_no_tls(bool secure)
-{
-    class fast_prng final : public prng
-    {
-        int refs_ = 0;
-        beast::detail::pcg r_;
-
-    public:
-        fast_prng* next = nullptr;
-
-        fast_prng()
-            : r_(
-                []{
-                    auto const pv = prng_seed();
-                    return
-                        ((static_cast<std::uint64_t>(pv[0])<<32)+pv[1]) ^
-                        ((static_cast<std::uint64_t>(pv[2])<<32)+pv[3]) ^
-                        ((static_cast<std::uint64_t>(pv[4])<<32)+pv[5]) ^
-                        ((static_cast<std::uint64_t>(pv[6])<<32)+pv[7]);
-                }(),
-                []{
-                    static std::atomic<
-                        std::uint32_t> nonce{0};
-                    return ++nonce;
-                }())
-        {
-        }
-
-    protected:
-        prng&
-        acquire() noexcept override
-        {
-            ++refs_;
-            return *this;
-        }
-
-        void
-        release() noexcept override
-        {
-            if(--refs_ == 0)
-                prng_pool<fast_prng>::instance().release(*this);
-        }
-
-        value_type
-        operator()() noexcept override
-        {
-            return r_();
-        }
-    };
-
-    class secure_prng final : public prng
-    {
-        int refs_ = 0;
-        beast::detail::chacha<20> r_;
-
-    public:
-        secure_prng* next = nullptr;
-
-        secure_prng()
-            : r_(prng_seed(), []
-                {
-                    static std::atomic<
-                        std::uint64_t> nonce{0};
-                    return ++nonce;
-                }())
-        {
-        }
-
-    protected:
-        prng&
-        acquire() noexcept override
-        {
-            ++refs_;
-            return *this;
-        }
-
-        void
-        release() noexcept override
-        {
-            if(--refs_ == 0)
-                prng_pool<secure_prng>::instance().release(*this);
-        }
-
-        value_type
-        operator()() noexcept override
-        {
-            return r_();
-        }
-    };
-
-    if(secure)
-        return prng_pool<secure_prng>::instance().acquire();
-
-    return prng_pool<fast_prng>::instance().acquire();
+    static std::atomic<std::uint32_t> nonce{0};
+    return ++nonce;
 }
 
-//------------------------------------------------------------------------------
-
-#ifndef BOOST_NO_CXX11_THREAD_LOCAL
-
-prng::ref
-make_prng_tls(bool secure)
+inline
+beast::detail::pcg make_pcg()
 {
-    class fast_prng final : public prng
+    auto const pv = prng_seed();
+    return beast::detail::pcg{
+        ((static_cast<std::uint64_t>(pv[0])<<32)+pv[1]) ^
+        ((static_cast<std::uint64_t>(pv[2])<<32)+pv[3]) ^
+        ((static_cast<std::uint64_t>(pv[4])<<32)+pv[5]) ^
+        ((static_cast<std::uint64_t>(pv[6])<<32)+pv[7]), make_nonce()};
+}
+
+#ifdef BOOST_NO_CXX11_THREAD_LOCAL
+
+inline
+std::uint32_t
+secure_generate()
+{
+    struct generator
     {
-        beast::detail::pcg r_;
-
-    public:
-        fast_prng()
-            : r_(
-                []{
-                    auto const pv = prng_seed();
-                    return
-                        ((static_cast<std::uint64_t>(pv[0])<<32)+pv[1]) ^
-                        ((static_cast<std::uint64_t>(pv[2])<<32)+pv[3]) ^
-                        ((static_cast<std::uint64_t>(pv[4])<<32)+pv[5]) ^
-                        ((static_cast<std::uint64_t>(pv[6])<<32)+pv[7]);
-                }(),
-                []{
-                    static std::atomic<
-                        std::uint32_t> nonce{0};
-                    return ++nonce;
-                }())
+        std::uint32_t operator()()
         {
+            std::lock_guard<std::mutex> guard{mtx};
+            return gen();
         }
 
-    protected:
-        prng&
-        acquire() noexcept override
-        {
-            return *this;
-        }
-
-        void
-        release() noexcept override
-        {
-        }
-
-        value_type
-        operator()() noexcept override
-        {
-            return r_();
-        }
+        beast::detail::chacha<20> gen;
+        std::mutex mtx;
     };
+    static generator gen{beast::detail::chacha<20>{prng_seed(), make_nonce()}};
+    return gen();
+}
 
-    class secure_prng final : public prng
+inline
+std::uint32_t
+fast_generate()
+{
+    struct generator
     {
-        beast::detail::chacha<20> r_;
-
-    public:
-        secure_prng()
-            : r_(prng_seed(), []
-                {
-                    static std::atomic<
-                        std::uint64_t> nonce{0};
-                    return ++nonce;
-                }())
+        std::uint32_t operator()()
         {
+            std::lock_guard<std::mutex> guard{mtx};
+            return gen();
         }
 
-    protected:
-        prng&
-        acquire() noexcept override
-        {
-            return *this;
-        }
-
-        void
-        release() noexcept override
-        {
-        }
-
-        value_type
-        operator()() noexcept override
-        {
-            return r_();
-        }
+        beast::detail::pcg gen;
+        std::mutex mtx;
     };
+    static generator gen{make_pcg()};
+    return gen();
+}
 
-    if(secure)
-    {
-        thread_local secure_prng sp;
-        return prng::ref(sp);
-    }
+#else
 
-    thread_local fast_prng fp;
-    return prng::ref(fp);
+inline
+std::uint32_t
+secure_generate()
+{
+    thread_local static beast::detail::chacha<20> gen{prng_seed(), make_nonce()};
+    return gen();
+}
+
+inline
+std::uint32_t
+fast_generate()
+{
+    thread_local static beast::detail::pcg gen{make_pcg()};
+    return gen();
 }
 
 #endif
 
-//------------------------------------------------------------------------------
-
-prng::ref
+generator
 make_prng(bool secure)
 {
-#ifdef BOOST_NO_CXX11_THREAD_LOCAL
-    return make_prng_no_tls(secure);
-#else
-    return make_prng_tls(secure);
-#endif
+    if (secure)
+        return &secure_generate;
+    else
+        return &fast_generate;
 }
 
 } // detail

--- a/include/boost/beast/websocket/impl/close.hpp
+++ b/include/boost/beast/websocket/impl/close.hpp
@@ -61,8 +61,7 @@ public:
             detail::frame_buffer>(*this))
     {
         // Serialize the close frame
-        sp->template write_close<
-            flat_static_buffer_base>(fb_, cr);
+        sp->write_close(fb_, cr);
         (*this)({}, 0, false);
     }
 
@@ -298,7 +297,7 @@ close(close_reason const& cr, error_code& ec)
         impl.wr_close = true;
         impl.change_status(status::closing);
         detail::frame_buffer fb;
-        impl.template write_close<flat_static_buffer_base>(fb, cr);
+        impl.write_close(fb, cr);
         net::write(impl.stream(), fb.data(), ec);
         if(impl.check_stop_now(ec))
             return;

--- a/include/boost/beast/websocket/impl/ping.hpp
+++ b/include/boost/beast/websocket/impl/ping.hpp
@@ -58,8 +58,7 @@ public:
             detail::frame_buffer>(*this))
     {
         // Serialize the ping or pong frame
-        sp->template write_ping<
-            flat_static_buffer_base>(fb_, op, payload);
+        sp->write_ping(fb_, op, payload);
         (*this)({}, 0, false);
     }
 
@@ -144,9 +143,7 @@ public:
         {
             // Create the ping frame
             ping_data payload; // empty for now
-            sp->template write_ping<
-                flat_static_buffer_base>(*fb_,
-                    detail::opcode::ping, payload);
+            sp->write_ping(*fb_, detail::opcode::ping, payload);
 
             sp->idle_pinging = true;
             (*this)({}, 0);
@@ -254,8 +251,7 @@ ping(ping_data const& payload, error_code& ec)
     if(impl_->check_stop_now(ec))
         return;
     detail::frame_buffer fb;
-    impl_->template write_ping<flat_static_buffer_base>(
-        fb, detail::opcode::ping, payload);
+    impl_->write_ping(fb, detail::opcode::ping, payload);
     net::write(impl_->stream(), fb.data(), ec);
     if(impl_->check_stop_now(ec))
         return;
@@ -280,8 +276,7 @@ pong(ping_data const& payload, error_code& ec)
     if(impl_->check_stop_now(ec))
         return;
     detail::frame_buffer fb;
-    impl_->template write_ping<flat_static_buffer_base>(
-        fb, detail::opcode::pong, payload);
+    impl_->write_ping(fb, detail::opcode::pong, payload);
     net::write(impl_->stream(), fb.data(), ec);
     if(impl_->check_stop_now(ec))
         return;

--- a/include/boost/beast/websocket/impl/read.hpp
+++ b/include/boost/beast/websocket/impl/read.hpp
@@ -226,8 +226,7 @@ public:
                                 impl.ctrl_cb(
                                     frame_type::ping, payload);
                             impl.rd_fb.clear();
-                            impl.template write_ping<
-                                flat_static_buffer_base>(impl.rd_fb,
+                            impl.write_ping(impl.rd_fb,
                                     detail::opcode::pong, payload);
                         }
 
@@ -563,9 +562,7 @@ public:
 
                 // Serialize close frame
                 impl.rd_fb.clear();
-                impl.template write_close<
-                    flat_static_buffer_base>(
-                        impl.rd_fb, code_);
+                impl.write_close(impl.rd_fb, code_);
 
                 // Send close frame
                 BOOST_ASSERT(impl.wr_block.is_locked(this));
@@ -1004,8 +1001,7 @@ loop:
                 if(impl.ctrl_cb)
                     impl.ctrl_cb(frame_type::ping, payload);
                 detail::frame_buffer fb;
-                impl.template write_ping<flat_static_buffer_base>(fb,
-                    detail::opcode::pong, payload);
+                impl.write_ping(fb, detail::opcode::pong, payload);
                 net::write(impl.stream(), fb.data(), ec);
                 if(impl.check_stop_now(ec))
                     return bytes_written;

--- a/include/boost/beast/websocket/impl/read.hpp
+++ b/include/boost/beast/websocket/impl/read.hpp
@@ -16,7 +16,6 @@
 #include <boost/beast/websocket/impl/stream_impl.hpp>
 #include <boost/beast/core/async_base.hpp>
 #include <boost/beast/core/bind_handler.hpp>
-#include <boost/beast/core/buffers_prefix.hpp>
 #include <boost/beast/core/buffers_suffix.hpp>
 #include <boost/beast/core/flat_static_buffer.hpp>
 #include <boost/beast/core/read_size.hpp>

--- a/include/boost/beast/websocket/impl/stream.hpp
+++ b/include/boost/beast/websocket/impl/stream.hpp
@@ -25,7 +25,6 @@
 #include <boost/beast/core/buffers_suffix.hpp>
 #include <boost/beast/core/flat_static_buffer.hpp>
 #include <boost/beast/core/detail/clamp.hpp>
-#include <boost/asio/bind_executor.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/assert.hpp>
 #include <boost/make_shared.hpp>

--- a/include/boost/beast/websocket/impl/stream.hpp
+++ b/include/boost/beast/websocket/impl/stream.hpp
@@ -321,8 +321,7 @@ do_fail(
     {
         impl_->wr_close = true;
         detail::frame_buffer fb;
-        impl_->template write_close<
-            flat_static_buffer_base>(fb, code);
+        impl_->write_close(fb, code);
         net::write(impl_->stream(), fb.data(), ec);
         if(impl_->check_stop_now(ec))
             return;

--- a/include/boost/beast/websocket/impl/stream.hpp
+++ b/include/boost/beast/websocket/impl/stream.hpp
@@ -138,12 +138,7 @@ read_size_hint(DynamicBuffer& buffer) const
     static_assert(
         net::is_dynamic_buffer<DynamicBuffer>::value,
         "DynamicBuffer type requirements not met");
-    auto const initial_size = (std::min)(
-        +tcp_frame_size,
-        buffer.max_size() - buffer.size());
-    if(initial_size == 0)
-        return 1; // buffer is full
-    return read_size_hint(initial_size);
+    return impl_->read_size_hint_db(buffer);
 }
 
 //------------------------------------------------------------------------------

--- a/include/boost/beast/websocket/impl/stream_impl.hpp
+++ b/include/boost/beast/websocket/impl/stream_impl.hpp
@@ -274,13 +274,6 @@ struct stream<NextLayer, deflateSupported>::impl_type
                 return key;
     }
 
-    std::size_t
-    read_size_hint(std::size_t initial_size) const
-    {
-        return this->read_size_hint_pmd(
-            initial_size, rd_done, rd_remain, rd_fh);
-    }
-
     template<class DynamicBuffer>
     std::size_t
     read_size_hint_db(DynamicBuffer& buffer) const
@@ -290,7 +283,8 @@ struct stream<NextLayer, deflateSupported>::impl_type
             buffer.max_size() - buffer.size());
         if(initial_size == 0)
             return 1; // buffer is full
-        return this->read_size_hint(initial_size);
+        return this->read_size_hint_pmd(
+            initial_size, rd_done, rd_remain, rd_fh);
     }
 
     template<class DynamicBuffer>

--- a/include/boost/beast/websocket/impl/stream_impl.hpp
+++ b/include/boost/beast/websocket/impl/stream_impl.hpp
@@ -31,6 +31,7 @@
 #include <boost/beast/core/stream_traits.hpp>
 #include <boost/beast/core/detail/clamp.hpp>
 #include <boost/beast/version.hpp>
+#include <boost/endian/conversion.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/core/empty_value.hpp>
 #include <boost/enable_shared_from_this.hpp>

--- a/include/boost/beast/websocket/impl/stream_impl.hpp
+++ b/include/boost/beast/websocket/impl/stream_impl.hpp
@@ -31,7 +31,6 @@
 #include <boost/beast/core/stream_traits.hpp>
 #include <boost/beast/core/detail/clamp.hpp>
 #include <boost/beast/version.hpp>
-#include <boost/asio/bind_executor.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/core/empty_value.hpp>
 #include <boost/enable_shared_from_this.hpp>

--- a/include/boost/beast/websocket/impl/write.hpp
+++ b/include/boost/beast/websocket/impl/write.hpp
@@ -191,8 +191,7 @@ operator()(
             fh_.fin = fin_;
             fh_.len = buffer_bytes(cb_);
             impl.wr_fb.clear();
-            detail::write<flat_static_buffer_base>(
-                impl.wr_fb, fh_);
+            detail::write(impl.wr_fb, fh_);
             impl.wr_cont = ! fin_;
             BOOST_ASIO_CORO_YIELD
             net::async_write(impl.stream(),
@@ -216,8 +215,7 @@ operator()(
                 remain_ -= n;
                 fh_.fin = fin_ ? remain_ == 0 : false;
                 impl.wr_fb.clear();
-                detail::write<flat_static_buffer_base>(
-                    impl.wr_fb, fh_);
+                detail::write(impl.wr_fb, fh_);
                 impl.wr_cont = ! fin_;
                 // Send frame
                 BOOST_ASIO_CORO_YIELD
@@ -261,8 +259,7 @@ operator()(
             fh_.key = impl.create_mask();
             detail::prepare_key(key_, fh_.key);
             impl.wr_fb.clear();
-            detail::write<flat_static_buffer_base>(
-                impl.wr_fb, fh_);
+            detail::write(impl.wr_fb, fh_);
             n = clamp(remain_, impl.wr_buf_size);
             net::buffer_copy(net::buffer(
                 impl.wr_buf.get(), n), cb_);
@@ -320,8 +317,7 @@ operator()(
                 detail::mask_inplace(net::buffer(
                     impl.wr_buf.get(), n), key_);
                 impl.wr_fb.clear();
-                detail::write<flat_static_buffer_base>(
-                    impl.wr_fb, fh_);
+                detail::write(impl.wr_fb, fh_);
                 impl.wr_cont = ! fin_;
                 // Send frame
                 BOOST_ASIO_CORO_YIELD
@@ -384,8 +380,7 @@ operator()(
                 fh_.fin = ! more_;
                 fh_.len = n;
                 impl.wr_fb.clear();
-                detail::write<
-                    flat_static_buffer_base>(impl.wr_fb, fh_);
+                detail::write(impl.wr_fb, fh_);
                 impl.wr_cont = ! fin_;
                 // Send frame
                 BOOST_ASIO_CORO_YIELD
@@ -555,8 +550,7 @@ write_some(bool fin,
             fh.fin = ! more;
             fh.len = n;
             detail::fh_buffer fh_buf;
-            detail::write<
-                flat_static_buffer_base>(fh_buf, fh);
+            detail::write(fh_buf, fh);
             impl.wr_cont = ! fin;
             net::write(impl.stream(),
                 buffers_cat(fh_buf.data(), b), ec);
@@ -578,8 +572,7 @@ write_some(bool fin,
             fh.fin = fin;
             fh.len = remain;
             detail::fh_buffer fh_buf;
-            detail::write<
-                flat_static_buffer_base>(fh_buf, fh);
+            detail::write(fh_buf, fh);
             impl.wr_cont = ! fin;
             net::write(impl.stream(),
                 buffers_cat(fh_buf.data(), buffers), ec);
@@ -600,8 +593,7 @@ write_some(bool fin,
                 fh.len = n;
                 fh.fin = fin ? remain == 0 : false;
                 detail::fh_buffer fh_buf;
-                detail::write<
-                    flat_static_buffer_base>(fh_buf, fh);
+                detail::write(fh_buf, fh);
                 impl.wr_cont = ! fin;
                 net::write(impl.stream(),
                     beast::buffers_cat(fh_buf.data(),
@@ -625,8 +617,7 @@ write_some(bool fin,
         detail::prepared_key key;
         detail::prepare_key(key, fh.key);
         detail::fh_buffer fh_buf;
-        detail::write<
-            flat_static_buffer_base>(fh_buf, fh);
+        detail::write(fh_buf, fh);
         buffers_suffix<
             ConstBufferSequence> cb{buffers};
         {
@@ -683,8 +674,7 @@ write_some(bool fin,
             fh.fin = fin ? remain == 0 : false;
             impl.wr_cont = ! fh.fin;
             detail::fh_buffer fh_buf;
-            detail::write<
-                flat_static_buffer_base>(fh_buf, fh);
+            detail::write(fh_buf, fh);
             net::write(impl.stream(),
                 buffers_cat(fh_buf.data(), b), ec);
             bytes_transferred += n;

--- a/test/beast/websocket/_detail_prng.cpp
+++ b/test/beast/websocket/_detail_prng.cpp
@@ -42,17 +42,20 @@ public:
     void
     testPrng(F const& f)
     {
+        auto const min = std::numeric_limits<std::uint32_t>::min();
+        auto const max = std::numeric_limits<std::uint32_t>::max();
+
         {
             auto v = f()();
             BEAST_EXPECT(
-                v >= (prng::ref::min)() &&
-                v <= (prng::ref::max)());
+                v >= min &&
+                v <= max);
         }
         {
             auto v = f()();
             BEAST_EXPECT(
-                v >= (prng::ref::min)() &&
-                v <= (prng::ref::max)());
+                v >= min &&
+                v <= max);
         }
     }
 
@@ -61,12 +64,6 @@ public:
     {
         testPrng([]{ return make_prng(true); });
         testPrng([]{ return make_prng(false); });
-        testPrng([]{ return make_prng_no_tls(true); });
-        testPrng([]{ return make_prng_no_tls(false); });
-    #ifndef BOOST_NO_CXX11_THREAD_LOCAL
-        testPrng([]{ return make_prng_tls(true); });
-        testPrng([]{ return make_prng_tls(false); });
-    #endif
     }
 };
 

--- a/test/beast/websocket/read2.cpp
+++ b/test/beast/websocket/read2.cpp
@@ -133,7 +133,7 @@ public:
         [&](ws_type_t<deflateSupported>& ws)
         {
             put(ws.next_layer().buffer(), cbuf(
-                0x89, 0x00));
+                {0x89, 0x00}));
             bool invoked = false;
             ws.control_callback(
                 [&](frame_type kind, string_view)
@@ -155,7 +155,7 @@ public:
         [&](ws_type_t<deflateSupported>& ws)
         {
             put(ws.next_layer().buffer(), cbuf(
-                0x88, 0x00));
+                {0x88, 0x00}));
             bool invoked = false;
             ws.control_callback(
                 [&](frame_type kind, string_view)
@@ -313,7 +313,7 @@ public:
         [&](ws_type_t<deflateSupported>& ws)
         {
             w.write_raw(ws, cbuf(
-                0x8f, 0x80, 0xff, 0xff, 0xff, 0xff));
+                {0x8f, 0x80, 0xff, 0xff, 0xff, 0xff}));
             doReadTest(w, ws, close_code::protocol_error);
         });
 
@@ -322,7 +322,7 @@ public:
         [&](ws_type_t<deflateSupported>& ws)
         {
             put(ws.next_layer().buffer(), cbuf(
-                0x88, 0x02, 0x03, 0xed));
+                {0x88, 0x02, 0x03, 0xed}));
             doFailTest(w, ws, error::bad_close_code);
         });
 
@@ -332,8 +332,8 @@ public:
         {
             w.write_some(ws, false, sbuf("*"));
             w.write_raw(ws, cbuf(
-                0x80, 0xff, 0xff, 0xff, 0xff, 0xff,
-                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff));
+                {0x80, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}));
             doReadTest(w, ws, close_code::too_big);
         });
 
@@ -351,7 +351,7 @@ public:
         [&](ws_type_t<deflateSupported>& ws)
         {
             put(ws.next_layer().buffer(), cbuf(
-                0x81, 0x06, 0x03, 0xea, 0xf0, 0x28, 0x8c, 0xbc));
+                {0x81, 0x06, 0x03, 0xea, 0xf0, 0x28, 0x8c, 0xbc}));
             doFailTest(w, ws, error::bad_frame_payload);
         });
 

--- a/test/beast/websocket/test.hpp
+++ b/test/beast/websocket/test.hpp
@@ -12,7 +12,6 @@
 
 #include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/buffer_traits.hpp>
-#include <boost/beast/core/buffers_prefix.hpp>
 #include <boost/beast/core/buffers_to_string.hpp>
 #include <boost/beast/core/ostream.hpp>
 #include <boost/beast/core/multi_buffer.hpp>
@@ -22,9 +21,7 @@
 #include <boost/beast/_experimental/unit_test/suite.hpp>
 #include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
-#include <boost/asio/spawn.hpp>
 #include <boost/optional.hpp>
-#include <array>
 #include <cstdlib>
 #include <memory>
 #include <random>
@@ -377,42 +374,9 @@ public:
 
     //--------------------------------------------------------------------------
 
-    template<std::size_t N>
-    class cbuf_helper
+    net::const_buffer cbuf(std::initializer_list<std::uint8_t> bytes)
     {
-        std::array<std::uint8_t, N> v_;
-        net::const_buffer cb_;
-
-    public:
-        using value_type = decltype(cb_);
-        using const_iterator = value_type const*;
-
-        template<class... Vn>
-        explicit
-        cbuf_helper(Vn... vn)
-            : v_({{ static_cast<std::uint8_t>(vn)... }})
-            , cb_(v_.data(), v_.size())
-        {
-        }
-
-        const_iterator
-        begin() const
-        {
-            return &cb_;
-        }
-
-        const_iterator
-        end() const
-        {
-            return begin()+1;
-        }
-    };
-
-    template<class... Vn>
-    cbuf_helper<sizeof...(Vn)>
-    cbuf(Vn... vn)
-    {
-        return cbuf_helper<sizeof...(Vn)>(vn...);
+        return {bytes.begin(), bytes.size()};
     }
 
     template<std::size_t N>


### PR DESCRIPTION
* Deduplicate `websocket::read_size_hint` definition
* Fix UB in websocket read tests
* Remove redundant includes in websocket
* Use `std::shared_ptr` in `test::stream`
* Simplify websocket::detail::prng
* More split compilation in websocket/detail/frame.hpp
* Detemplatize websocket frame parsing routines