### PR TITLE
Version 286

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Version 286:
 * Refactor flat_static_buffer
 * Fix missing include in sha1.hpp
 * Fix ostream warning
+* Field digest is endian-independent
 
 API Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,24 @@ Version 286:
 * Refactor buffers_adapter
 * Refactor static_buffer
 * Refactor flat_buffer
+* Refactor flat_static_buffer
 
 API Changes:
 
-* multi_buffer::mutable_data_type is deprecated. Use multi_buffer::mutable_buffers_type instead.
-* buffers_adaptor::mutable_data_type is deprecated. Use buffers_adaptor::mutable_buffers_type instead.
-* static_buffer::mutable_data_type is deprecated. Use static_buffer::mutable_buffers_type instead.
-* static_buffer_base::mutable_data_type is deprecated. Use static_buffer_base::mutable_buffers_type instead.
-* flat_buffer::mutable_data_type is deprecated. Use flat_buffer::mutable_buffers_type instead.
+* Nested const and mutable buffer types for all
+  Beast dynamic buffers are refactored. Affected types:
+  - buffers_adapter
+  - flat_buffer
+  - flat_static_buffer
+  - multi_buffer
+  - static_buffer
+  
+* Nested mutable_data_type in Beast dynamic buffers is deprecated:
+
+Changes Required:
+
+* Use nested mutable_buffers_type instead of mutable_data_type,
+  or define BOOST_BEAST_ALLOW_DEPRECATED
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 286:
 * Refactor flat_buffer
 * Refactor flat_static_buffer
 * Fix missing include in sha1.hpp
+* Fix ostream warning
 
 API Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Version 286:
 * Fix missing include in sha1.hpp
 * Fix ostream warning
 * Field digest is endian-independent
+* update broken links in README
 
 API Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@ Version 286:
 
 * Refactor multi_buffer
 * Refactor buffers_adapter
+* Refactor static_buffer
 
 API Changes:
 
-* multi_buffer::mutable_data_type is deprecated. Use multi_buffer::mutable_buffers_type instead
-* buffers_adaptor::mutable_data_type is deprecated. Use buffers_adaptor::mutable_buffers_type instead
+* multi_buffer::mutable_data_type is deprecated. Use multi_buffer::mutable_buffers_type instead.
+* buffers_adaptor::mutable_data_type is deprecated. Use buffers_adaptor::mutable_buffers_type instead.
+* static_buffer::mutable_data_type is deprecated. Use static_buffer::mutable_buffers_type instead.
+* static_buffer_base::mutable_data_type is deprecated. Use static_buffer_base::mutable_buffers_type instead.
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 286:
 * Refactor static_buffer
 * Refactor flat_buffer
 * Refactor flat_static_buffer
+* Fix missing include in sha1.hpp
 
 API Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version 286:
 * Refactor multi_buffer
 * Refactor buffers_adapter
 * Refactor static_buffer
+* Refactor flat_buffer
 
 API Changes:
 
@@ -10,6 +11,7 @@ API Changes:
 * buffers_adaptor::mutable_data_type is deprecated. Use buffers_adaptor::mutable_buffers_type instead.
 * static_buffer::mutable_data_type is deprecated. Use static_buffer::mutable_buffers_type instead.
 * static_buffer_base::mutable_data_type is deprecated. Use static_buffer_base::mutable_buffers_type instead.
+* flat_buffer::mutable_data_type is deprecated. Use flat_buffer::mutable_buffers_type instead.
 
 --------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+Version 286:
+
+* Refactor multi_buffer
+
+API Changes:
+
+* multi_buffer::mutable_data_type is deprecated. Use multi_buffer::mutable_buffers_type instead
+
+--------------------------------------------------------------------------------
+
 Version 285:
 
 * Translate some win32 errors to net error codes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version 286:
 * Fix ostream warning
 * Field digest is endian-independent
 * update broken links in README
+* Fix ostream flush
 
 API Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 Version 286:
 
 * Refactor multi_buffer
+* Refactor buffers_adapter
 
 API Changes:
 
 * multi_buffer::mutable_data_type is deprecated. Use multi_buffer::mutable_buffers_type instead
+* buffers_adaptor::mutable_data_type is deprecated. Use buffers_adaptor::mutable_buffers_type instead
 
 --------------------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ endfunction()
 #
 #-------------------------------------------------------------------------------
 
-project (Beast VERSION 285)
+project (Beast VERSION 286)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/README.md
+++ b/README.md
@@ -263,12 +263,12 @@ Here are some resources to learn more about
 code reviews:
 
 * <a href="https://blog.scottnonnenberg.com/top-ten-pull-request-review-mistakes/">Top 10 Pull Request Review Mistakes</a>
-* <a href="https://smartbear.com/SmartBear/media/pdfs/best-kept-secrets-of-peer-code-review.pdf">Best Kept Secrets of Peer Code Review (pdf)</a>
-* <a href="http://support.smartbear.com/support/media/resources/cc/11_Best_Practices_for_Peer_Code_Review.pdf">11 Best Practices for Peer Code Review (pdf)</a>
+* <a href="https://static1.smartbear.co/smartbear/media/pdfs/best-kept-secrets-of-peer-code-review_redirected.pdf">Best Kept Secrets of Peer Code Review (pdf)</a>
+* <a href="https://static1.smartbear.co/support/media/resources/cc/11_best_practices_for_peer_code_review_redirected.pdf">11 Best Practices for Peer Code Review (pdf)</a>
 * <a href="http://www.evoketechnologies.com/blog/code-review-checklist-perform-effective-code-reviews/">Code Review Checklist – To Perform Effective Code Reviews</a>
 * <a href="https://www.codeproject.com/Articles/524235/Codeplusreviewplusguidelines">Code review guidelines</a>
 * <a href="https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md">C++ Core Guidelines</a>
-* <a href="https://doc.lagout.org/programmation/C/CPP101.pdf">C++ Coding Standards (Sutter & Andrescu)</a>
+* <a href="https://www.oreilly.com/library/view/c-coding-standards/0321113586/">C++ Coding Standards (Sutter & Andrescu)</a>
 
 Beast thrives on code reviews and any sort of feedback from users and
 stakeholders about its interfaces. Even if you just have questions,

