### PR TITLE
Fix basic_stream expires_after:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+* Fix basic_stream expires_after (API Change)
+
+API Changes:
+
+basic_stream::expires_after used to take a nanosecond duration type argument. This
+required users on systems where the steady_clock::duration_type was less accurate
+to explicity duration_cast when calling this function, making code non-portable.
+The duration type is now that of the embedded steady_clock.
+
+--------------------------------------------------------------------------------
+
 Version 294:
 
 * Fix FILE namespace qualification

--- a/include/boost/beast/core/basic_stream.hpp
+++ b/include/boost/beast/core/basic_stream.hpp
@@ -456,7 +456,7 @@ public:
     */
     void
     expires_after(
-        std::chrono::nanoseconds expiry_time);
+        net::steady_timer::duration expiry_time);
 
     /** Set the timeout for the next logical operation.
 

--- a/include/boost/beast/core/impl/basic_stream.hpp
+++ b/include/boost/beast/core/impl/basic_stream.hpp
@@ -704,7 +704,7 @@ release_socket() ->
 template<class Protocol, class Executor, class RatePolicy>
 void
 basic_stream<Protocol, Executor, RatePolicy>::
-expires_after(std::chrono::nanoseconds expiry_time)
+expires_after(net::steady_timer::duration expiry_time)
 {
     // If assert goes off, it means that there are
     // already read or write (or connect) operations


### PR DESCRIPTION
Many thanks to @spdw for noticing this and providing a patch.

fixes #1943