### PR TITLE
Fix echo op test

### DIFF
--- a/example/echo-op/echo_op.cpp
+++ b/example/echo-op/echo_op.cpp
@@ -332,6 +332,7 @@ async_echo(
 
 struct move_only_handler
 {
+    move_only_handler() = default;
     move_only_handler(move_only_handler&&) = default;
     move_only_handler(move_only_handler const&) = delete;
 


### PR DESCRIPTION
echo_op test's move_only_handler has missing default constructor but defines move operators.
Failed to compile on clang, c++2a