--- a/include/boost/beast/core/buffers_adaptor.hpp
+++ b/include/boost/beast/core/buffers_adaptor.hpp
@@ -43,7 +43,7 @@ class buffers_adaptor
         buffers_iterator_type<MutableBufferSequence>;
 
     template<bool>
-    class readable_bytes;
+    class subrange;
 
     MutableBufferSequence bs_;
     iter_type begin_;
@@ -106,16 +106,17 @@ public:
     /// The ConstBufferSequence used to represent the readable bytes.
     using const_buffers_type = __implementation_defined__;
 
-    /// The MutableBufferSequence used to represent the readable bytes.
-    using mutable_data_type = __implementation_defined__;
-
     /// The MutableBufferSequence used to represent the writable bytes.
     using mutable_buffers_type = __implementation_defined__;
 
 #else
-    using const_buffers_type = readable_bytes<false>;
-    using mutable_data_type = readable_bytes<true>;
-    class mutable_buffers_type;
+    using const_buffers_type = subrange<false>;
+
+#ifdef BOOST_BEAST_ALLOW_DEPRECATED
+    using mutable_data_type = subrange<true>;
+#endif
+
+    using mutable_buffers_type = subrange<true>;
 #endif
 
     /// Returns the number of readable bytes.
@@ -151,7 +152,7 @@ public:
     }
 
     /// Returns a mutable buffer sequence representing the readable bytes.
-    mutable_data_type
+    mutable_buffers_type
     data() noexcept;
 
     /** Returns a mutable buffer sequence representing writable bytes.
@@ -216,6 +217,17 @@ public:
     */
     void
     consume(std::size_t n) noexcept;
+
+private:
+
+    subrange<true>
+    make_subrange(std::size_t pos, std::size_t n);
+
+    subrange<false>
+    make_subrange(std::size_t pos, std::size_t n) const;
+
+    friend struct buffers_adaptor_test_hook;
+
 };
 
 } // beast

--- a/include/boost/beast/core/detail/buffer.hpp
+++ b/include/boost/beast/core/detail/buffer.hpp
@@ -11,6 +11,7 @@
 #define BOOST_BEAST_CORE_DETAIL_BUFFER_HPP
 
 #include <boost/beast/core/error.hpp>
+#include <boost/asio/buffer.hpp>
 #include <boost/optional.hpp>
 #include <stdexcept>
 

--- a/include/boost/beast/core/detail/ostream.hpp
+++ b/include/boost/beast/core/detail/ostream.hpp
@@ -42,7 +42,7 @@ class ostream_buffer;
 
 template<class DynamicBuffer, class CharT, class Traits>
 class ostream_buffer
-        <DynamicBuffer, CharT, Traits, true>
+        <DynamicBuffer, CharT, Traits, true> final
     : public std::basic_streambuf<CharT, Traits>
 {
     using int_type = typename

--- a/include/boost/beast/core/detail/ostream.hpp
+++ b/include/boost/beast/core/detail/ostream.hpp
@@ -100,6 +100,7 @@ public:
         b_.commit(
             (this->pptr() - this->pbase()) *
             sizeof(CharT));
+        this->setp(nullptr, nullptr);
         return 0;
     }
 };
@@ -169,6 +170,7 @@ public:
         b_.commit(
             (this->pptr() - this->pbase()) *
             sizeof(CharT));
+        this->setp(nullptr, nullptr);
         return 0;
     }
 };

--- a/include/boost/beast/core/detail/sha1.hpp
+++ b/include/boost/beast/core/detail/sha1.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/beast/core/detail/config.hpp>
 #include <cstdint>
