### PR TITLE
Version 261

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 261:
 * Fix UB in websocket read tests
 * Remove redundant includes in websocket
 * Simplify websocket::detail::prng
+* Don't over-allocate in http::basic_fields
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 261:
 
 * Deduplicate `websocket::read_size_hint` definition
 * Fix UB in websocket read tests
+* Remove redundant includes in websocket
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 261:
 * Simplify websocket::detail::prng
 * Don't over-allocate in http::basic_fields
 * Fix multi_buffer allocation alignment
+* Tidy up buffers_range
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 261:
 * Remove redundant includes in websocket
 * Simplify websocket::detail::prng
 * Don't over-allocate in http::basic_fields
+* Fix multi_buffer allocation alignment
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 261:
 
 * Deduplicate `websocket::read_size_hint` definition
+* Fix UB in websocket read tests
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 261:
+
+* Deduplicate `websocket::read_size_hint` definition
+
+--------------------------------------------------------------------------------
+
 Version 260:
 
 * More split compilation in rfc7230.hpp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 261:
 * Deduplicate `websocket::read_size_hint` definition
 * Fix UB in websocket read tests
 * Remove redundant includes in websocket
+* Simplify websocket::detail::prng
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endfunction()
 #
 #-------------------------------------------------------------------------------
 
-project (Beast VERSION 260)
+project (Beast VERSION 261)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,14 @@ jobs:
           B2_FLAGS: <boost.beast.separate-compilation>off <boost.beast.allow-deprecated>off
           CXXSTD: 11
           B2_TARGETS: libs/beast/test//run-fat-tests
+        GCC 9 C++11 NO_DEPRECATED NO_TLS:
+          TOOLSET: gcc
+          CXX: g++-9
+          PACKAGES: g++-9
+          VARIANT: release
+          B2_FLAGS: <boost.beast.allow-deprecated>off <define>BOOST_NO_CXX11_THREAD_LOCAL
+          CXXSTD: 11
+          B2_TARGETS: libs/beast/test//run-fat-tests
         GCC 9 C++11 UBASAN:
           TOOLSET: gcc
           CXX: g++-9

--- a/include/boost/beast/core/detail/buffers_range_adaptor.hpp
+++ b/include/boost/beast/core/detail/buffers_range_adaptor.hpp
@@ -38,13 +38,9 @@ public:
             buffers_iterator_type<BufferSequence>;
 
         iter_type it_{};
-        buffers_range_adaptor const* b_ = nullptr;
 
-        const_iterator(
-            buffers_range_adaptor const& b,
-            iter_type const& it)
+        const_iterator(iter_type const& it)
             : it_(it)
-            , b_(&b)
         {
         }
 
@@ -62,7 +58,7 @@ public:
         bool
         operator==(const_iterator const& other) const
         {
-            return b_ == other.b_ && it_ == other.it_;
+            return it_ == other.it_;
         }
 
         bool
@@ -111,11 +107,6 @@ public:
         }
     };
 
-    buffers_range_adaptor(
-        buffers_range_adaptor const&) = default;
-    buffers_range_adaptor& operator=(
-        buffers_range_adaptor const&) = default;
-
     explicit
     buffers_range_adaptor(BufferSequence const& b)
         : b_(b)
@@ -125,13 +116,13 @@ public:
     const_iterator
     begin() const noexcept
     {
-        return {*this, net::buffer_sequence_begin(b_)};
+        return {net::buffer_sequence_begin(b_)};
     }
 
     const_iterator
     end() const noexcept
     {
-        return {*this, net::buffer_sequence_end(b_)};
+        return {net::buffer_sequence_end(b_)};
     }
 };
 

--- a/include/boost/beast/core/detail/remap_post_to_defer.hpp
+++ b/include/boost/beast/core/detail/remap_post_to_defer.hpp
@@ -10,7 +10,6 @@
 #ifndef BOOST_BEAST_DETAIL_REMAP_POST_TO_DEFER_HPP
 #define BOOST_BEAST_DETAIL_REMAP_POST_TO_DEFER_HPP
 
-#include <boost/asio/bind_executor.hpp>
 #include <boost/asio/is_executor.hpp>
 #include <boost/core/empty_value.hpp>
 #include <type_traits>

--- a/include/boost/beast/http/fields.hpp
+++ b/include/boost/beast/http/fields.hpp
@@ -196,7 +196,7 @@ private:
 
     using rebind_type = typename
         beast::detail::allocator_traits<Allocator>::
