### PR TITLE
Fix async_close error code when async_read times out

### DIFF
--- a/include/boost/beast/websocket/impl/stream_impl.hpp
+++ b/include/boost/beast/websocket/impl/stream_impl.hpp
@@ -210,6 +210,13 @@ struct stream<NextLayer, deflateSupported>::impl_type
         timer.cancel();
     }
 
+    void
+    time_out()
+    {
+        timed_out = true;
+        close_socket(get_lowest_layer(stream()));
+    }
+
     // Called just before sending
     // the first frame of each message
     void
@@ -516,8 +523,7 @@ private:
             switch(impl.status_)
             {
             case status::handshake:
-                impl.timed_out = true;
-                close_socket(get_lowest_layer(impl.stream()));
+                impl.time_out();
                 return;
 
             case status::open:
@@ -537,14 +543,11 @@ private:
                     return;
                 }
 
-                // timeout
-                impl.timed_out = true;
-                close_socket(get_lowest_layer(impl.stream()));
+                impl.time_out();
                 return;
 
             case status::closing:
-                impl.timed_out = true;
-                close_socket(get_lowest_layer(impl.stream()));
+                impl.time_out();
                 return;
 
             case status::closed:

--- a/include/boost/beast/websocket/impl/stream_impl.hpp
+++ b/include/boost/beast/websocket/impl/stream_impl.hpp
@@ -214,6 +214,7 @@ struct stream<NextLayer, deflateSupported>::impl_type
     time_out()
     {
         timed_out = true;
+        change_status(status::closed);
         close_socket(get_lowest_layer(stream()));
     }
 


### PR DESCRIPTION
My understanding of the Beast codebase is limited, but AFAIK this works fine. The rationale is explained in https://github.com/boostorg/beast/issues/1729#issuecomment-547392533.