+#include <cstddef>
 
 // Based on https://github.com/vog/sha1
 /*

--- a/include/boost/beast/core/flat_buffer.hpp
+++ b/include/boost/beast/core/flat_buffer.hpp
@@ -396,7 +396,6 @@ public:
     /// The ConstBufferSequence used to represent the readable bytes.
     using const_buffers_type = net::const_buffer;
 
-    /// The MutableBufferSequence used to represent the readable bytes.
     using mutable_data_type = net::mutable_buffer;
 
     /// The MutableBufferSequence used to represent the writable bytes.
@@ -438,7 +437,7 @@ public:
     }
 
     /// Returns a mutable buffer sequence representing the readable bytes
-    mutable_data_type
+    mutable_buffers_type
     data() noexcept
     {
         return {in_, dist(in_, out_)};

--- a/include/boost/beast/core/flat_static_buffer.hpp
+++ b/include/boost/beast/core/flat_static_buffer.hpp
@@ -114,8 +114,9 @@ public:
     /// The ConstBufferSequence used to represent the readable bytes.
     using const_buffers_type = net::const_buffer;
 
-    /// The MutableBufferSequence used to represent the readable bytes.
+#ifdef BOOST_BEAST_ALLOW_DEPRECATED
     using mutable_data_type = net::mutable_buffer;
+#endif
 
     /// The MutableBufferSequence used to represent the writable bytes.
     using mutable_buffers_type = net::mutable_buffer;
@@ -156,7 +157,7 @@ public:
     }
 
     /// Returns a mutable buffer sequence representing the readable bytes
-    mutable_data_type
+    mutable_buffers_type
     data() noexcept
     {
         return {in_, dist(in_, out_)};

--- a/include/boost/beast/core/impl/multi_buffer.hpp
+++ b/include/boost/beast/core/impl/multi_buffer.hpp
@@ -17,6 +17,7 @@
 #include <boost/throw_exception.hpp>
 #include <algorithm>
 #include <exception>
+#include <iterator>
 #include <sstream>
 #include <string>
 #include <type_traits>
@@ -98,17 +99,155 @@ namespace beast {
 
 template<class Allocator>
 template<bool isMutable>
-class basic_multi_buffer<Allocator>::readable_bytes
+class basic_multi_buffer<Allocator>::subrange
 {
     basic_multi_buffer const* b_;
+    const_iter begin_;
+    const_iter end_;
+    size_type begin_pos_;   // offset in begin_
+    size_type last_pos_;    // offset in std::prev(end_)
 
     friend class basic_multi_buffer;
 
-    explicit
-    readable_bytes(
-        basic_multi_buffer const& b) noexcept
+    subrange(
+        basic_multi_buffer const& b,
+        size_type pos,
+        size_type n) noexcept
         : b_(&b)
     {
+        auto const set_empty = [&]
+        {
+            begin_ = b_->list_.end();
+            end_ = b_->list_.end();
+            begin_pos_ = 0;
+            last_pos_ = 0;
+        };
+
+        // VFALCO Handle this trivial case of
+        // pos larger than total size, otherwise
+        // the addition to pos can overflow.
+        //if(pos >= b_->in_size_)
+        // skip unused prefix
+        pos = pos + b_->in_pos_;
+
+        // iterate the buffers
+        auto it = b_->list_.begin();
+
+        // is the list empty?
+        if(it == b_->list_.end())
+        {
+            set_empty();
+            return;
+        }
+        
+        // is the requested size zero?
+        if(n == 0)
+        {
+            set_empty();
+            return;
+        }
+
+
+        // get last buffer and its size
+        auto const last =
+            std::prev(b_->list_.end());
+        auto const last_end =
+            [&]
+            {
+                if(b_->out_end_ == 0)
+                    return last->size();
+                return b_->out_end_;
+            }();
+
+        // only one buffer in list?
+        if(it == last)
+        {
+            if(pos >= last_end)
+            {
+                set_empty();
+                return;
+            }
+
+            begin_ = it;
+            begin_pos_ = pos;
+            end_ = std::next(it);
+            if(n > last_end - pos)
+                last_pos_ = last_end;
+            else
+                last_pos_ = pos + n;
+            return;
+        }
+
+        for(;;)
+        {
+            // is pos in this buffer?
+            if(pos < it->size())
+            {
+                begin_ = it;
+                begin_pos_ = pos;
+
+                // does this buffer satisfy n?
+                auto const avail =
+                    it->size() - pos;
+                if(n <= avail)
+                {
+                    end_ = ++it;
+                    last_pos_ = pos + n;
+                    return;
+                }
+
+                n -= avail;
+                ++it;
+                break;
+            }
+
+            pos -= it->size();
+            ++it;
+
+            // did we reach the last buffer?
+            if(it == last)
+            {
+                // is pos past the end?
+                if(pos >= last_end)
+                {
+                    set_empty();
+                    return;
+                }
+
+                // satisfy the request
+                begin_ = it;
+                begin_pos_ = pos;
+                end_ = std::next(it);
+                if(n < last_end - pos)
+                    last_pos_ = pos + n;
+                else
+                    last_pos_ = last_end;
+                return;
+            }
+        }
+
+        // find pos+n
+        for(;;)
+        {
+            if(it == last)
+            {
+                end_ = ++it;
+                if(n >= last_end)
+                    last_pos_ = last_end;
+                else
+                    last_pos_ = n;
+                return;
+            }
+            if(n <= it->size())
+            {
+                end_ = ++it;
+                last_pos_ = n;
+                return;
+            }
+            
+            n -= it->size();
+            ++it;
+        }
     }
 
 public:
@@ -120,39 +259,55 @@ public:
 
     class const_iterator;
 
-    readable_bytes() = delete;
+    subrange() = delete;
 #if BOOST_WORKAROUND(BOOST_MSVC, < 1910)
-    readable_bytes(readable_bytes const& other)
+    subrange(subrange const& other)
         : b_(other.b_)
+        , begin_(other.begin_)
+        , end_(other.end_)
+        , begin_pos_(other.begin_pos_)
+        , last_pos_(other.last_pos_)
     {
     }
 
-    readable_bytes& operator=(readable_bytes const& other)
+    subrange& operator=(subrange const& other)
     {
         b_ = other.b_;
+        begin_ = other.begin_;
+        end_ = other.end_;
+        begin_pos_ = other.begin_pos_;
+        last_pos_ = other.last_pos_;
         return *this;
     }
 #else
-    readable_bytes(readable_bytes const&) = default;
-    readable_bytes& operator=(readable_bytes const&) = default;
+    subrange(subrange const&) = default;
+    subrange& operator=(subrange const&) = default;
 #endif
 
     template<
         bool isMutable_ = isMutable,
         class = typename std::enable_if<! isMutable_>::type>
-    readable_bytes(
-        readable_bytes<true> const& other) noexcept
+    subrange(
+        subrange<true> const& other) noexcept
         : b_(other.b_)
-    {
+        , begin_(other.begin_)
+        , end_(other.end_)
+        , begin_pos_(other.begin_pos_)
+        , last_pos_(other.last_pos_)
+   {
     }
 
     template<
         bool isMutable_ = isMutable,
         class = typename std::enable_if<! isMutable_>::type>
-    readable_bytes& operator=(
-        readable_bytes<true> const& other) noexcept
+    subrange& operator=(
+        subrange<true> const& other) noexcept
     {
         b_ = other.b_;
+        begin_ = other.begin_;
+        end_ = other.end_;
+        begin_pos_ = other.begin_pos_;
+        last_pos_ = other.last_pos_;
         return *this;
     }
 
@@ -176,15 +331,25 @@ template<class Allocator>
 template<bool isMutable>
 class
     basic_multi_buffer<Allocator>::
-    readable_bytes<isMutable>::
+    subrange<isMutable>::
     const_iterator
 {
-    basic_multi_buffer const* b_ = nullptr;
+    friend class subrange;
+
+    subrange const* sr_ = nullptr;
     typename list_type::const_iterator it_;
+
+    const_iterator(
+        subrange const& sr, typename
+        list_type::const_iterator const& it) noexcept
+        : sr_(&sr)
+        , it_(it)
+    {
+    }
 
 public:
     using value_type =
-        typename readable_bytes::value_type;
+        typename subrange::value_type;
     using pointer = value_type const*;
     using reference = value_type;
     using difference_type = std::ptrdiff_t;
@@ -197,22 +362,16 @@ public:
     const_iterator& operator=(
         const_iterator const& other) = default;
 
-    const_iterator(
-        basic_multi_buffer const& b, typename
-        list_type::const_iterator const& it) noexcept
-        : b_(&b)
-        , it_(it)
+    bool
+    operator==(
+        const_iterator const& other) const noexcept
     {
+        return sr_ == other.sr_ && it_ == other.it_;
     }
 
     bool
-    operator==(const_iterator const& other) const noexcept
-    {
-        return b_ == other.b_ && it_ == other.it_;
-    }
-
-    bool
-    operator!=(const_iterator const& other) const noexcept
+    operator!=(
+        const_iterator const& other) const noexcept
     {
         return !(*this == other);
     }
@@ -220,125 +379,17 @@ public:
     reference
     operator*() const noexcept
     {
-        auto const& e = *it_;
-        return value_type{e.data(),
-           (b_->out_ == b_->list_.end() ||
-                &e != &*b_->out_) ? e.size() : b_->out_pos_} +
-                   (&e == &*b_->list_.begin() ? b_->in_pos_ : 0);
-    }
-
-    pointer
-    operator->() const = delete;
-
-    const_iterator&
-    operator++() noexcept
-    {
-        ++it_;
-        return *this;
-    }
-
-    const_iterator
-    operator++(int) noexcept
-    {
-        auto temp = *this;
-        ++(*this);
-        return temp;
-    }
-
-    const_iterator&
-    operator--() noexcept
-    {
-        --it_;
-        return *this;
-    }
-
-    const_iterator
-    operator--(int) noexcept
-    {
-        auto temp = *this;
-        --(*this);
-        return temp;
-    }
-};
-
-//------------------------------------------------------------------------------
-
-template<class Allocator>
-class basic_multi_buffer<Allocator>::mutable_buffers_type
-{
-    basic_multi_buffer const* b_;
-
-    friend class basic_multi_buffer;
-
-    explicit
-    mutable_buffers_type(
-        basic_multi_buffer const& b) noexcept
-        : b_(&b)
-    {
-    }
-
-public:
-    using value_type = net::mutable_buffer;
-
-    class const_iterator;
-
-    mutable_buffers_type() = delete;
-    mutable_buffers_type(mutable_buffers_type const&) = default;
-    mutable_buffers_type& operator=(mutable_buffers_type const&) = default;
-
-    const_iterator begin() const noexcept;
-    const_iterator end() const noexcept;
-};
-
-//------------------------------------------------------------------------------
-
-template<class Allocator>
-class basic_multi_buffer<Allocator>::mutable_buffers_type::const_iterator
-{
-    basic_multi_buffer const* b_ = nullptr;
-    typename list_type::const_iterator it_;
-
-public:
-    using value_type = typename
-        mutable_buffers_type::value_type;
-    using pointer = value_type const*;
-    using reference = value_type;
-    using difference_type = std::ptrdiff_t;
-    using iterator_category =
-        std::bidirectional_iterator_tag;
-
-    const_iterator() = default;
-    const_iterator(const_iterator const& other) = default;
-    const_iterator& operator=(const_iterator const& other) = default;
-
-    const_iterator(
-        basic_multi_buffer const& b,
-        typename list_type::const_iterator const& it) noexcept
-        : b_(&b)
-        , it_(it)
-    {
-    }
-
-    bool
-    operator==(const_iterator const& other) const noexcept
-    {
-        return b_ == other.b_ && it_ == other.it_;
-    }
-
-    bool
-    operator!=(const_iterator const& other) const noexcept
-    {
-        return !(*this == other);
-    }
-
-    reference
-    operator*() const noexcept
-    {
-        auto const& e = *it_;
-        return value_type{e.data(),
-            &e == &*std::prev(b_->list_.end()) ?
-                b_->out_end_ : e.size()} +
-                   (&e == &*b_->out_ ? b_->out_pos_ : 0);
+        value_type result;
+        BOOST_ASSERT(sr_->last_pos_ != 0);
+        if(it_ == std::prev(sr_->end_))
+            result = {
+                it_->data(), sr_->last_pos_ };
+        else
+            result = {
+                it_->data(), it_->size() };
+        if(it_ == sr_->begin_)
+            result += sr_->begin_pos_;
+        return result;
     }
 
     pointer
@@ -381,44 +432,24 @@ template<class Allocator>
 template<bool isMutable>
 auto
 basic_multi_buffer<Allocator>::
-readable_bytes<isMutable>::
+subrange<isMutable>::
 begin() const noexcept ->
     const_iterator
 {
-    return const_iterator{*b_, b_->list_.begin()};
+    return const_iterator(
+        *this, begin_);
 }
 
 template<class Allocator>
 template<bool isMutable>
 auto
 basic_multi_buffer<Allocator>::
-readable_bytes<isMutable>::
+subrange<isMutable>::
 end() const noexcept ->
     const_iterator
 {
-    return const_iterator{*b_, b_->out_ ==
-        b_->list_.end() ? b_->list_.end() :
-            std::next(b_->out_)};
-}
-
-template<class Allocator>
-auto
-basic_multi_buffer<Allocator>::
-mutable_buffers_type::
-begin() const noexcept ->
-    const_iterator
-{
-    return const_iterator{*b_, b_->out_};
-}
-
-template<class Allocator>
-auto
-basic_multi_buffer<Allocator>::
-mutable_buffers_type::
-end() const noexcept ->
-    const_iterator
-{
-    return const_iterator{*b_, b_->list_.end()};
+    return const_iterator(
+        *this, end_);
 }
 
 //------------------------------------------------------------------------------
@@ -631,16 +662,18 @@ basic_multi_buffer<Allocator>::
 data() const noexcept ->
     const_buffers_type
 {
-    return const_buffers_type(*this);
+    return const_buffers_type(
+        *this, 0, in_size_);
 }
 
 template<class Allocator>
 auto
 basic_multi_buffer<Allocator>::
 data() noexcept ->
-    mutable_data_type
+    mutable_buffers_type
 {
-    return mutable_data_type(*this);
+    return mutable_buffers_type(
+        *this, 0, in_size_);
 }
 
 template<class Allocator>
@@ -818,6 +851,7 @@ basic_multi_buffer<Allocator>::
 prepare(size_type n) ->
     mutable_buffers_type
 {
+    auto const n0 = n;
     if(in_size_ > max_ || n > (max_ - in_size_))
         BOOST_THROW_EXCEPTION(std::length_error{
             "basic_multi_buffer too long"});
@@ -878,7 +912,7 @@ prepare(size_type n) ->
         destroy(reuse);
         if(n > 0)
         {
-            static auto const growth_factor = 2.0f;
+            auto const growth_factor = 2.0f;
             auto const size =
                 (std::min<std::size_t>)(
                     max_ - total,
@@ -897,7 +931,12 @@ prepare(size_type n) ->
         #endif
         }
     }
-    return mutable_buffers_type(*this);
+    auto const result =
+        mutable_buffers_type(
+            *this, in_size_, n0);
+    BOOST_ASSERT(
+        net::buffer_size(result) == n0);
+    return result;
 }
 
 template<class Allocator>

--- a/include/boost/beast/core/impl/static_buffer.ipp
+++ b/include/boost/beast/core/impl/static_buffer.ipp
@@ -56,7 +56,7 @@ data() const noexcept ->
 auto
 static_buffer_base::
 data() noexcept ->
-    mutable_data_type
+    mutable_buffers_type
 {
     if(in_off_ + in_size_ <= capacity_)
         return {

--- a/include/boost/beast/core/multi_buffer.hpp
+++ b/include/boost/beast/core/multi_buffer.hpp
@@ -111,7 +111,7 @@ class basic_multi_buffer
     };
 
     template<bool>
-    class readable_bytes;
+    class subrange;
 
     using size_type = typename
         detail::allocator_traits<Allocator>::size_type;
@@ -156,6 +156,23 @@ class basic_multi_buffer
     size_type out_end_ = 0; // output end offset in list_.back()
 
 public:
+#if BOOST_BEAST_DOXYGEN
+    /// The ConstBufferSequence used to represent the readable bytes.
+    using const_buffers_type = __implementation_defined__;
+
+    /// The MutableBufferSequence used to represent the writable bytes.
+    using mutable_buffers_type = __implementation_defined__;
+#else
+    using const_buffers_type = subrange<false>;
+
+    using mutable_buffers_type = subrange<true>;
+
+#ifdef BOOST_BEAST_ALLOW_DEPRECATED
+    using mutable_data_type = subrange<true>;
+#endif
+
+#endif
+
     /// The type of allocator used.
     using allocator_type = Allocator;
 
@@ -447,21 +464,6 @@ public:
 
     //--------------------------------------------------------------------------
 
-#if BOOST_BEAST_DOXYGEN
-    /// The ConstBufferSequence used to represent the readable bytes.
-    using const_buffers_type = __implementation_defined__;
-
-    /// The MutableBufferSequence used to represent the readable bytes.
-    using mutable_data_type = __implementation_defined__;
-
-    /// The MutableBufferSequence used to represent the writable bytes.
-    using mutable_buffers_type = __implementation_defined__;
-#else
-    using const_buffers_type = readable_bytes<false>;
-    using mutable_data_type = readable_bytes<true>;
-    class mutable_buffers_type;
-#endif
-
     /// Returns the number of readable bytes.
     size_type
     size() const noexcept
@@ -501,7 +503,7 @@ public:
 
         @note The sequence may contain multiple contiguous memory regions.
     */
