### PR TITLE
cmake: check policy first

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,10 @@
 #
 
 cmake_minimum_required (VERSION 3.5.1)
-cmake_policy (SET CMP0074 NEW)
+
+if (POLICY CMP0074)
+    cmake_policy (SET CMP0074 NEW)
+endif()
 
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
fix unkown policy with higher version cmake, e.g. 3.11.4
>  Policy "CMP0074" is not known to this version of CMake.