-            template rebind_alloc<element>;
+            template rebind_alloc<align_type>;
 
     using alloc_traits =
         beast::detail::allocator_traits<rebind_type>;

--- a/include/boost/beast/http/impl/fields.hpp
+++ b/include/boost/beast/http/impl/fields.hpp
@@ -990,8 +990,8 @@ delete_element(element& e)
         (sizeof(element) + e.off_ + e.len_ + 2 + sizeof(align_type) - 1) /
             sizeof(align_type);
     e.~element();
-    alloc_traits::deallocate(a, &e, n);
-        //reinterpret_cast<align_type*>(&e), n);
+    alloc_traits::deallocate(a,
+        reinterpret_cast<align_type*>(&e), n);
 }
 
 template<class Allocator>

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 260
+#define BOOST_BEAST_VERSION 261
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/detail/prng.ipp
+++ b/include/boost/beast/websocket/detail/prng.ipp
@@ -13,14 +13,10 @@
 #include <boost/beast/websocket/detail/prng.hpp>
 #include <boost/beast/core/detail/chacha.hpp>
 #include <boost/beast/core/detail/pcg.hpp>
-#include <boost/align/aligned_alloc.hpp>
-#include <boost/throw_exception.hpp>
 #include <atomic>
 #include <cstdlib>
 #include <mutex>
-#include <new>
 #include <random>
