### PR TITLE
Fix signed/unsigned mismatch in file_stdio::seek

### DIFF
--- a/include/boost/beast/core/impl/file_stdio.ipp
+++ b/include/boost/beast/core/impl/file_stdio.ipp
@@ -241,7 +241,7 @@ seek(std::uint64_t offset, error_code& ec)
         ec = make_error_code(errc::bad_file_descriptor);
         return;
     }
-    if(offset > (std::numeric_limits<long>::max)())
+    if(offset > static_cast<std::uint64_t>(std::numeric_limits<long>::max()))
     {
         ec = make_error_code(errc::invalid_seek);
         return;


### PR DESCRIPTION
This fixes a C4388 warning when compiling with MSVC.