### PR TITLE
simplify openssl on windows

### DIFF
--- a/.dockers/windows-vs-32/Dockerfile
+++ b/.dockers/windows-vs-32/Dockerfile
@@ -27,8 +27,6 @@ RUN choco install -y python --version 3.8.3
 # chocolaty install of openssl 1.1.1
 # RUN choco install -y openssl --x86 --version 1.1.1.700
 # RUN mklink /D "OpenSSL" "Program Files (x86)\\OpenSSL-Win32"
-# RUN copy "C:\\OpenSSL\\lib\\libcrypto.lib" "C:\\OpenSSL\\lib\\libeay32.lib"
-# RUN copy "C:\\OpenSSL\\lib\\libssl.lib" "C:\\OpenSSL\\lib\\ssleay32.lib"
 
 # scoop install of openssl 1.0.2u
 # RUN powershell -Command scoop install openssl@1.0.2u -a 32bit -g
@@ -37,8 +35,6 @@ RUN choco install -y python --version 3.8.3
 # scoop install of openssl 1.1.1g
 RUN powershell -Command scoop install openssl@1.1.1g -a 32bit -g
 RUN mklink /D "OpenSSL" "ProgramData\\scoop\\apps\\openssl\\current"
-RUN copy "C:\\OpenSSL\\lib\\libcrypto.lib" "C:\\OpenSSL\\lib\\libeay32.lib"
-RUN copy "C:\\OpenSSL\\lib\\libssl.lib" "C:\\OpenSSL\\lib\\ssleay32.lib"
 
 RUN mkdir C:\devel
 

--- a/.dockers/windows-vs-32/user-config.jam
+++ b/.dockers/windows-vs-32/user-config.jam
@@ -10,14 +10,12 @@ feature.compose <asio.mode>nodep-ts : <define>"BOOST_ASIO_NO_DEPRECATED" <define
 #using clang :   : clang++ : <stdlib>"libc++" <cxxflags>"-Wno-c99-extensions" ;
 #using gcc :   : g++ : <cxxflags>"-Wno-c99-extensions" ;
 
-import os ;
-
-local OPENSSL_ROOT = [ os.environ OPENSSL_ROOT ] ;
-
-project
-  : requirements
-    <include>$(OPENSSL_ROOT)/include
-    <variant>debug:<library-path>$(OPENSSL_ROOT)/lib
-    <target-os>windows<variant>debug:<library-path>$(OPENSSL_ROOT)/debug/lib
-    <variant>release:<library-path>$(OPENSSL_ROOT)/lib
-  ;
+#import os ;
+#local OPENSSL_ROOT = [ os.environ OPENSSL_ROOT ] ;
+#project
+#  : requirements
+#    <include>$(OPENSSL_ROOT)/include
+#    <variant>debug:<library-path>$(OPENSSL_ROOT)/lib
+#    <target-os>windows<variant>debug:<library-path>$(OPENSSL_ROOT)/debug/lib
+#    <variant>release:<library-path>$(OPENSSL_ROOT)/lib
+#  ;

--- a/Jamfile
+++ b/Jamfile
@@ -9,6 +9,7 @@
 
 import ac ;
 import os ;
+import path ;
 import feature ;
 import boost ;
 import modules ;
@@ -28,8 +29,49 @@ lib ssl ;
 lib crypto ;
 lib crypt32 ;
 
-lib ssl : : <target-os>windows <name>ssleay32 ;
-lib crypto : : <target-os>windows <name>libeay32 ;
+# Microsoft Windows section. Refer to FAQ "Windows and OpenSSL"
+if [ os.name ] = NT
+{
+  local OPENSSL_ROOT_DEFAULT = "C:/OpenSSL" ;
+  local OPENSSL_ROOT_ENV = [ os.environ OPENSSL_ROOT ] ;
+  local OPENSSL_ROOT = "" ;
+  if $(OPENSSL_ROOT_ENV)
+    {
+       OPENSSL_ROOT = $(OPENSSL_ROOT_ENV) ;
+    }
+  else 
+    {
+      OPENSSL_ROOT = $(OPENSSL_ROOT_DEFAULT) ;
+    }
+  project
+    : requirements
+      <include>$(OPENSSL_ROOT)/include
+      <variant>debug:<library-path>$(OPENSSL_ROOT)/lib
+      <target-os>windows<variant>debug:<library-path>$(OPENSSL_ROOT)/debug/lib
+      <variant>release:<library-path>$(OPENSSL_ROOT)/lib
+    ;
+
+  if [ path.exists $(OPENSSL_ROOT)/lib/libssl.lib ]
+    {
+      echo "OpenSSL > 1.1.0. Including libssl" ;
+      lib ssl : : <target-os>windows <name>libssl ;
+    }
+  if [ path.exists $(OPENSSL_ROOT)/lib/libcrypto.lib ]
+    {
+      echo "OpenSSL > 1.1.0. Including libcrypto" ;
+      lib crypto : : <target-os>windows <name>libcrypto ;
+    }
+  if [ path.exists $(OPENSSL_ROOT)/lib/ssleay32.lib ]
+    {
+      echo "OpenSSL < 1.1.0. Including ssleay32" ;
+      lib ssl : : <target-os>windows <name>ssleay32 ;
+    }
+  if [ path.exists $(OPENSSL_ROOT)/lib/libeay32.lib ]
+    {
+      echo "OpenSSL < 1.1.0. Including libeay32" ;
+      lib crypto : : <target-os>windows <name>libeay32 ;
+    }
+}
 
 feature.feature boost.beast.allow-deprecated : on off : propagated composite ;
 feature.compose <boost.beast.allow-deprecated>on : <define>BOOST_BEAST_ALLOW_DEPRECATED ;

--- a/doc/qbk/08_design/4_faq.qbk
+++ b/doc/qbk/08_design/4_faq.qbk
@@ -279,7 +279,24 @@ about Beast and other HTTP libraries that have gone through formal review.
     for TLS streams. Callers may provide their own overloads of these functions
     for user-defined next layer types.
 ]]
+[[
+    Windows and OpenSSL: How do I install and build with OpenSSL on Microsoft Windows?
+][
+    An easy method is to use command-line package installers chocolatey or scoop. Examples:
+    "choco install -y openssl --x86 --version 1.1.1.700" or 
+    "scoop install openssl@1.1.1g -a 32bit -g"
 
+    If you've installed OpenSSL to a directory with spaces in the name, it's often
+    preferable to create a symbolic link so that you may use a simpler path, such as:
+
+    mklink /D "OpenSSL" "Program Files (x86)\\OpenSSL-Win32"
+
+    Set the environment variable OPENSSL_ROOT to the location of the new install:
+
+    set OPENSSL_ROOT=C:/OpenSSL
+
+    Then, proceed to build. Refer to beast/.dockers/windows-vs-32/Dockerfile for an example of building the test cases with OpenSSL.
+]]
 ]
 
 [endsect]


### PR DESCRIPTION

For your consideration.  
I don't believe this creates any new requirement on OpenSSL which wasn't there before. The goal is only to make including the libraries easier. Let me know what you think.