-#include <stdexcept>
 
 namespace boost {
 namespace beast {
@@ -59,264 +55,92 @@ prng_seed(std::seed_seq* ss)
 
 //------------------------------------------------------------------------------
 
-template<class T>
-class prng_pool
+inline
+std::uint32_t
+make_nonce()
 {
-    std::mutex m_;
-    T* head_ = nullptr;
-
-public:
-    static
-    prng_pool&
-    instance()
-    {
-        static prng_pool p;
-        return p;
-    }
-
-    ~prng_pool()
-    {
-        for(auto p = head_; p;)
-        {
-            auto next = p->next;
-            p->~T();
-            boost::alignment::aligned_free(p);
-            p = next;
-        }
-    }
-
-    prng::ref
-    acquire()
-    {
-        {
-            std::lock_guard<
-                std::mutex> g(m_);
-            if(head_)
-            {
-                auto p = head_;
-                head_ = head_->next;
-                return prng::ref(*p);
-            }
-        }
-        auto p = boost::alignment::aligned_alloc(
-            16, sizeof(T));
-        if(! p)
-            BOOST_THROW_EXCEPTION(std::bad_alloc{});
-        return prng::ref(*(::new(p) T()));
-    }
-
-    void
-    release(T& t)
-    {
-        std::lock_guard<
-            std::mutex> g(m_);
-        t.next = head_;
-        head_ = &t;
-    }
-};
-
-prng::ref
-make_prng_no_tls(bool secure)
-{
-    class fast_prng final : public prng
-    {
-        int refs_ = 0;
-        beast::detail::pcg r_;
-
-    public:
-        fast_prng* next = nullptr;
-
-        fast_prng()
-            : r_(
-                []{
-                    auto const pv = prng_seed();
-                    return
-                        ((static_cast<std::uint64_t>(pv[0])<<32)+pv[1]) ^
-                        ((static_cast<std::uint64_t>(pv[2])<<32)+pv[3]) ^
-                        ((static_cast<std::uint64_t>(pv[4])<<32)+pv[5]) ^
-                        ((static_cast<std::uint64_t>(pv[6])<<32)+pv[7]);
-                }(),
-                []{
-                    static std::atomic<
-                        std::uint32_t> nonce{0};
-                    return ++nonce;
-                }())
-        {
-        }
-
-    protected:
-        prng&
-        acquire() noexcept override
-        {
-            ++refs_;
-            return *this;
-        }
-
-        void
-        release() noexcept override
-        {
-            if(--refs_ == 0)
-                prng_pool<fast_prng>::instance().release(*this);
-        }
-
-        value_type
-        operator()() noexcept override
-        {
-            return r_();
-        }
-    };
-
-    class secure_prng final : public prng
-    {
-        int refs_ = 0;
-        beast::detail::chacha<20> r_;
-
-    public:
-        secure_prng* next = nullptr;
-
-        secure_prng()
-            : r_(prng_seed(), []
-                {
-                    static std::atomic<
-                        std::uint64_t> nonce{0};
-                    return ++nonce;
-                }())
-        {
-        }
-
-    protected:
-        prng&
-        acquire() noexcept override
-        {
-            ++refs_;
-            return *this;
-        }
-
-        void
-        release() noexcept override
-        {
-            if(--refs_ == 0)
-                prng_pool<secure_prng>::instance().release(*this);
-        }
-
-        value_type
-        operator()() noexcept override
-        {
-            return r_();
-        }
-    };
-
-    if(secure)
-        return prng_pool<secure_prng>::instance().acquire();
-
-    return prng_pool<fast_prng>::instance().acquire();
+    static std::atomic<std::uint32_t> nonce{0};
+    return ++nonce;
 }
 
-//------------------------------------------------------------------------------
-
-#ifndef BOOST_NO_CXX11_THREAD_LOCAL
-
-prng::ref
-make_prng_tls(bool secure)
+inline
+beast::detail::pcg make_pcg()
 {
-    class fast_prng final : public prng
+    auto const pv = prng_seed();
+    return beast::detail::pcg{
+        ((static_cast<std::uint64_t>(pv[0])<<32)+pv[1]) ^
+        ((static_cast<std::uint64_t>(pv[2])<<32)+pv[3]) ^
+        ((static_cast<std::uint64_t>(pv[4])<<32)+pv[5]) ^
+        ((static_cast<std::uint64_t>(pv[6])<<32)+pv[7]), make_nonce()};
+}
+
+#ifdef BOOST_NO_CXX11_THREAD_LOCAL
+
+inline
+std::uint32_t
+secure_generate()
+{
+    struct generator
     {
-        beast::detail::pcg r_;
-
-    public:
-        fast_prng()
-            : r_(
-                []{
-                    auto const pv = prng_seed();
-                    return
-                        ((static_cast<std::uint64_t>(pv[0])<<32)+pv[1]) ^
-                        ((static_cast<std::uint64_t>(pv[2])<<32)+pv[3]) ^
-                        ((static_cast<std::uint64_t>(pv[4])<<32)+pv[5]) ^
-                        ((static_cast<std::uint64_t>(pv[6])<<32)+pv[7]);
-                }(),
-                []{
-                    static std::atomic<
-                        std::uint32_t> nonce{0};
-                    return ++nonce;
-                }())
+        std::uint32_t operator()()
         {
+            std::lock_guard<std::mutex> guard{mtx};
+            return gen();
         }
 
-    protected:
-        prng&
-        acquire() noexcept override
-        {
-            return *this;
-        }
-
-        void
-        release() noexcept override
-        {
-        }
-
-        value_type
-        operator()() noexcept override
-        {
-            return r_();
-        }
+        beast::detail::chacha<20> gen;
+        std::mutex mtx;
     };
+    static generator gen{beast::detail::chacha<20>{prng_seed(), make_nonce()}};
+    return gen();
+}
 
-    class secure_prng final : public prng
+inline
+std::uint32_t
+fast_generate()
+{
+    struct generator
     {
-        beast::detail::chacha<20> r_;
-
-    public:
-        secure_prng()
-            : r_(prng_seed(), []
-                {
-                    static std::atomic<
-                        std::uint64_t> nonce{0};
-                    return ++nonce;
-                }())
+        std::uint32_t operator()()
         {
+            std::lock_guard<std::mutex> guard{mtx};
+            return gen();
         }
 
-    protected:
-        prng&
-        acquire() noexcept override
-        {
-            return *this;
-        }
-
-        void
-        release() noexcept override
-        {
-        }
-
-        value_type
-        operator()() noexcept override
-        {
-            return r_();
-        }
+        beast::detail::pcg gen;
+        std::mutex mtx;
     };
+    static generator gen{make_pcg()};
+    return gen();
+}
 
-    if(secure)
-    {
-        thread_local secure_prng sp;
-        return prng::ref(sp);
-    }
+#else
 
-    thread_local fast_prng fp;
-    return prng::ref(fp);
+inline
+std::uint32_t
+secure_generate()
+{
+    thread_local static beast::detail::chacha<20> gen{prng_seed(), make_nonce()};
+    return gen();
+}
+
+inline
+std::uint32_t
+fast_generate()
+{
+    thread_local static beast::detail::pcg gen{make_pcg()};
+    return gen();
 }
 
 #endif
 
-//------------------------------------------------------------------------------
-
-prng::ref
+generator
 make_prng(bool secure)
 {
-#ifdef BOOST_NO_CXX11_THREAD_LOCAL
-    return make_prng_no_tls(secure);
-#else
-    return make_prng_tls(secure);
-#endif
+    if (secure)
+        return &secure_generate;
+    else
+        return &fast_generate;
 }
 
 } // detail

--- a/include/boost/beast/websocket/impl/stream.hpp
+++ b/include/boost/beast/websocket/impl/stream.hpp
@@ -25,7 +25,6 @@
 #include <boost/beast/core/buffers_suffix.hpp>
 #include <boost/beast/core/flat_static_buffer.hpp>
 #include <boost/beast/core/detail/clamp.hpp>
-#include <boost/asio/bind_executor.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/assert.hpp>
 #include <boost/make_shared.hpp>

--- a/include/boost/beast/websocket/impl/stream.hpp
+++ b/include/boost/beast/websocket/impl/stream.hpp
@@ -138,12 +138,7 @@ read_size_hint(DynamicBuffer& buffer) const
     static_assert(
         net::is_dynamic_buffer<DynamicBuffer>::value,
         "DynamicBuffer type requirements not met");
-    auto const initial_size = (std::min)(
-        +tcp_frame_size,
-        buffer.max_size() - buffer.size());
-    if(initial_size == 0)
-        return 1; // buffer is full
-    return read_size_hint(initial_size);
+    return impl_->read_size_hint_db(buffer);
 }
 
 //------------------------------------------------------------------------------