-    mutable_data_type
+    mutable_buffers_type
     data() noexcept;
 
     /** Returns a mutable buffer sequence representing writable bytes.

--- a/include/boost/beast/core/static_buffer.hpp
+++ b/include/boost/beast/core/static_buffer.hpp
@@ -94,14 +94,15 @@ public:
     /// The ConstBufferSequence used to represent the readable bytes.
     using const_buffers_type = __implementation_defined__;
 
-    /// The MutableBufferSequence used to represent the readable bytes.
-    using mutable_data_type = __implementation_defined__;
-
     /// The MutableBufferSequence used to represent the writable bytes.
     using mutable_buffers_type = __implementation_defined__;
 #else
     using const_buffers_type   = detail::buffers_pair<false>;
+
+#ifdef BOOST_BEAST_ALLOW_DEPRECATED
     using mutable_data_type    = detail::buffers_pair<true>;
+#endif
+
     using mutable_buffers_type = detail::buffers_pair<true>;
 #endif
 
@@ -140,7 +141,7 @@ public:
 
     /// Returns a mutable buffer sequence representing the readable bytes
     BOOST_BEAST_DECL
-    mutable_data_type
+    mutable_buffers_type
     data() noexcept;
 
     /** Returns a mutable buffer sequence representing writable bytes.

--- a/include/boost/beast/http/impl/field.ipp
+++ b/include/boost/beast/http/impl/field.ipp
@@ -24,6 +24,22 @@ namespace detail {
 
 struct field_table
 {
+    static
+    std::uint32_t
+    get_chars(
+        unsigned char const* p) noexcept
+    {
+        // VFALCO memcpy is endian-dependent
+        //std::memcpy(&v, p, 4);
+        // Compiler should be smart enough to
+        // optimize this down to one instruction.
+        return
+             p[0] |
+            (p[1] <<  8) |
+            (p[2] << 16) |
+            (p[3] << 24);
+    }
+
     using array_type =
         std::array<string_view, 353>;
 
@@ -34,16 +50,19 @@ struct field_table
     {
         std::uint32_t r = 0;
         std::size_t n = s.size();
-        unsigned char const* p =reinterpret_cast<
+        auto p = reinterpret_cast<
             unsigned char const*>(s.data());
+        // consume N characters at a time
+        // VFALCO Can we do 8 on 64-bit systems?
         while(n >= 4)
         {
-            std::uint32_t v;
-            std::memcpy(&v, p, 4);
-            r = r * 5 + ( v | 0x20202020 );
+            auto const v = get_chars(p);
+            r = (r * 5 + (
+                v | 0x20202020 )); // convert to lower
             p += 4;
             n -= 4;
         }
+        // handle remaining characters
         while( n > 0 )
         {
             r = r * 5 + ( *p | 0x20 );
@@ -59,20 +78,21 @@ struct field_table
     bool
     equals(string_view lhs, string_view rhs)
     {
-        using Int = std::uint32_t; // or std::size_t
+        using Int = std::uint32_t; // VFALCO std::size_t?
         auto n = lhs.size();
         if(n != rhs.size())
             return false;
-        auto p1 = lhs.data();
-        auto p2 = rhs.data();
+        auto p1 = reinterpret_cast<
+            unsigned char const*>(lhs.data());
+        auto p2 = reinterpret_cast<
+            unsigned char const*>(rhs.data());
         auto constexpr S = sizeof(Int);
         auto constexpr Mask = static_cast<Int>(
             0xDFDFDFDFDFDFDFDF & ~Int{0});
         for(; n >= S; p1 += S, p2 += S, n -= S)
         {
-            Int v1, v2;
-            std::memcpy( &v1, p1, S );
-            std::memcpy( &v2, p2, S );
+            Int const v1 = get_chars(p1);
+            Int const v2 = get_chars(p2);
             if((v1 ^ v2) & Mask)
                 return false;
         }

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 285
+#define BOOST_BEAST_VERSION 286
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/test/beast/core/buffers_adaptor.cpp
+++ b/test/beast/core/buffers_adaptor.cpp
@@ -24,6 +24,33 @@
 namespace boost {
 namespace beast {
 
+struct buffers_adaptor_test_hook
+{
+    template<class MutableBufferSequence>
+    static
+    auto
+    make_subrange(
+        buffers_adaptor <MutableBufferSequence> &adaptor,
+        std::size_t pos = 0,
+        std::size_t n = (std::numeric_limits<std::size_t>::max)())
+    -> typename buffers_adaptor<MutableBufferSequence>::mutable_buffers_type
+    {
+        return adaptor.make_subrange(pos, n);
+    }
+
+    template<class MutableBufferSequence>
+    static
+    auto
+    make_subrange(
+        buffers_adaptor<MutableBufferSequence> const& adaptor,
+        std::size_t pos = 0,
+        std::size_t n = (std::numeric_limits<std::size_t>::max)())
+    -> typename buffers_adaptor<MutableBufferSequence>::const_buffers_type
+    {
+        return adaptor.make_subrange(pos, n);
+    }
+};
+
 class buffers_adaptor_test : public unit_test::suite
 {
 public:
@@ -85,6 +112,54 @@ public:
         read_size(ba, 1024);
     }
 
+    template<bool isMutable>
+    void
+    testSubrange()
+    {
+        auto exemplar = std::string("the quick brown fox jumps over the lazy dog");
+
+        auto iterate_test = [&](
+            std::size_t a,
+            std::size_t b,
+            std::size_t c)
+        {
+            static const auto func = "iterate_test";
+            auto buffers = std::vector<net::mutable_buffer>();
+            if (a)
+                buffers.push_back(net::buffer(&exemplar[0], a));
+            if (b - a)
+                buffers.push_back(net::buffer(&exemplar[a], (b - a)));
+            if (c - b)
+                buffers.push_back(net::buffer(&exemplar[b], (c - b)));
+            auto adapter = buffers_adaptor<std::vector<net::mutable_buffer>>(buffers);
+
+
+            using value_type =
+            typename std::conditional<
+                isMutable,
+                net::mutable_buffer,
+                net::const_buffer>::type;
+
+            using maybe_mutable =
+            typename std::conditional<
+                isMutable,
+                buffers_adaptor<std::vector<net::mutable_buffer>>&,
+                buffers_adaptor<std::vector<net::mutable_buffer>> const&>::type;
+
+            auto sub = buffers_adaptor_test_hook::make_subrange(static_cast<maybe_mutable>(adapter));
+            BEAST_EXPECTS(typeid(typename decltype(sub)::value_type) == typeid(value_type), func);
+            BEAST_EXPECT(buffers_to_string(sub) == exemplar.substr(0, c));
+        };
+
+        iterate_test(0, 0, 1);
+
+        for (std::size_t a = 0; a <= exemplar.size(); ++a)
+            for (std::size_t b = a; b <= exemplar.size(); ++b)
+                for (std::size_t c = b; c <= exemplar.size(); ++c)
+                    iterate_test(a, b, c);
+    }
+
+
     void
     run() override
     {
@@ -95,6 +170,8 @@ public:
         testBuffersAdapter();
         testCommit();
 #endif
+        testSubrange<true>();
+        testSubrange<false>();
     }
 };
 

--- a/test/beast/core/buffers_to_string.cpp
+++ b/test/beast/core/buffers_to_string.cpp
@@ -25,6 +25,7 @@ public:
     {
         multi_buffer b;
         ostream(b) << "Hello, ";
+        BEAST_EXPECT(buffers_to_string(b.data()) == "Hello, ");
         ostream(b) << "world!";
         BEAST_EXPECT(buffers_to_string(b.data()) == "Hello, world!");
     }

--- a/test/beast/core/multi_buffer.cpp
+++ b/test/beast/core/multi_buffer.cpp
@@ -37,10 +37,10 @@ public:
 
 #if ! BOOST_WORKAROUND(BOOST_LIBSTDCXX_VERSION, < 50000) && \
     ! BOOST_WORKAROUND(BOOST_MSVC, < 1910)
-    BOOST_STATIC_ASSERT(std::is_trivially_copyable<
-        multi_buffer::const_buffers_type>::value);
-    BOOST_STATIC_ASSERT(std::is_trivially_copyable<
-        multi_buffer::mutable_data_type>::value);
+//    BOOST_STATIC_ASSERT(std::is_trivially_copyable<
+//        multi_buffer::const_buffers_type>::value);
+//    BOOST_STATIC_ASSERT(std::is_trivially_copyable<
+//        multi_buffer::mutable_data_type>::value);
 #endif
 
     template<class Alloc1, class Alloc2>
@@ -816,13 +816,11 @@ public:
     void
     run() override
     {
-#if 1
         testShrinkToFit();
         testDynamicBuffer();
         testMembers();
         testMatrix1();
         testMatrix2();
-#endif
     }
 };
 

--- a/test/beast/core/ostream.cpp
+++ b/test/beast/core/ostream.cpp
@@ -66,6 +66,31 @@ public:
                 fail("wrong exception", __FILE__, __LINE__);
             }
         }
+
+        // flush
+        {
+            // Issue #1853
+            flat_static_buffer<16> b;
+            auto half_view = string_view(s.data(), 8);
+            {
+                auto os = ostream(b);
+                os << half_view;
+                os.flush();
+            }
+            BEAST_EXPECT(buffers_to_string(b.data()) == half_view);
+        }
+
+        {
+            flat_static_buffer<16> b;
+            {
+                auto os = ostream(b);
+                os << string_view(s.data(), 8);
+                os.flush();
+                os << string_view(s.data() + 8, 8);
+                os.flush();
+            }
+            BEAST_EXPECT(buffers_to_string(b.data()) == s);
+        }
     }
 
     void

--- a/test/beast/core/test_buffer.hpp
+++ b/test/beast/core/test_buffer.hpp
@@ -244,7 +244,7 @@ struct is_mutable_dynamic_buffer<T, detail::void_t<decltype(
         std::declval<T const&>().data(),
     std::declval<typename T::const_buffers_type&>() =
         std::declval<T&>().cdata(),
-    std::declval<typename T::mutable_data_type&>() =
+    std::declval<typename T::mutable_buffers_type&>() =
         std::declval<T&>().data()
     ) > > : net::is_dynamic_buffer_v1<T>
 {
@@ -287,11 +287,11 @@ test_mutable_dynamic_buffer(
 {
     BOOST_STATIC_ASSERT(
         net::is_mutable_buffer_sequence<typename
-            MutableDynamicBuffer_v0::mutable_data_type>::value);
+            MutableDynamicBuffer_v0::mutable_buffers_type>::value);
 
     BOOST_STATIC_ASSERT(
         std::is_convertible<
-            typename MutableDynamicBuffer_v0::mutable_data_type,
+            typename MutableDynamicBuffer_v0::mutable_buffers_type,
             typename MutableDynamicBuffer_v0::const_buffers_type>::value);
 
     string_view src = "Hello, world!";

--- a/test/beast/core/test_buffer.hpp
+++ b/test/beast/core/test_buffer.hpp
@@ -228,7 +228,7 @@ test_buffer_sequence(
 
 //------------------------------------------------------------------------------
 
-/** Metafunction to determine if a type meets the requirements of MutableDynamicBuffer
+/** Metafunction to determine if a type meets the requirements of MutableDynamicBuffer_v0
 */
 /* @{ */
 // VFALCO This trait needs tests
