### PR TITLE
Upgrade to Clang 9 in Azure Pipelines and document config macros

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -185,13 +185,41 @@ jobs:
           PACKAGES: clang-8 libc++-8-dev libc++abi-8-dev
           VARIANT: release
           B2_FLAGS: <thread-sanitizer>norecover
-          CXXSTD: 11
+          CXXSTD: 14
           CXX_FLAGS: <cxxflags>"-stdlib=libc++ -msse4.2 -funsigned-char -fno-omit-frame-pointer" <linkflags>-stdlib=libc++
           B2_TARGETS: libs/beast/test//run-fat-tests
-        Clang 8 libc++ C++11 Release HEADER_ONLY NO_DEPRECATED:
+        Clang 9 libc++ C++14 Release HEADER_ONLY NO_DEPRECATED:
           TOOLSET: clang
-          CXX: clang++-8
-          PACKAGES: clang-8 libc++-8-dev libc++abi-8-dev
+          CXX: clang++-9
+          PACKAGES: clang-9 libc++-9-dev libc++abi-9-dev
+          VARIANT: release
+          B2_FLAGS: <boost.beast.separate-compilation>off <boost.beast.allow-deprecated>off
+          CXXSTD: 14
+          CXX_FLAGS: <cxxflags>"-stdlib=libc++ -msse4.2 -funsigned-char -fno-omit-frame-pointer" <linkflags>-stdlib=libc++
+          B2_TARGETS: libs/beast/test//run-fat-tests
+        Clang 9 libc++ C++17 UBASAN:
+          TOOLSET: clang
+          CXX: clang++-9
+          PACKAGES: clang-9 libc++-9-dev libc++abi-9-dev
+          VARIANT: release
+          B2_FLAGS: <address-sanitizer>norecover <undefined-sanitizer>norecover
+          UBSAN_OPTIONS: print_stacktrace=1
+          CXXSTD: 17
+          CXX_FLAGS: <cxxflags>"-stdlib=libc++ -msse4.2 -funsigned-char -fno-omit-frame-pointer" <linkflags>-stdlib=libc++
+          B2_TARGETS: libs/beast/test//run-fat-tests
+        Clang 9 libc++ C++17 TSAN:
+          TOOLSET: clang
+          CXX: clang++-9
+          PACKAGES: clang-9 libc++-9-dev libc++abi-9-dev
+          VARIANT: release
+          B2_FLAGS: <thread-sanitizer>norecover
+          CXXSTD: 17
+          CXX_FLAGS: <cxxflags>"-stdlib=libc++ -msse4.2 -funsigned-char -fno-omit-frame-pointer" <linkflags>-stdlib=libc++
+          B2_TARGETS: libs/beast/test//run-fat-tests
+        Clang 9 libc++ C++11 Release HEADER_ONLY NO_DEPRECATED:
+          TOOLSET: clang
+          CXX: clang++-9
+          PACKAGES: clang-9 libc++-9-dev libc++abi-9-dev
           VARIANT: release
           B2_FLAGS: <boost.beast.separate-compilation>off <boost.beast.allow-deprecated>off
           CXXSTD: 11

--- a/doc/qbk/03_core/8_conf_macros.qbk
+++ b/doc/qbk/03_core/8_conf_macros.qbk
@@ -1,0 +1,46 @@
+[/
+    Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+    Official repository: https://github.com/boostorg/beast
+]
+
+[section Configuration preprocessor definitions]
+
+A number of configuration preprocessor definitions can be used to change
+the behavior of Beast.
+The user should assume that they introduce significant changes to the public part
+of this library's API and make sure that all translation units (usually files)
+compiled and linked into a program use the same combination of configuration macros,
+failure to do so may result in violations of ODR (One Definition Rule).
+
+[table Special Fields
+[[Definition][Description]]
+[
+    [
+        BOOST_BEAST_USE_STD_STRING_VIEW
+    ][
+        Causes Beast to use std::string_view instead of boost::string_view.
+        Requires C++17.
+    ]
+]
+[
+    [
+        BOOST_BEAST_SEPARATE_COMPILATION
+    ][
+        Enables the split compilation mode, which allows the user to compile
+        definitions of non-template entities in a single translation unit, thus
+        improving compilation speed. That translation unit has to include
+        boost/beast/src.hpp in order to compile the definitions.
+    ]
+]
+[
+    [
+        BOOST_BEAST_ALLOW_DEPRECATED
+    ][
+        Enables the use of deprecated APIs within Beast.
+    ]
+]
+]

--- a/doc/qbk/03_core/_core.qbk
+++ b/doc/qbk/03_core/_core.qbk
@@ -96,5 +96,5 @@ effect:
 [include 5_buffers.qbk]
 [include 6_files.qbk]
 [include 7_composed.qbk]
-
+[8_conf_macros.qbk]
 [endsect]


### PR DESCRIPTION
Suggested in #1720