--- a/include/boost/beast/websocket/impl/stream_impl.hpp
+++ b/include/boost/beast/websocket/impl/stream_impl.hpp
@@ -274,13 +274,6 @@ struct stream<NextLayer, deflateSupported>::impl_type
                 return key;
     }
 
-    std::size_t
-    read_size_hint(std::size_t initial_size) const
-    {
-        return this->read_size_hint_pmd(
-            initial_size, rd_done, rd_remain, rd_fh);
-    }
-
     template<class DynamicBuffer>
     std::size_t
     read_size_hint_db(DynamicBuffer& buffer) const
@@ -290,7 +283,8 @@ struct stream<NextLayer, deflateSupported>::impl_type
             buffer.max_size() - buffer.size());
         if(initial_size == 0)
             return 1; // buffer is full
-        return this->read_size_hint(initial_size);
+        return this->read_size_hint_pmd(
+            initial_size, rd_done, rd_remain, rd_fh);
     }
 
     template<class DynamicBuffer>

--- a/include/boost/beast/websocket/impl/stream_impl.hpp
+++ b/include/boost/beast/websocket/impl/stream_impl.hpp
@@ -31,7 +31,6 @@
 #include <boost/beast/core/stream_traits.hpp>
 #include <boost/beast/core/detail/clamp.hpp>
 #include <boost/beast/version.hpp>
-#include <boost/asio/bind_executor.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/core/empty_value.hpp>
 #include <boost/enable_shared_from_this.hpp>

--- a/test/beast/websocket/_detail_prng.cpp
+++ b/test/beast/websocket/_detail_prng.cpp
@@ -42,17 +42,20 @@ public:
     void
     testPrng(F const& f)
     {
+        auto const min = std::numeric_limits<std::uint32_t>::min();
+        auto const max = std::numeric_limits<std::uint32_t>::max();
+
         {
             auto v = f()();
             BEAST_EXPECT(
-                v >= (prng::ref::min)() &&
-                v <= (prng::ref::max)());
+                v >= min &&
+                v <= max);
         }
         {
             auto v = f()();
             BEAST_EXPECT(
-                v >= (prng::ref::min)() &&
-                v <= (prng::ref::max)());
+                v >= min &&
+                v <= max);
         }
     }
 
@@ -61,12 +64,6 @@ public:
     {
         testPrng([]{ return make_prng(true); });
         testPrng([]{ return make_prng(false); });
-        testPrng([]{ return make_prng_no_tls(true); });
-        testPrng([]{ return make_prng_no_tls(false); });
-    #ifndef BOOST_NO_CXX11_THREAD_LOCAL
-        testPrng([]{ return make_prng_tls(true); });
-        testPrng([]{ return make_prng_tls(false); });
-    #endif
     }
 };
 

