### PR TITLE
Version 264

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Version 264:
 
 * Handle overflow in max size calculation in `basic_dynamic_body`
 * Fix unused variable warnings in tests
+* Fix missing initializer warning in `basic_fields`
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version 264:
 * Fix unused variable warnings in tests
 * Fix missing initializer warning in `basic_fields`
 * Remove unused functions in `impl/static_string.hpp`
+* Fix unused variable warning in `multi_buffer`
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 264:
 * Remove unused functions in `impl/static_string.hpp`
 * Fix unused variable warning in `multi_buffer`
 * Fix header-only compilation errors in some configurations
+* Workaround for miscompilation in MSVC 14.2
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 264:
 * Handle overflow in max size calculation in `basic_dynamic_body`
 * Fix unused variable warnings in tests
 * Fix missing initializer warning in `basic_fields`
+* Remove unused functions in `impl/static_string.hpp`
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 264:
+
+* Handle overflow in max size calculation in `basic_dynamic_body`
+
+--------------------------------------------------------------------------------
+
 Version 263:
 
 * Update documentation
@@ -135,7 +141,7 @@ Version 250:
 
 * Use SaxonHE in reference generation
 * Cleanup endianness conversions
-* Set parser status and flags even if body_limit_ has been reached 
+* Set parser status and flags even if body_limit_ has been reached
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Version 264:
 
 * Handle overflow in max size calculation in `basic_dynamic_body`
+* Fix unused variable warnings in tests
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 264:
 * Fix missing initializer warning in `basic_fields`
 * Remove unused functions in `impl/static_string.hpp`
 * Fix unused variable warning in `multi_buffer`
+* Fix header-only compilation errors in some configurations
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endfunction()
 #
 #-------------------------------------------------------------------------------
 
-project (Beast VERSION 263)
+project (Beast VERSION 264)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/include/boost/beast/core/detail/sha1.ipp
+++ b/include/boost/beast/core/detail/sha1.ipp
@@ -12,6 +12,7 @@
 
 #include <boost/beast/core/detail/sha1.hpp>
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 

--- a/include/boost/beast/core/impl/multi_buffer.hpp
+++ b/include/boost/beast/core/impl/multi_buffer.hpp
@@ -956,7 +956,6 @@ consume(size_type n) noexcept
 {
     if(list_.empty())
         return;
-    auto a = rebind_type{this->get()};
     for(;;)
     {
         if(list_.begin() != out_)

--- a/include/boost/beast/core/impl/static_string.hpp
+++ b/include/boost/beast/core/impl/static_string.hpp
@@ -558,64 +558,6 @@ assign_char(CharT, std::false_type) ->
         "max_size() == 0"});
 }
 
-namespace detail {
-
-template<class Integer>
-static_string<max_digits(sizeof(Integer))>
-to_static_string(Integer x, std::true_type)
-{
-    if(x == 0)
-        return {'0'};
-    static_string<detail::max_digits(
-        sizeof(Integer))> s;
-    if(x < 0)
-    {
-        x = -x;
-        char buf[max_digits(sizeof(x))];
-        char* p = buf;
-        for(;x > 0; x /= 10)
-            *p++ = "0123456789"[x % 10];
-        s.resize(1 + p - buf);
-        s[0] = '-';
-        auto d = &s[1];
-        while(p > buf)
-            *d++ = *--p;
-    }
-    else
-    {
-        char buf[max_digits(sizeof(x))];
-        char* p = buf;
-        for(;x > 0; x /= 10)
-            *p++ = "0123456789"[x % 10];
-        s.resize(p - buf);
-        auto d = &s[0];
-        while(p > buf)
-            *d++ = *--p;
-    }
-    return s;
-}
-
-template<class Integer>
-static_string<max_digits(sizeof(Integer))>
-to_static_string(Integer x, std::false_type)
-{
-    if(x == 0)
-        return {'0'};
-    char buf[max_digits(sizeof(x))];
-    char* p = buf;
-    for(;x > 0; x /= 10)
-        *p++ = "0123456789"[x % 10];
-    static_string<detail::max_digits(
-        sizeof(Integer))> s;
-    s.resize(p - buf);
-    auto d = &s[0];
-    while(p > buf)
-        *d++ = *--p;
-    return s;
-}
-
-} // detail
-
 template<class Integer, class>
 static_string<detail::max_digits(sizeof(Integer))>
 to_static_string(Integer x)

