### PR TITLE
ostream_buffer satisfies preconditions of DynamicBuffer_v1::commit:

### DIFF
--- a/include/boost/beast/core/detail/ostream.hpp
+++ b/include/boost/beast/core/detail/ostream.hpp
@@ -66,6 +66,7 @@ public:
     ostream_buffer(DynamicBuffer& b)
         : b_(b)
     {
+        b_.prepare(0);
     }
 
     int_type


### PR DESCRIPTION
```
/home/rhodges/github/boostorg/boost/libs/beast/cmake-build-debug/test/beast/core/tests-beast-core
beast.core.async_base
beast.core.base64
beast.core.basic_stream
beast.core.bind_handler
beast.core.buffer
beast.core.buffer_traits
beast.core.buffered_read_stream
beast.core.buffers_adaptor
beast.core.buffers_cat
beast.core.buffers_prefix
beast.core.buffers_range
beast.core.buffers_suffix
beast.core.buffers_to_string
beast.core.clamp
beast.core.detect_ssl
beast.core.error
beast.core.file_posix
beast.core.file_stdio
beast.core.flat_buffer
beast.core.flat_static_buffer
beast.core.flat_stream
beast.core.get_io_context
beast.core.make_printable
beast.core.multi_buffer
beast.core.ostream
beast.core.rate_policy
beast.core.read
beast.core.read_size
beast.core.saved_handler
beast.core.sha1
beast.core.span
beast.core.static_buffer
beast.core.static_string
beast.core.stream_traits
beast.core.string_param
beast.core.tcp_stream
beast.core.tuple
beast.core.variant
beast.core.varint
291ms, 39 suites, 39 cases, 134956 tests total, 0 failures
```
