### PR TITLE
https_get: request should send Host header, not Server header

### DIFF
--- a/test/doc/core_3_timeouts.cpp
+++ b/test/doc/core_3_timeouts.cpp
@@ -356,7 +356,7 @@ https_get (std::string const& host, std::string const& target, error_code& ec)
             req.method(http::verb::get);
             req.target(target);
             req.version(11);
-            req.set(http::field::server, host);
+            req.set(http::field::host, host);
             req.set(http::field::user_agent, "Beast");
             http::async_write(stream, req, yield[ec]);
             if(ec)


### PR DESCRIPTION
If you try the https_get example with the Server header, servers will
respond with 400 Bad Request. This example works as it should when it
uses the Host header.