### PR TITLE
Allow the use of fake timers

### DIFF
--- a/include/boost/beast/core/basic_stream.hpp
+++ b/include/boost/beast/core/basic_stream.hpp
@@ -198,11 +198,12 @@ namespace beast {
 template<
     class Protocol,
     class Executor = net::any_io_executor,
-    class RatePolicy = unlimited_rate_policy
+    class RatePolicy = unlimited_rate_policy,
+    class TimeoutTimer = net::steady_timer
 >
 class basic_stream
 #if ! BOOST_BEAST_DOXYGEN
-    : private detail::stream_base
+    : private detail::stream_base<TimeoutTimer>
 #endif
 {
 public:
@@ -236,6 +237,13 @@ private:
     static_assert(
         net::is_executor<Executor>::value || net::execution::is_executor<Executor>::value,
         "Executor type requirements not met");
+
+    using stream_base = detail::stream_base<TimeoutTimer>;
+    using typename stream_base::clock_type;
+    using typename stream_base::op_state;
+    using typename stream_base::pending_guard;
+    using typename stream_base::tick_type;
+    using stream_base::never;
 
     struct impl_type
         : boost::enable_shared_from_this<impl_type>
@@ -457,7 +465,7 @@ public:
     */
     void
     expires_after(
-        net::steady_timer::duration expiry_time);
+        typename TimeoutTimer::duration expiry_time);
 
     /** Set the timeout for the next logical operation.
 
@@ -479,7 +487,7 @@ public:
         operation should be considered timed out.
     */
     void
-    expires_at(net::steady_timer::time_point expiry_time);
+    expires_at(typename TimeoutTimer::time_point expiry_time);
 
     /// Disable the timeout for the next logical operation.
     void

--- a/include/boost/beast/core/detail/stream_base.hpp
+++ b/include/boost/beast/core/detail/stream_base.hpp
@@ -32,16 +32,16 @@ struct any_endpoint
     }
 };
 
