### PR TITLE
core: make detail::ostream_buffer final

### DIFF
--- a/include/boost/beast/core/detail/ostream.hpp
+++ b/include/boost/beast/core/detail/ostream.hpp
@@ -42,7 +42,7 @@ class ostream_buffer;
 
 template<class DynamicBuffer, class CharT, class Traits>
 class ostream_buffer
-        <DynamicBuffer, CharT, Traits, true>
+        <DynamicBuffer, CharT, Traits, true> final
     : public std::basic_streambuf<CharT, Traits>
 {
     using int_type = typename


### PR DESCRIPTION
The Clang Static Analyzer was complaining about the fact the destructor
calls a virtual function. This silences it.