--- a/include/boost/beast/http/basic_dynamic_body.hpp
+++ b/include/boost/beast/http/basic_dynamic_body.hpp
@@ -13,6 +13,7 @@
 #include <boost/beast/core/detail/config.hpp>
 #include <boost/beast/core/buffer_traits.hpp>
 #include <boost/beast/core/detail/buffer.hpp>
+#include <boost/beast/core/detail/clamp.hpp>
 #include <boost/beast/http/error.hpp>
 #include <boost/beast/http/message.hpp>
 #include <boost/optional.hpp>
@@ -89,7 +90,7 @@ struct basic_dynamic_body
             error_code& ec)
         {
             auto const n = buffer_bytes(buffers);
-            if(body_.size() > body_.max_size() - n)
+            if(beast::detail::sum_exceeds(body_.size(), n, body_.max_size()))
             {
                 ec = error::buffer_overflow;
                 return 0;

--- a/include/boost/beast/http/impl/fields.hpp
+++ b/include/boost/beast/http/impl/fields.hpp
@@ -916,7 +916,7 @@ set_chunked_impl(bool value)
     if(it == end())
         return;
 
-    detail::filter_token_list_last(buf, it->value(), {"chunked"});
+    detail::filter_token_list_last(buf, it->value(), {"chunked", {}});
     if(! buf.empty())
         set(field::transfer_encoding, buf.view());
     else

--- a/include/boost/beast/http/impl/fields.ipp
+++ b/include/boost/beast/http/impl/fields.ipp
@@ -95,7 +95,7 @@ keep_alive_impl(
         if(keep_alive)
         {
             // remove close
-            filter_token_list(s, value, iequals_predicate{"close"});
+            filter_token_list(s, value, iequals_predicate{"close", {}});
             // add keep-alive
             if(s.empty())
                 s.append("keep-alive");
@@ -120,7 +120,7 @@ keep_alive_impl(
         else
         {
             // remove keep-alive
-            filter_token_list(s, value, iequals_predicate{"keep-alive"});
+            filter_token_list(s, value, iequals_predicate{"keep-alive", {}});
             // add close
             if(s.empty())
                 s.append("close");

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 263
+#define BOOST_BEAST_VERSION 264
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/test/beast/core/basic_stream.cpp
+++ b/test/beast/core/basic_stream.cpp
@@ -1204,7 +1204,6 @@ public:
         }
 
         {
-            error_code ec;
             stream_type s(ioc);
             async_teardown(role_type::server, s,
                 [](error_code)

--- a/test/beast/core/file_test.hpp
+++ b/test/beast/core/file_test.hpp
@@ -72,7 +72,6 @@ test_file()
     auto const remove =
         [](fs::path const& path)
         {
-            error_code ec;
             fs::remove(path);
         };
 

--- a/test/beast/core/flat_stream.cpp
+++ b/test/beast/core/flat_stream.cpp
@@ -148,7 +148,6 @@ public:
             BEAST_EXPECT(buffer_bytes(bs) <=
                 detail::flat_stream_base::max_size);
             flat_stream<test::stream> s(ioc);
-            error_code ec;
             s.async_write_some(bs,
                 [](error_code, std::size_t)
                 {

--- a/test/beast/core/static_string.cpp
+++ b/test/beast/core/static_string.cpp
@@ -569,7 +569,8 @@ public:
         //
 
         {
-            static_string<7> s1("12345");
+            // Using 7 as the size causes a miscompile in MSVC14.2 x64 Release
+            static_string<8> s1("12345");
             s1.insert(2, 2, '_');
             BEAST_EXPECT(s1 == "12__345");
             BEAST_EXPECT(*s1.end() == 0);


### PR DESCRIPTION
* Handle overflow in max size calculation in `basic_dynamic_body`
* Fix unused variable warnings in tests
* Fix missing initializer warning in `basic_fields`
* Remove unused functions in `impl/static_string.hpp`
* Fix unused variable warning in `multi_buffer`
* Fix header-only compilation errors in some configurations
* Workaround for miscompilation in MSVC 14.2