### PR TITLE
Bug in ASIO (includes Dockerfile for windows)

### DIFF
--- a/.dockers/windows-vs-32/Dockerfile
+++ b/.dockers/windows-vs-32/Dockerfile
@@ -1,0 +1,61 @@
+# escape=`
+
+# Use the latest Windows Server Core image with .NET Framework 4.8.
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
+
+# Restore the default Windows shell for correct batch processing.
+SHELL ["cmd", "/S", "/C"]
+
+# Download the Build Tools bootstrapper.
+ADD https://aka.ms/vs/16/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
+
+RUN C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
+    --installPath C:\BuildTools `
+    --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended `
+ || IF "%ERRORLEVEL%"=="3010" EXIT 0
+
+# --------------
+# Boost Section
+# --------------
+
+WORKDIR C:\
+RUN powershell -Command iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+RUN powershell -Command Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+RUN choco install -y git.install
+RUN choco install -y python --version 3.8.3
+
+# chocolaty install of openssl 1.1.1
+# RUN choco install -y openssl --x86 --version 1.1.1.700
+# RUN mklink /D "OpenSSL" "Program Files (x86)\\OpenSSL-Win32"
+# RUN copy "C:\\OpenSSL\\lib\\libcrypto.lib" "C:\\OpenSSL\\lib\\libeay32.lib"
+# RUN copy "C:\\OpenSSL\\lib\\libssl.lib" "C:\\OpenSSL\\lib\\ssleay32.lib"
+
+# scoop install of openssl 1.0.2u
+# RUN powershell -Command scoop install openssl@1.0.2u -a 32bit -g
+# RUN mklink /D "OpenSSL" "ProgramData\\scoop\\apps\\openssl\\current"
+
+# scoop install of openssl 1.1.1g
+RUN powershell -Command scoop install openssl@1.1.1g -a 32bit -g
+RUN mklink /D "OpenSSL" "ProgramData\\scoop\\apps\\openssl\\current"
+RUN copy "C:\\OpenSSL\\lib\\libcrypto.lib" "C:\\OpenSSL\\lib\\libeay32.lib"
+RUN copy "C:\\OpenSSL\\lib\\libssl.lib" "C:\\OpenSSL\\lib\\ssleay32.lib"
+
+RUN mkdir C:\devel
+
+WORKDIR C:\devel
+RUN git.exe clone -b develop https://github.com/boostorg/boost.git
+
+WORKDIR C:\devel\boost
+RUN git.exe submodule update --init --recursive
+COPY . C:\devel\boost\libs\beast\
+COPY ".dockers\\windows-vs-32\\user-config.jam" C:\devel\boost\
+COPY ".dockers\\windows-vs-32\\tests.bat" C:\devel\boost\
+
+RUN C:\\BuildTools\\VC\\Auxiliary\\Build\\vcvars32.bat && bootstrap.bat
+RUN C:\\BuildTools\\VC\\Auxiliary\\Build\\vcvars32.bat && b2 variant=release cxxstd=latest headers
+
+# Choose one of the following two lines. The second will succeed regardless of the test results, if you'd prefer the build to complete.
+RUN C:\\BuildTools\\VC\\Auxiliary\\Build\\vcvars32.bat && set OPENSSL_ROOT=C:/OpenSSL&& tests.bat
+# RUN C:\\BuildTools\\VC\\Auxiliary\\Build\\vcvars32.bat && set OPENSSL_ROOT=C:/OpenSSL&& tests.bat || ver>nul
+
+ENTRYPOINT ["C:\\BuildTools\\VC\\Auxiliary\\Build\\vcvars32.bat", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]

--- a/.dockers/windows-vs-32/README.md
+++ b/.dockers/windows-vs-32/README.md
@@ -1,0 +1,8 @@
+
+Build docker image from root directory of the repository:
+
+```
+docker -f .dockers\windows-vs-32\Dockerfile .
+```
+
+

--- a/.dockers/windows-vs-32/tests.bat
+++ b/.dockers/windows-vs-32/tests.bat
@@ -1,0 +1,13 @@
+
+set PROCESSORS=%NUMBER_OF_PROCESSORS%
+
+REM Optionally throttle cpus:
+if %PROCESSORS% GTR 2 set PROCESSORS=2
+
+b2 --user-config=user-config.jam ^
+  asio.mode=dflt,nodep,nots,ts,nodep-nots,nodep-ts ^
+  variant=release ^
+  cxxstd=2a,17,14,11 ^
+  -j%PROCESSORS% ^
+  -q ^
+  libs/beast/test libs/beast/example

--- a/.dockers/windows-vs-32/user-config.jam
+++ b/.dockers/windows-vs-32/user-config.jam
@@ -1,0 +1,23 @@
+import feature ;
+
+feature.feature asio.mode : dflt nodep nots ts nodep-nots nodep-ts : propagated composite ;
+feature.compose <asio.mode>nodep : <define>"BOOST_ASIO_NO_DEPRECATED" ;
+feature.compose <asio.mode>nots : <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>ts : <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+feature.compose <asio.mode>nodep-nots : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>nodep-ts : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+
+#using clang :   : clang++ : <stdlib>"libc++" <cxxflags>"-Wno-c99-extensions" ;
+#using gcc :   : g++ : <cxxflags>"-Wno-c99-extensions" ;
+
+import os ;
+
+local OPENSSL_ROOT = [ os.environ OPENSSL_ROOT ] ;
+
+project
+  : requirements
+    <include>$(OPENSSL_ROOT)/include
+    <variant>debug:<library-path>$(OPENSSL_ROOT)/lib
+    <target-os>windows<variant>debug:<library-path>$(OPENSSL_ROOT)/debug/lib
+    <variant>release:<library-path>$(OPENSSL_ROOT)/lib
+  ;


### PR DESCRIPTION
Dockerfile to run tests on Microsoft Windows platform.

You can observe an error during the tests:

```
.\boost/asio/detail/win_iocp_overlapped_ptr.hpp(145): error C2039: 'context': is not a member of 'boost::asio::io_context::basic_executor_type<std::allocator<void>,0>'
...
...failed compile-c-c++ bin.v2\libs\beast\example\advanced\server\msvc-14.2\release\asio.mode-nots\cxxstd-2a-iso\threading-multi\advanced_server.obj..
```

With 8 cpus, this occurs at around 200 targets completed.
With 4 cpus, this occurs at around 6000 targets completed.
With 2 cpus, reaches 9900 targets, and then a different error.

It might be a race condition. To deal with this, the first part of tests.bat detects number-of-processors and then caps it. Can be adjusted.