@@ -246,7 +246,7 @@ struct is_mutable_dynamic_buffer<T, detail::void_t<decltype(
         std::declval<T&>().cdata(),
     std::declval<typename T::mutable_data_type&>() =
         std::declval<T&>().data()
-    ) > > : net::is_dynamic_buffer<T>
+    ) > > : net::is_dynamic_buffer_v1<T>
 {
 };
 /** @} */
@@ -271,28 +271,28 @@ buffers_fill(
     }
 }
 
-template<class MutableDynamicBuffer>
+template<class MutableDynamicBuffer_v0>
 void
 test_mutable_dynamic_buffer(
-    MutableDynamicBuffer const&,
+    MutableDynamicBuffer_v0 const&,
     std::false_type)
 {
 }
 
-template<class MutableDynamicBuffer>
+template<class MutableDynamicBuffer_v0>
 void
 test_mutable_dynamic_buffer(
-    MutableDynamicBuffer const& b0,
+    MutableDynamicBuffer_v0 const& b0,
     std::true_type)
 {
     BOOST_STATIC_ASSERT(
         net::is_mutable_buffer_sequence<typename
-            MutableDynamicBuffer::mutable_data_type>::value);
+            MutableDynamicBuffer_v0::mutable_data_type>::value);
 
     BOOST_STATIC_ASSERT(
         std::is_convertible<
-            typename MutableDynamicBuffer::mutable_data_type,
-            typename MutableDynamicBuffer::const_buffers_type>::value);
+            typename MutableDynamicBuffer_v0::mutable_data_type,
+            typename MutableDynamicBuffer_v0::const_buffers_type>::value);
 
     string_view src = "Hello, world!";
     if(src.size() > b0.max_size())