+template<class Timer>
 struct stream_base
 {
-    using clock_type = std::chrono::steady_clock;
-    using time_point = typename
-        std::chrono::steady_clock::time_point;
+    using clock_type = typename Timer::clock_type;
+    using time_point = typename Timer::time_point;
     using tick_type = std::uint64_t;
 
     struct op_state
     {
-        net::steady_timer timer;    // for timing out
+        Timer timer;                // for timing out
         tick_type tick = 0;         // counts waits
         bool pending = false;       // if op is pending
         bool timeout = false;       // if timed out

--- a/include/boost/beast/core/rate_policy.hpp
+++ b/include/boost/beast/core/rate_policy.hpp
@@ -41,7 +41,7 @@ namespace beast {
 class rate_policy_access
 {
 private:
-    template<class, class, class>
+    template<class, class, class, class>
     friend class basic_stream;
 
     template<class Policy>

--- a/include/boost/beast/websocket/impl/accept.hpp
+++ b/include/boost/beast/websocket/impl/accept.hpp
@@ -63,10 +63,10 @@ build_response_pmd(
 
 } // detail
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Body, class Allocator, class Decorator>
 response_type
-stream<NextLayer, deflateSupported>::impl_type::
+stream<NextLayer, deflateSupported, Timer>::impl_type::
 build_response(
     http::request<Body,
         http::basic_fields<Allocator>> const& req,
@@ -161,9 +161,9 @@ build_response(
 
 /** Respond to an HTTP request
 */
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Handler>
-class stream<NextLayer, deflateSupported>::response_op
+class stream<NextLayer, deflateSupported, Timer>::response_op
     : public beast::stable_async_base<
         Handler, beast::executor_type<stream>>
     , public asio::coroutine
@@ -236,9 +236,9 @@ public:
 
 // read and respond to an upgrade request
 //
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Handler, class Decorator>
-class stream<NextLayer, deflateSupported>::accept_op
+class stream<NextLayer, deflateSupported, Timer>::accept_op
     : public beast::stable_async_base<
         Handler, beast::executor_type<stream>>
     , public asio::coroutine
@@ -323,8 +323,8 @@ public:
     }
 };
 
-template<class NextLayer, bool deflateSupported>
-struct stream<NextLayer, deflateSupported>::
+template<class NextLayer, bool deflateSupported, class Timer>
+struct stream<NextLayer, deflateSupported, Timer>::
     run_response_op
 {
     template<
@@ -354,8 +354,8 @@ struct stream<NextLayer, deflateSupported>::
     }
 };
 
-template<class NextLayer, bool deflateSupported>
-struct stream<NextLayer, deflateSupported>::
+template<class NextLayer, bool deflateSupported, class Timer>
+struct stream<NextLayer, deflateSupported, Timer>::
     run_accept_op
 {
     template<
@@ -390,11 +390,11 @@ struct stream<NextLayer, deflateSupported>::
 
 //------------------------------------------------------------------------------
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Body, class Allocator,
     class Decorator>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 do_accept(
     http::request<Body,
         http::basic_fields<Allocator>> const& req,
@@ -419,10 +419,10 @@ do_accept(
     impl_->open(role_type::server);
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Buffers, class Decorator>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 do_accept(
     Buffers const& buffers,
     Decorator const& decorator,
@@ -448,9 +448,9 @@ do_accept(
 
 //------------------------------------------------------------------------------
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 accept()
 {
     static_assert(is_sync_stream<next_layer_type>::value,
@@ -461,9 +461,9 @@ accept()
         BOOST_THROW_EXCEPTION(system_error{ec});
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 accept(error_code& ec)
 {
     static_assert(is_sync_stream<next_layer_type>::value,
@@ -473,11 +473,11 @@ accept(error_code& ec)
         &default_decorate_res, ec);
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class ConstBufferSequence>
 typename std::enable_if<! http::detail::is_header<
     ConstBufferSequence>::value>::type
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 accept(ConstBufferSequence const& buffers)
 {
     static_assert(is_sync_stream<next_layer_type>::value,
@@ -490,11 +490,11 @@ accept(ConstBufferSequence const& buffers)
     if(ec)
         BOOST_THROW_EXCEPTION(system_error{ec});
 }
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class ConstBufferSequence>
 typename std::enable_if<! http::detail::is_header<
     ConstBufferSequence>::value>::type
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 accept(
     ConstBufferSequence const& buffers, error_code& ec)
 {
@@ -507,10 +507,10 @@ accept(
 }
 
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Body, class Allocator>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 accept(
     http::request<Body,
         http::basic_fields<Allocator>> const& req)
@@ -523,10 +523,10 @@ accept(
         BOOST_THROW_EXCEPTION(system_error{ec});
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Body, class Allocator>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 accept(
     http::request<Body,
         http::basic_fields<Allocator>> const& req,
@@ -540,11 +540,11 @@ accept(
 
 //------------------------------------------------------------------------------
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<
     BOOST_BEAST_ASYNC_TPARAM1 AcceptHandler>
 BOOST_BEAST_ASYNC_RESULT1(AcceptHandler)
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 async_accept(
     AcceptHandler&& handler)
 {
@@ -561,12 +561,12 @@ async_accept(
             net::const_buffer{});
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<
     class ConstBufferSequence,
     BOOST_BEAST_ASYNC_TPARAM1 AcceptHandler>
 BOOST_BEAST_ASYNC_RESULT1(AcceptHandler)
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 async_accept(
     ConstBufferSequence const& buffers,
     AcceptHandler&& handler,
@@ -591,12 +591,12 @@ async_accept(
             buffers);
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<
     class Body, class Allocator,
     BOOST_BEAST_ASYNC_TPARAM1 AcceptHandler>
 BOOST_BEAST_ASYNC_RESULT1(AcceptHandler)
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 async_accept(
     http::request<Body, http::basic_fields<Allocator>> const& req,
     AcceptHandler&& handler)

--- a/include/boost/beast/websocket/impl/close.hpp
+++ b/include/boost/beast/websocket/impl/close.hpp
@@ -33,9 +33,9 @@ namespace websocket {
     frame. Finally it invokes the teardown operation to shut down the
     underlying connection.
 */
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Handler>
-class stream<NextLayer, deflateSupported>::close_op
+class stream<NextLayer, deflateSupported, Timer>::close_op
     : public beast::stable_async_base<
         Handler, beast::executor_type<stream>>
     , public asio::coroutine
@@ -232,8 +232,8 @@ public:
     }
 };
 
-template<class NextLayer, bool deflateSupported>
-struct stream<NextLayer, deflateSupported>::
+template<class NextLayer, bool deflateSupported, class Timer>
+struct stream<NextLayer, deflateSupported, Timer>::
     run_close_op
 {
     template<class CloseHandler>
@@ -262,9 +262,9 @@ struct stream<NextLayer, deflateSupported>::
 
 //------------------------------------------------------------------------------
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 close(close_reason const& cr)
 {
     static_assert(is_sync_stream<next_layer_type>::value,
@@ -275,9 +275,9 @@ close(close_reason const& cr)
         BOOST_THROW_EXCEPTION(system_error{ec});
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 close(close_reason const& cr, error_code& ec)
 {
     static_assert(is_sync_stream<next_layer_type>::value,
@@ -381,10 +381,10 @@ close(close_reason const& cr, error_code& ec)
         ec = {};
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<BOOST_BEAST_ASYNC_TPARAM1 CloseHandler>
 BOOST_BEAST_ASYNC_RESULT1(CloseHandler)
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 async_close(close_reason const& cr, CloseHandler&& handler)
 {
     static_assert(is_async_stream<next_layer_type>::value,

--- a/include/boost/beast/websocket/impl/handshake.hpp
+++ b/include/boost/beast/websocket/impl/handshake.hpp
@@ -32,9 +32,9 @@ namespace websocket {
 
 // send the upgrade request and process the response
 //
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Handler>
-class stream<NextLayer, deflateSupported>::handshake_op
+class stream<NextLayer, deflateSupported, Timer>::handshake_op
     : public beast::stable_async_base<Handler,
         beast::executor_type<stream>>
     , public asio::coroutine
@@ -166,8 +166,8 @@ public:
     }
 };
 
-template<class NextLayer, bool deflateSupported>
-struct stream<NextLayer, deflateSupported>::
+template<class NextLayer, bool deflateSupported, class Timer>
+struct stream<NextLayer, deflateSupported, Timer>::
     run_handshake_op
 {
     template<class HandshakeHandler>
@@ -196,10 +196,10 @@ struct stream<NextLayer, deflateSupported>::
 
 //------------------------------------------------------------------------------
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class RequestDecorator>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 do_handshake(
     response_type* res_p,
     string_view host,
@@ -267,10 +267,10 @@ do_handshake(
 
 //------------------------------------------------------------------------------
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<BOOST_BEAST_ASYNC_TPARAM1 HandshakeHandler>
 BOOST_BEAST_ASYNC_RESULT1(HandshakeHandler)
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 async_handshake(
     string_view host,
     string_view target,
@@ -292,10 +292,10 @@ async_handshake(
             nullptr);
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<BOOST_BEAST_ASYNC_TPARAM1 HandshakeHandler>
 BOOST_BEAST_ASYNC_RESULT1(HandshakeHandler)
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 async_handshake(
     response_type& res,
     string_view host,
@@ -318,9 +318,9 @@ async_handshake(
             &res);
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 handshake(string_view host,
     string_view target)
 {
@@ -333,9 +333,9 @@ handshake(string_view host,
         BOOST_THROW_EXCEPTION(system_error{ec});
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 handshake(response_type& res,
     string_view host,
         string_view target)
@@ -348,9 +348,9 @@ handshake(response_type& res,
         BOOST_THROW_EXCEPTION(system_error{ec});
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 handshake(string_view host,
     string_view target, error_code& ec)
 {
@@ -360,9 +360,9 @@ handshake(string_view host,
         host, target, &default_decorate_req, ec);
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 handshake(response_type& res,
     string_view host,
         string_view target,

--- a/include/boost/beast/websocket/impl/ping.hpp
+++ b/include/boost/beast/websocket/impl/ping.hpp
@@ -30,9 +30,9 @@ namespace websocket {
     It only sends the frames it does not make attempts to read
     any frame data.
 */
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Handler>
-class stream<NextLayer, deflateSupported>::ping_op
+class stream<NextLayer, deflateSupported, Timer>::ping_op
     : public beast::stable_async_base<
         Handler, beast::executor_type<stream>>
     , public asio::coroutine
@@ -112,9 +112,9 @@ public:
 //------------------------------------------------------------------------------
 
 // sends the idle ping
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Executor>
-class stream<NextLayer, deflateSupported>::idle_ping_op
+class stream<NextLayer, deflateSupported, Timer>::idle_ping_op
     : public asio::coroutine
     , public boost::empty_value<Executor>
 {
@@ -203,8 +203,8 @@ public:
     }
 };
 
-template<class NextLayer, bool deflateSupported>
-struct stream<NextLayer, deflateSupported>::
+template<class NextLayer, bool deflateSupported, class Timer>
+struct stream<NextLayer, deflateSupported, Timer>::
     run_ping_op
 {
     template<class WriteHandler>
@@ -235,9 +235,9 @@ struct stream<NextLayer, deflateSupported>::
 
 //------------------------------------------------------------------------------
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 ping(ping_data const& payload)
 {
     error_code ec;
@@ -246,9 +246,9 @@ ping(ping_data const& payload)
         BOOST_THROW_EXCEPTION(system_error{ec});
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 ping(ping_data const& payload, error_code& ec)
 {
     if(impl_->check_stop_now(ec))
@@ -261,9 +261,9 @@ ping(ping_data const& payload, error_code& ec)
         return;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 pong(ping_data const& payload)
 {
     error_code ec;
@@ -272,9 +272,9 @@ pong(ping_data const& payload)
         BOOST_THROW_EXCEPTION(system_error{ec});
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 pong(ping_data const& payload, error_code& ec)
 {
     if(impl_->check_stop_now(ec))
@@ -287,10 +287,10 @@ pong(ping_data const& payload, error_code& ec)
         return;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<BOOST_BEAST_ASYNC_TPARAM1 WriteHandler>
 BOOST_BEAST_ASYNC_RESULT1(WriteHandler)
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 async_ping(ping_data const& payload, WriteHandler&& handler)
 {
     static_assert(is_async_stream<next_layer_type>::value,
@@ -305,10 +305,10 @@ async_ping(ping_data const& payload, WriteHandler&& handler)
             payload);
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<BOOST_BEAST_ASYNC_TPARAM1 WriteHandler>
 BOOST_BEAST_ASYNC_RESULT1(WriteHandler)
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 async_pong(ping_data const& payload, WriteHandler&& handler)
 {
     static_assert(is_async_stream<next_layer_type>::value,

--- a/include/boost/beast/websocket/impl/read.hpp
+++ b/include/boost/beast/websocket/impl/read.hpp
@@ -43,9 +43,9 @@ namespace websocket {
 
     Also reads and handles control frames.
 */
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Handler, class MutableBufferSequence>
-class stream<NextLayer, deflateSupported>::read_some_op
+class stream<NextLayer, deflateSupported, Timer>::read_some_op
     : public beast::async_base<
         Handler, beast::executor_type<stream>>
     , public asio::coroutine
@@ -615,9 +615,9 @@ public:
 
 //------------------------------------------------------------------------------
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Handler,  class DynamicBuffer>
-class stream<NextLayer, deflateSupported>::read_op
+class stream<NextLayer, deflateSupported, Timer>::read_op
     : public beast::async_base<
         Handler, beast::executor_type<stream>>
     , public asio::coroutine
@@ -694,8 +694,8 @@ public:
     }
 };
 
-template<class NextLayer, bool deflateSupported>
-struct stream<NextLayer, deflateSupported>::
+template<class NextLayer, bool deflateSupported, class Timer>
+struct stream<NextLayer, deflateSupported, Timer>::
     run_read_some_op
 {
     template<
@@ -725,8 +725,8 @@ struct stream<NextLayer, deflateSupported>::
     }
 };
 
-template<class NextLayer, bool deflateSupported>
-struct stream<NextLayer, deflateSupported>::
+template<class NextLayer, bool deflateSupported, class Timer>
+struct stream<NextLayer, deflateSupported, Timer>::
     run_read_op
 {
     template<
@@ -762,10 +762,10 @@ struct stream<NextLayer, deflateSupported>::
 
 //------------------------------------------------------------------------------
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class DynamicBuffer>
 std::size_t
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 read(DynamicBuffer& buffer)
 {
     static_assert(is_sync_stream<next_layer_type>::value,
@@ -780,10 +780,10 @@ read(DynamicBuffer& buffer)
     return bytes_written;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class DynamicBuffer>
 std::size_t
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 read(DynamicBuffer& buffer, error_code& ec)
 {
     static_assert(is_sync_stream<next_layer_type>::value,
@@ -802,10 +802,10 @@ read(DynamicBuffer& buffer, error_code& ec)
     return bytes_written;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class DynamicBuffer, BOOST_BEAST_ASYNC_TPARAM2 ReadHandler>
 BOOST_BEAST_ASYNC_RESULT2(ReadHandler)
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 async_read(DynamicBuffer& buffer, ReadHandler&& handler)
 {
     static_assert(is_async_stream<next_layer_type>::value,
@@ -826,10 +826,10 @@ async_read(DynamicBuffer& buffer, ReadHandler&& handler)
 
 //------------------------------------------------------------------------------
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class DynamicBuffer>
 std::size_t
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 read_some(
     DynamicBuffer& buffer,
     std::size_t limit)
@@ -847,10 +847,10 @@ read_some(
     return bytes_written;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class DynamicBuffer>
 std::size_t
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 read_some(
     DynamicBuffer& buffer,
     std::size_t limit,
@@ -876,10 +876,10 @@ read_some(
     return bytes_written;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class DynamicBuffer, BOOST_BEAST_ASYNC_TPARAM2 ReadHandler>
 BOOST_BEAST_ASYNC_RESULT2(ReadHandler)
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 async_read_some(
     DynamicBuffer& buffer,
     std::size_t limit,
@@ -903,10 +903,10 @@ async_read_some(
 
 //------------------------------------------------------------------------------
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class MutableBufferSequence>
 std::size_t
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 read_some(
     MutableBufferSequence const& buffers)
 {
@@ -922,10 +922,10 @@ read_some(
     return bytes_written;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class MutableBufferSequence>
 std::size_t
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 read_some(
     MutableBufferSequence const& buffers,
     error_code& ec)
@@ -1261,10 +1261,10 @@ loop:
     return bytes_written;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class MutableBufferSequence, BOOST_BEAST_ASYNC_TPARAM2 ReadHandler>
 BOOST_BEAST_ASYNC_RESULT2(ReadHandler)
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 async_read_some(
     MutableBufferSequence const& buffers,
     ReadHandler&& handler)

--- a/include/boost/beast/websocket/impl/stream.hpp
+++ b/include/boost/beast/websocket/impl/stream.hpp
@@ -39,17 +39,17 @@ namespace boost {
 namespace beast {
 namespace websocket {
 
-template<class NextLayer, bool deflateSupported>
-stream<NextLayer, deflateSupported>::
+template<class NextLayer, bool deflateSupported, class Timer>
+stream<NextLayer, deflateSupported, Timer>::
 ~stream()
 {
     if(impl_)
         impl_->remove();
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class... Args>
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 stream(Args&&... args)
     : impl_(boost::make_shared<impl_type>(
         std::forward<Args>(args)...))
@@ -58,68 +58,68 @@ stream(Args&&... args)
         max_control_frame_size);
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 auto
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 get_executor() noexcept ->
     executor_type
 {
     return impl_->stream().get_executor();
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 auto
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 next_layer() noexcept ->
     next_layer_type&
 {
     return impl_->stream();
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 auto
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 next_layer() const noexcept ->
     next_layer_type const&
 {
     return impl_->stream();
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 bool
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 is_open() const noexcept
 {
     return impl_->status_ == status::open;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 bool
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 got_binary() const noexcept
 {
     return impl_->rd_op == detail::opcode::binary;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 bool
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 is_message_done() const noexcept
 {
     return impl_->rd_done;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 close_reason const&
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 reason() const noexcept
 {
     return impl_->cr;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 std::size_t
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 read_size_hint(
     std::size_t initial_size) const
 {
@@ -128,10 +128,10 @@ read_size_hint(
         impl_->rd_remain, impl_->rd_fh);
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class DynamicBuffer, class>
 std::size_t
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 read_size_hint(DynamicBuffer& buffer) const
 {
     static_assert(
@@ -148,9 +148,9 @@ read_size_hint(DynamicBuffer& buffer) const
 
 // decorator
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 set_option(decorator opt)
 {
     impl_->decorator_opt = std::move(opt.d_);
@@ -158,17 +158,17 @@ set_option(decorator opt)
 
 // timeout
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 get_option(timeout& opt)
 {
     opt = impl_->timeout_opt;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 set_option(timeout const& opt)
 {
     impl_->set_option(opt);
@@ -176,41 +176,41 @@ set_option(timeout const& opt)
 
 //
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 set_option(permessage_deflate const& o)
 {
     impl_->set_option_pmd(o);
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 get_option(permessage_deflate& o)
 {
     impl_->get_option_pmd(o);
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 auto_fragment(bool value)
 {
     impl_->wr_frag_opt = value;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 bool
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 auto_fragment() const
 {
     return impl_->wr_frag_opt;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 binary(bool value)
 {
     impl_->wr_opcode = value ?
@@ -218,58 +218,58 @@ binary(bool value)
         detail::opcode::text;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 bool
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 binary() const
 {
     return impl_->wr_opcode == detail::opcode::binary;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 control_callback(std::function<
     void(frame_type, string_view)> cb)
 {
     impl_->ctrl_cb = std::move(cb);
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 control_callback()
 {
     impl_->ctrl_cb = {};
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 read_message_max(std::size_t amount)
 {
     impl_->rd_msg_max = amount;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 std::size_t
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 read_message_max() const
 {
     return impl_->rd_msg_max;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 secure_prng(bool value)
 {
     this->impl_->secure_prng_ = value;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 write_buffer_bytes(std::size_t amount)
 {
     if(amount < 8)
@@ -278,17 +278,17 @@ write_buffer_bytes(std::size_t amount)
     impl_->wr_buf_opt = amount;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 std::size_t
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 write_buffer_bytes() const
 {
     return impl_->wr_buf_opt;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 text(bool value)
 {
     impl_->wr_opcode = value ?
@@ -296,9 +296,9 @@ text(bool value)
         detail::opcode::binary;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 bool
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 text() const
 {
     return impl_->wr_opcode == detail::opcode::text;
@@ -307,9 +307,9 @@ text() const
 //------------------------------------------------------------------------------
 
 // _Fail the WebSocket Connection_
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 do_fail(
     std::uint16_t code,         // if set, send a close frame first
     error_code ev,              // error code to use upon success

--- a/include/boost/beast/websocket/impl/stream_impl.hpp
+++ b/include/boost/beast/websocket/impl/stream_impl.hpp
@@ -41,8 +41,8 @@ namespace beast {
 namespace websocket {
 
 template<
-    class NextLayer, bool deflateSupported>
-struct stream<NextLayer, deflateSupported>::impl_type
+    class NextLayer, bool deflateSupported, class Timer>
+struct stream<NextLayer, deflateSupported, Timer>::impl_type
     : boost::empty_value<NextLayer>
     , detail::service::impl_type
     , detail::impl_base<deflateSupported>
@@ -69,7 +69,7 @@ struct stream<NextLayer, deflateSupported>::impl_type
                 impl_type::shared_from_this());
     }
 
-    net::steady_timer       timer;          // used for timeouts
+    Timer                   timer;          // used for timeouts
     close_reason            cr;             // set from received close frame
     control_cb_type         ctrl_cb;        // control callback
 
@@ -582,10 +582,10 @@ private:
 //
 //--------------------------------------------------------------------------
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Decorator>
 request_type
-stream<NextLayer, deflateSupported>::impl_type::
+stream<NextLayer, deflateSupported, Timer>::impl_type::
 build_request(
     detail::sec_ws_key_type& key,
     string_view host, string_view target,
@@ -608,9 +608,9 @@ build_request(
 }
 
 // Called when the WebSocket Upgrade response is received
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 void
-stream<NextLayer, deflateSupported>::impl_type::
+stream<NextLayer, deflateSupported, Timer>::impl_type::
 on_response(
     response_type const& res,
     detail::sec_ws_key_type const& key,
@@ -659,10 +659,10 @@ on_response(
 
 // Attempt to read a complete frame header.
 // Returns `false` if more bytes are needed
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class DynamicBuffer>
 bool
-stream<NextLayer, deflateSupported>::impl_type::
+stream<NextLayer, deflateSupported, Timer>::impl_type::
 parse_fh(
     detail::frame_header& fh,
     DynamicBuffer& b,
@@ -869,10 +869,10 @@ parse_fh(
     return true;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class DynamicBuffer>
 void
-stream<NextLayer, deflateSupported>::impl_type::
+stream<NextLayer, deflateSupported, Timer>::impl_type::
 write_ping(DynamicBuffer& db,
     detail::opcode code, ping_data const& data)
 {
@@ -901,10 +901,10 @@ write_ping(DynamicBuffer& db,
     db.commit(data.size());
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class DynamicBuffer>
 void
-stream<NextLayer, deflateSupported>::impl_type::
+stream<NextLayer, deflateSupported, Timer>::impl_type::
 write_close(DynamicBuffer& db, close_reason const& cr)
 {
     using namespace boost::endian;

--- a/include/boost/beast/websocket/impl/write.hpp
+++ b/include/boost/beast/websocket/impl/write.hpp
@@ -36,9 +36,9 @@ namespace boost {
 namespace beast {
 namespace websocket {
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Handler, class Buffers>
-class stream<NextLayer, deflateSupported>::write_some_op
+class stream<NextLayer, deflateSupported, Timer>::write_some_op
     : public beast::async_base<
         Handler, beast::executor_type<stream>>
     , public asio::coroutine
@@ -146,10 +146,10 @@ public:
         bool cont = true);
 };
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class Buffers, class Handler>
 void
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 write_some_op<Buffers, Handler>::
 operator()(
     error_code ec,
@@ -433,8 +433,8 @@ operator()(
     }
 }
 
-template<class NextLayer, bool deflateSupported>
-struct stream<NextLayer, deflateSupported>::
+template<class NextLayer, bool deflateSupported, class Timer>
+struct stream<NextLayer, deflateSupported, Timer>::
     run_write_some_op
 {
     template<
@@ -468,10 +468,10 @@ struct stream<NextLayer, deflateSupported>::
 
 //------------------------------------------------------------------------------
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class ConstBufferSequence>
 std::size_t
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 write_some(bool fin, ConstBufferSequence const& buffers)
 {
     static_assert(is_sync_stream<next_layer_type>::value,
@@ -487,10 +487,10 @@ write_some(bool fin, ConstBufferSequence const& buffers)
     return bytes_transferred;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class ConstBufferSequence>
 std::size_t
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 write_some(bool fin,
     ConstBufferSequence const& buffers, error_code& ec)
 {
@@ -699,10 +699,10 @@ write_some(bool fin,
     return bytes_transferred;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class ConstBufferSequence, BOOST_BEAST_ASYNC_TPARAM2 WriteHandler>
 BOOST_BEAST_ASYNC_RESULT2(WriteHandler)
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 async_write_some(bool fin,
     ConstBufferSequence const& bs, WriteHandler&& handler)
 {
@@ -723,10 +723,10 @@ async_write_some(bool fin,
 
 //------------------------------------------------------------------------------
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class ConstBufferSequence>
 std::size_t
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 write(ConstBufferSequence const& buffers)
 {
     static_assert(is_sync_stream<next_layer_type>::value,
@@ -741,10 +741,10 @@ write(ConstBufferSequence const& buffers)
     return bytes_transferred;
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class ConstBufferSequence>
 std::size_t
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 write(ConstBufferSequence const& buffers, error_code& ec)
 {
     static_assert(is_sync_stream<next_layer_type>::value,
@@ -755,10 +755,10 @@ write(ConstBufferSequence const& buffers, error_code& ec)
     return write_some(true, buffers, ec);
 }
 
-template<class NextLayer, bool deflateSupported>
+template<class NextLayer, bool deflateSupported, class Timer>
 template<class ConstBufferSequence, BOOST_BEAST_ASYNC_TPARAM2 WriteHandler>
 BOOST_BEAST_ASYNC_RESULT2(WriteHandler)
-stream<NextLayer, deflateSupported>::
+stream<NextLayer, deflateSupported, Timer>::
 async_write(
     ConstBufferSequence const& bs, WriteHandler&& handler)
 {

--- a/include/boost/beast/websocket/stream.hpp
+++ b/include/boost/beast/websocket/stream.hpp
@@ -123,10 +123,11 @@ class frame_test;
 */
 template<
     class NextLayer,
-    bool deflateSupported>
+    bool deflateSupported,
+    class Timer>
 class stream
 #if ! BOOST_BEAST_DOXYGEN
-    : private stream_base
+    : private stream_base_clock<Timer>
 #endif
 {
     struct impl_type;
@@ -134,10 +135,16 @@ class stream
     boost::shared_ptr<impl_type> impl_;
 
     using time_point = typename
-        std::chrono::steady_clock::time_point;
+        Timer::time_point;
 
     using control_cb_type =
         std::function<void(frame_type, string_view)>;
+
+    using stream_base = stream_base_clock<Timer>;
+    using typename stream_base::decorator;
+    using typename stream_base::status;
+    using typename stream_base::timeout;
+    using stream_base::none;
 
     friend class close_test;
     friend class frame_test;

--- a/include/boost/beast/websocket/stream_base.hpp
+++ b/include/boost/beast/websocket/stream_base.hpp
@@ -10,6 +10,7 @@
 #ifndef BOOST_BEAST_WEBSOCKET_STREAM_BASE_HPP
 #define BOOST_BEAST_WEBSOCKET_STREAM_BASE_HPP
 
+#include <boost/asio/steady_timer.hpp>
 #include <boost/beast/core/detail/config.hpp>
 #include <boost/beast/websocket/detail/decorator.hpp>
 #include <boost/beast/core/role.hpp>
@@ -22,15 +23,16 @@ namespace websocket {
 
 /** This class is used as a base for the @ref websocket::stream class template to group common types and constants.
 */
-struct stream_base
+template<class Timer>
+struct stream_base_clock
 {
     /// The type used to represent durations
     using duration =
-        std::chrono::steady_clock::duration;
+        typename Timer::duration;
 
     /// The type used to represent time points
     using time_point =
-        std::chrono::steady_clock::time_point;
+        typename Timer::time_point;
 
     /// Returns the special time_point value meaning "never"
     static
@@ -54,7 +56,7 @@ struct stream_base
     {
         detail::decorator d_;
 
-        template<class, bool>
+        template<class, bool, class>
         friend class stream;
 
     public:
@@ -170,6 +172,8 @@ protected:
         failed // VFALCO Is this needed?
     };
 };
+
+using stream_base = stream_base_clock<net::steady_timer>;
 
 } // websocket
 } // beast

--- a/include/boost/beast/websocket/stream_fwd.hpp
+++ b/include/boost/beast/websocket/stream_fwd.hpp
@@ -10,6 +10,7 @@
 #ifndef BOOST_BEAST_WEBSOCKET_STREAM_FWD_HPP
 #define BOOST_BEAST_WEBSOCKET_STREAM_FWD_HPP
 
+#include <boost/asio/steady_timer.hpp>
 #include <boost/beast/core/detail/config.hpp>
 
 //[code_websocket_1h
@@ -20,7 +21,8 @@ namespace websocket {
 
 template<
     class NextLayer,
-    bool deflateSupported = true>
+    bool deflateSupported = true,
+    class Timer = net::steady_timer>
 class stream;
 
 } // websocket


### PR DESCRIPTION
Related to https://github.com/boostorg/beast/issues/1503

While it would certainly be better to specialise net::basic_waitable_timer I can't see myself doing this any time soon. But by using a silly WaitTraits I can today do

```
struct my_clock
{
  using duration = std::chrono::steady_clock::duration;
  using rep = duration::rep;
  using period = duration::period;
  using time_point = std::chrono::time_point<my_clock>;

  static constexpr bool is_steady = true;

  static time_point current_time;

  static time_point now() noexcept
  {
    return current_time;
  }

  static void move_forward(duration period) {
    current_time += period;
  }
};

my_clock::time_point my_clock::current_time;

struct constant_wait_traits
{
  static my_clock::duration to_wait_duration(
      const my_clock::duration& d)
  {
    return my_clock::duration::min();
  }

  static my_clock::duration to_wait_duration(
      const my_clock::time_point& t)
  {
    return my_clock::duration::min();
  }
};

using my_clock_timer = boost::asio::basic_waitable_timer<my_clock, constant_wait_traits>;

using my_basic_stream = beast::basic_stream<asio::local::stream_protocol, boost::asio::executor, boost::beast::unlimited_rate_policy, my_clock_timer>;
```

and create tests with that.