--- a/test/beast/websocket/read2.cpp
+++ b/test/beast/websocket/read2.cpp
@@ -133,7 +133,7 @@ public:
         [&](ws_type_t<deflateSupported>& ws)
         {
             put(ws.next_layer().buffer(), cbuf(
-                0x89, 0x00));
+                {0x89, 0x00}));
             bool invoked = false;
             ws.control_callback(
                 [&](frame_type kind, string_view)
@@ -155,7 +155,7 @@ public:
         [&](ws_type_t<deflateSupported>& ws)
         {
             put(ws.next_layer().buffer(), cbuf(
-                0x88, 0x00));
+                {0x88, 0x00}));
             bool invoked = false;
             ws.control_callback(
                 [&](frame_type kind, string_view)
@@ -313,7 +313,7 @@ public:
         [&](ws_type_t<deflateSupported>& ws)
         {
             w.write_raw(ws, cbuf(
-                0x8f, 0x80, 0xff, 0xff, 0xff, 0xff));
+                {0x8f, 0x80, 0xff, 0xff, 0xff, 0xff}));
             doReadTest(w, ws, close_code::protocol_error);
         });
 
@@ -322,7 +322,7 @@ public:
         [&](ws_type_t<deflateSupported>& ws)
         {
             put(ws.next_layer().buffer(), cbuf(
-                0x88, 0x02, 0x03, 0xed));
+                {0x88, 0x02, 0x03, 0xed}));
             doFailTest(w, ws, error::bad_close_code);
         });
 
@@ -332,8 +332,8 @@ public:
         {
             w.write_some(ws, false, sbuf("*"));
             w.write_raw(ws, cbuf(
-                0x80, 0xff, 0xff, 0xff, 0xff, 0xff,
-                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff));
+                {0x80, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}));
             doReadTest(w, ws, close_code::too_big);
         });
 
@@ -351,7 +351,7 @@ public:
         [&](ws_type_t<deflateSupported>& ws)
         {
             put(ws.next_layer().buffer(), cbuf(
-                0x81, 0x06, 0x03, 0xea, 0xf0, 0x28, 0x8c, 0xbc));
+                {0x81, 0x06, 0x03, 0xea, 0xf0, 0x28, 0x8c, 0xbc}));
             doFailTest(w, ws, error::bad_frame_payload);
         });
 

--- a/test/beast/websocket/test.hpp
+++ b/test/beast/websocket/test.hpp
@@ -12,7 +12,6 @@
 
 #include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/buffer_traits.hpp>
-#include <boost/beast/core/buffers_prefix.hpp>
 #include <boost/beast/core/buffers_to_string.hpp>
 #include <boost/beast/core/ostream.hpp>
 #include <boost/beast/core/multi_buffer.hpp>
@@ -22,9 +21,7 @@
 #include <boost/beast/_experimental/unit_test/suite.hpp>
 #include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
-#include <boost/asio/spawn.hpp>
 #include <boost/optional.hpp>
-#include <array>
 #include <cstdlib>
 #include <memory>
 #include <random>
@@ -377,42 +374,9 @@ public:
 
     //--------------------------------------------------------------------------
 
-    template<std::size_t N>
-    class cbuf_helper
+    net::const_buffer cbuf(std::initializer_list<std::uint8_t> bytes)
     {
-        std::array<std::uint8_t, N> v_;
-        net::const_buffer cb_;
-
-    public:
-        using value_type = decltype(cb_);
-        using const_iterator = value_type const*;
-
-        template<class... Vn>
-        explicit
-        cbuf_helper(Vn... vn)
-            : v_({{ static_cast<std::uint8_t>(vn)... }})
-            , cb_(v_.data(), v_.size())
-        {
-        }
-
-        const_iterator
-        begin() const
-        {
-            return &cb_;
-        }
-
-        const_iterator
-        end() const
-        {
-            return begin()+1;
-        }
-    };
-
-    template<class... Vn>
-    cbuf_helper<sizeof...(Vn)>
-    cbuf(Vn... vn)
-    {
-        return cbuf_helper<sizeof...(Vn)>(vn...);
+        return {bytes.begin(), bytes.size()};
     }
 
     template<std::size_t N>


### PR DESCRIPTION
* Deduplicate `websocket::read_size_hint` definition
* Fix UB in websocket read tests
* Remove redundant includes in websocket
* Use `std::shared_ptr` in `test::stream`
* Simplify websocket::detail::prng
* Don't over-allocate in http::basic_fields
* Fix multi_buffer allocation alignment
* Tidy up buffers_range