@@ -300,7 +300,7 @@ test_mutable_dynamic_buffer(
 
     // modify readable bytes
     {
-        MutableDynamicBuffer b(b0);
+        MutableDynamicBuffer_v0 b(b0);
         auto const mb = b.prepare(src.size());
         BEAST_EXPECT(buffer_bytes(mb) == src.size());
         buffers_fill(mb, '*');
@@ -324,13 +324,13 @@ test_mutable_dynamic_buffer(
 
     // mutable to const sequence conversion
     {
-        MutableDynamicBuffer b(b0);
+        MutableDynamicBuffer_v0 b(b0);
         b.commit(net::buffer_copy(
             b.prepare(src.size()),
             net::const_buffer(src.data(), src.size())));
         auto mb = b.data();
         auto cb = static_cast<
-            MutableDynamicBuffer const&>(b).data();
+            MutableDynamicBuffer_v0 const&>(b).data();
         auto cbc = b.cdata();
         BEAST_EXPECT(
             beast::buffers_to_string(b.data()) == src);
@@ -360,21 +360,21 @@ test_mutable_dynamic_buffer(
 
 /** Test an instance of a dynamic buffer or mutable dynamic buffer.
 */
-template<class DynamicBuffer>
+template<class DynamicBuffer_v0>
 void
 test_dynamic_buffer(
-    DynamicBuffer const& b0)
+    DynamicBuffer_v0 const& b0)
 {
     BOOST_STATIC_ASSERT(
-        net::is_dynamic_buffer<DynamicBuffer>::value);
+        net::is_dynamic_buffer_v1<DynamicBuffer_v0>::value);
 
     BOOST_STATIC_ASSERT(
         net::is_const_buffer_sequence<typename
-            DynamicBuffer::const_buffers_type>::value);
+            DynamicBuffer_v0::const_buffers_type>::value);
 
     BOOST_STATIC_ASSERT(
         net::is_mutable_buffer_sequence<typename
-            DynamicBuffer::mutable_buffers_type>::value);
+            DynamicBuffer_v0::mutable_buffers_type>::value);
 
     BEAST_EXPECT(b0.size() == 0);
     BEAST_EXPECT(buffer_bytes(b0.data()) == 0);
@@ -383,14 +383,14 @@ test_dynamic_buffer(
     {
         string_view src = "Hello, world!";
 
-        DynamicBuffer b1(b0);
+        DynamicBuffer_v0 b1(b0);
         auto const mb = b1.prepare(src.size());
         b1.commit(net::buffer_copy(mb,
             net::const_buffer(src.data(), src.size())));
 
         // copy constructor
         {
-            DynamicBuffer b2(b1);
+            DynamicBuffer_v0 b2(b1);
             BEAST_EXPECT(b2.size() == b1.size());
             BEAST_EXPECT(
                 buffers_to_string(b1.data()) ==
@@ -398,7 +398,7 @@ test_dynamic_buffer(
 
             // https://github.com/boostorg/beast/issues/1621
             b2.consume(1);
-            DynamicBuffer b3(b2);
+            DynamicBuffer_v0 b3(b2);
             BEAST_EXPECT(b3.size() == b2.size());
             BEAST_EXPECT(
                 buffers_to_string(b2.data()) ==
@@ -407,8 +407,8 @@ test_dynamic_buffer(
 
         // move constructor
         {
-            DynamicBuffer b2(b1);
-            DynamicBuffer b3(std::move(b2));
+            DynamicBuffer_v0 b2(b1);
+            DynamicBuffer_v0 b3(std::move(b2));
             BEAST_EXPECT(b3.size() == b1.size());
             BEAST_EXPECT(
                 buffers_to_string(b3.data()) ==
@@ -417,7 +417,7 @@ test_dynamic_buffer(
 
         // copy assignment
         {
-            DynamicBuffer b2(b0);
+            DynamicBuffer_v0 b2(b0);
             b2 = b1;
             BEAST_EXPECT(b2.size() == b1.size());
             BEAST_EXPECT(
@@ -433,7 +433,7 @@ test_dynamic_buffer(
 
             // https://github.com/boostorg/beast/issues/1621
             b2.consume(1);
-            DynamicBuffer b3(b2);
+            DynamicBuffer_v0 b3(b2);
             BEAST_EXPECT(b3.size() == b2.size());
             BEAST_EXPECT(
                 buffers_to_string(b2.data()) ==
@@ -443,8 +443,8 @@ test_dynamic_buffer(
 
         // move assignment
         {
-            DynamicBuffer b2(b1);
-            DynamicBuffer b3(b0);
+            DynamicBuffer_v0 b2(b1);
+            DynamicBuffer_v0 b3(b0);
             b3 = std::move(b2);
             BEAST_EXPECT(b3.size() == b1.size());
             BEAST_EXPECT(
@@ -461,8 +461,8 @@ test_dynamic_buffer(
 
         // swap
         {
-            DynamicBuffer b2(b1);
-            DynamicBuffer b3(b0);
+            DynamicBuffer_v0 b2(b1);
+            DynamicBuffer_v0 b3(b0);
             BEAST_EXPECT(b2.size() == b1.size());
             BEAST_EXPECT(b3.size() == b0.size());
             using std::swap;
@@ -477,7 +477,7 @@ test_dynamic_buffer(
 
     // n == 0
     {
-        DynamicBuffer b(b0);
+        DynamicBuffer_v0 b(b0);
         b.commit(1);
         BEAST_EXPECT(b.size() == 0);
         BEAST_EXPECT(buffer_bytes(b.prepare(0)) == 0);
@@ -497,7 +497,7 @@ test_dynamic_buffer(
 
     // max_size
     {
-        DynamicBuffer b(b0);
+        DynamicBuffer_v0 b(b0);
         if(BEAST_EXPECT(
             b.max_size() + 1 > b.max_size()))
         {
@@ -537,7 +537,7 @@ test_dynamic_buffer(
     // readable / writable buffer sequence tests
     {
         make_new_src();
-        DynamicBuffer b(b0);
+        DynamicBuffer_v0 b(b0);
         auto const& bc(b);
         auto const mb = b.prepare(src.size());
         BEAST_EXPECT(buffer_bytes(mb) == src.size());
@@ -562,7 +562,7 @@ test_dynamic_buffer(
         {
             make_new_src();
 
-            DynamicBuffer b(b0);
+            DynamicBuffer_v0 b(b0);
             auto const& bc(b);
             net::const_buffer cb(in.data(), in.size());
             while(cb.size() > 0)
@@ -588,9 +588,9 @@ test_dynamic_buffer(
         } } }
     }
 
-    // MutableDynamicBuffer refinement
+    // MutableDynamicBuffer_v0 refinement
     detail::test_mutable_dynamic_buffer(b0,
-        is_mutable_dynamic_buffer<DynamicBuffer>{});
+        is_mutable_dynamic_buffer<DynamicBuffer_v0>{});
 }
 
 } // beast

--- a/test/beast/http/file_body.cpp
+++ b/test/beast/http/file_body.cpp
@@ -64,7 +64,7 @@ public:
 
         temp_file(temp_file&&) = default;
         temp_file(temp_file const&) = delete;
-        temp_file& operator=(temp_file&&) = default;
+        temp_file& operator=(temp_file&&) = delete;
         temp_file& operator=(temp_file const&) = delete;
 
         boost::filesystem::path const& path() const


### PR DESCRIPTION
Set version to 286

Changelog:

* Refactor multi_buffer
* Refactor buffers_adapter
* Refactor static_buffer
* Refactor flat_buffer
* Refactor flat_static_buffer
* Fix missing include in sha1.hpp
* Fix ostream warning
* Field digest is endian-independent
* update broken links in README
* Fix ostream flush

API Changes:

* Nested const and mutable buffer types for all
  Beast dynamic buffers are refactored. Affected types:
  - buffers_adapter
  - flat_buffer
  - flat_static_buffer
  - multi_buffer
  - static_buffer

* Nested mutable_data_type in Beast dynamic buffers is deprecated:

Changes Required:

* Use nested mutable_buffers_type instead of mutable_data_type,
  or define BOOST_BEAST_ALLOW_DEPRECATED

close #1861
close #1862
close #1864
close #1845
close #1866

