### PR TITLE
Properly handle filename encodings in file_win32

### DIFF
--- a/include/boost/beast/core/detail/win32_unicode_path.hpp
+++ b/include/boost/beast/core/detail/win32_unicode_path.hpp
@@ -1,0 +1,82 @@
+//
+// Copyright (c) 2019 Mika Fischer (mika.fischer@zoopnet.de)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_CORE_DETAIL_WIN32_UNICODE_PATH_HPP
+#define BOOST_BEAST_CORE_DETAIL_WIN32_UNICODE_PATH_HPP
+
+#ifdef _WIN32
+#include <boost/config.hpp>
+#include <boost/beast/core/error.hpp>
+#include <boost/winapi/character_code_conversion.hpp>
+#include <boost/winapi/file_management.hpp>
+#include <boost/winapi/get_last_error.hpp>
+#include <array>
+#include <vector>
+
+namespace boost {
+namespace beast {
+namespace detail {
+
+class win32_unicode_path
+{
+    using WCHAR_ = boost::winapi::WCHAR_;
+
+public:
+    win32_unicode_path(const char* utf8_path, error_code& ec) {
+        int ret = mb2wide(utf8_path, static_buf_.data(),
+            static_buf_.size());
+        if (ret == 0)
+        {
+            int sz = mb2wide(utf8_path, nullptr, 0);
+            if (sz == 0)
+            {
+                ec.assign(boost::winapi::GetLastError(),
+                    system_category());
+                return;
+            }
+            dynamic_buf_.resize(sz);
+            int ret2 = mb2wide(utf8_path,
+                dynamic_buf_.data(),
+                dynamic_buf_.size());
+            if (ret2 == 0)
+            {
+                ec.assign(boost::winapi::GetLastError(),
+                    system_category());
+                return;
+            }
+        }
+    }
+
+    WCHAR_ const* c_str() const noexcept
+    {
+        return dynamic_buf_.empty()
+            ? static_buf_.data()
+            : dynamic_buf_.data();
+    }
+
+private:
+    int mb2wide(const char* utf8_path, WCHAR_* buf, size_t sz)
+    {
+        return boost::winapi::MultiByteToWideChar(
+            boost::winapi::CP_UTF8_,
+            boost::winapi::MB_ERR_INVALID_CHARS_,
+            utf8_path, -1,
+            buf, static_cast<int>(sz));
+    }
+
+    std::array<WCHAR_, boost::winapi::MAX_PATH_> static_buf_;
+    std::vector<WCHAR_> dynamic_buf_;
+};
+
+} // detail
+} // beast
+} // boost
+#endif
+
+#endif

--- a/include/boost/beast/core/impl/file_win32.ipp
+++ b/include/boost/beast/core/impl/file_win32.ipp
@@ -16,11 +16,14 @@
 
 #include <boost/core/exchange.hpp>
 #include <boost/winapi/access_rights.hpp>
+#include <boost/winapi/character_code_conversion.hpp>
 #include <boost/winapi/error_codes.hpp>
 #include <boost/winapi/file_management.hpp>
 #include <boost/winapi/get_last_error.hpp>
+#include <array>
 #include <limits>
 #include <utility>
+#include <vector>
 
 namespace boost {
 namespace beast {
@@ -186,8 +189,42 @@ open(char const* path, file_mode mode, error_code& ec)
         flags_and_attributes = 0x08000000; // FILE_FLAG_SEQUENTIAL_SCAN
         break;
     }
-    h_ = ::CreateFileA(
-        path,
+    
+    constexpr auto cp = boost::winapi::CP_UTF8_;
+    constexpr auto flags = boost::winapi::MB_ERR_INVALID_CHARS_;
+    std::array<boost::winapi::WCHAR_, boost::winapi::MAX_PATH_> static_unicode_path;
+    std::vector<boost::winapi::WCHAR_> dynamic_unicode_path;
+    int ret = boost::winapi::MultiByteToWideChar(
+        cp, flags, path, -1,
+        static_unicode_path.data(),
+        static_unicode_path.size());
+    if (ret == 0)
+    {
+        int sz = boost::winapi::MultiByteToWideChar(
+            cp, flags, path, -1,
+            nullptr, 0);
+        if (sz == 0)
+        {
+            ec.assign(boost::winapi::GetLastError(),
+                system_category());
+            return;
+        }
+        dynamic_unicode_path.resize(sz);
+        int ret2 = boost::winapi::MultiByteToWideChar(
+            cp, flags, path, -1,
+            dynamic_unicode_path.data(),
+            dynamic_unicode_path.size());
+        if (ret2 == 0)
+        {
+            ec.assign(boost::winapi::GetLastError(),
+                system_category());
+            return;
+        }
+    }
+    h_ = ::CreateFileW(
+        dynamic_unicode_path.empty() ?
+            static_unicode_path.data() :
+            dynamic_unicode_path.data(),
         desired_access,
         share_mode,
         NULL,

--- a/test/beast/core/file_stdio.cpp
+++ b/test/beast/core/file_stdio.cpp
@@ -26,7 +26,11 @@ public:
     void
     run()
     {
+#ifdef BOOST_MSVC
+        test_file<file_stdio, true>();
+#else
         test_file<file_stdio>();
+#endif
     }
 };
 

--- a/test/beast/core/file_win32.cpp
+++ b/test/beast/core/file_win32.cpp
@@ -26,7 +26,7 @@ public:
     void
     run()
     {
-        test_file<file_win32>();
+        test_file<file_win32, true>();
     }
 };
 


### PR DESCRIPTION
This brings file_win32 in sync with the documentation.
Previously, the path passed to open worked if encoded in the system
codepage (which is almost never UTF-8).
Now, the path must be encoded as UTF-8, as stated in the
documentation.

Adapt file tests so that for file_win32 all paths include a unicorn
character.

Note that file_stdio on Windows is still broken as before.

Partially fixes #793