### PR TITLE
After calling the DynamicBuffer commit function the buffer received via

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version 286:
+
+* fix ostream flush
+
 Version 285:
 
 * Translate some win32 errors to net error codes

--- a/include/boost/beast/core/detail/ostream.hpp
+++ b/include/boost/beast/core/detail/ostream.hpp
@@ -100,6 +100,7 @@ public:
         b_.commit(
             (this->pptr() - this->pbase()) *
             sizeof(CharT));
+        this->setp(nullptr, nullptr);
         return 0;
     }
 };
@@ -169,6 +170,7 @@ public:
         b_.commit(
             (this->pptr() - this->pbase()) *
             sizeof(CharT));
+        this->setp(nullptr, nullptr);
         return 0;
     }
 };

--- a/test/beast/core/ostream.cpp
+++ b/test/beast/core/ostream.cpp
@@ -66,6 +66,31 @@ public:
                 fail("wrong exception", __FILE__, __LINE__);
             }
         }
+
+        // flush
+        {
+            // Issue #1853
+            flat_static_buffer<16> b;
+            auto half_view = string_view(s.data(), 8);
+            {
+                auto os = ostream(b);
+                os << half_view;
+                os.flush();
+            }
+            BEAST_EXPECT(buffers_to_string(b.data()) == half_view);
+        }
+
+        {
+            flat_static_buffer<16> b;
+            {
+                auto os = ostream(b);
+                os << string_view(s.data(), 8);
+                os.flush();
+                os << string_view(s.data() + 8, 8);
+                os.flush();
+            }
+            BEAST_EXPECT(buffers_to_string(b.data()) == s);
+        }
     }
 
     void


### PR DESCRIPTION
fix ostream flush:

prepare() can be invalidated but the ostream kept using it.

fix #1853
close #1859