### PR TITLE
Compatibility - clang 3.8.1 bug in websocket server sync example

### DIFF
--- a/.dockers/centos-7/Dockerfile
+++ b/.dockers/centos-7/Dockerfile
@@ -1,0 +1,19 @@
+FROM centos:7
+
+RUN yum update -y
+RUN yum install -y epel-release
+RUN yum -y groupinstall "Development Tools"
+RUN yum install -y cmake openssl-devel clang libcxx-devel libcxxabi-devel bzip2-devel which zlib-devel
+
+WORKDIR /devel
+RUN git clone -b develop https://github.com/boostorg/boost.git
+COPY .dockers/centos-7/user-config.jam /devel/boost/
+COPY .dockers/centos-7/tests.sh /devel/boost/
+
+WORKDIR /devel/boost
+RUN git submodule update --init --recursive
+COPY . /devel/boost/libs/beast/
+
+RUN ./bootstrap.sh
+RUN ./b2 toolset=gcc variant=release cxxstd=latest headers
+RUN ./tests.sh || true

--- a/.dockers/centos-7/tests.sh
+++ b/.dockers/centos-7/tests.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+#cxxstd=2a,17,14,11 \
+
+./b2 --user-config=./user-config.jam \
+  toolset=clang,gcc \
+  asio.mode=dflt,nodep,nots,ts,nodep-nots,nodep-ts \
+  variant=release \
+  cxxstd=11 \
+  -j`grep processor /proc/cpuinfo | wc -l` \
+  -q \
+  libs/beast/test libs/beast/example

--- a/.dockers/centos-7/user-config.jam
+++ b/.dockers/centos-7/user-config.jam
@@ -1,0 +1,11 @@
+import feature ;
+
+feature.feature asio.mode : dflt nodep nots ts nodep-nots nodep-ts : propagated composite ;
+feature.compose <asio.mode>nodep : <define>"BOOST_ASIO_NO_DEPRECATED" ;
+feature.compose <asio.mode>nots : <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>ts : <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+feature.compose <asio.mode>nodep-nots : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>nodep-ts : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+
+using clang :   : clang++ : <stdlib>"libc++" <cxxflags>"-Wno-c99-extensions" ;
+using gcc :   : g++ : <cxxflags>"-Wno-c99-extensions" ;

--- a/.dockers/debian-10/Dockerfile
+++ b/.dockers/debian-10/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:10
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata
+RUN apt-get install -y build-essential
+RUN apt-get install -y git cmake libssl-dev clang libc++-dev libc++abi-dev libbz2-dev zlib1g-dev mlocate
+
+WORKDIR /devel
+RUN git clone -b develop https://github.com/boostorg/boost.git
+COPY .dockers/debian-10/user-config.jam /devel/boost/
+COPY .dockers/debian-10/tests.sh /devel/boost/
+
+WORKDIR /devel/boost
+RUN git submodule update --init --recursive
+COPY . /devel/boost/libs/beast/
+
+RUN ./bootstrap.sh
+RUN ./b2 toolset=gcc variant=release cxxstd=latest headers
+RUN ./tests.sh || true

--- a/.dockers/debian-10/tests.sh
+++ b/.dockers/debian-10/tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+./b2 --user-config=./user-config.jam \
+  toolset=clang,gcc \
+  asio.mode=dflt,nodep,nots,ts,nodep-nots,nodep-ts \
+  variant=release \
+  cxxstd=2a,17,14,11 \
+  -j`grep processor /proc/cpuinfo | wc -l` \
+  -q \
+  libs/beast/test libs/beast/example

--- a/.dockers/debian-10/user-config.jam
+++ b/.dockers/debian-10/user-config.jam
@@ -1,0 +1,11 @@
+import feature ;
+
+feature.feature asio.mode : dflt nodep nots ts nodep-nots nodep-ts : propagated composite ;
+feature.compose <asio.mode>nodep : <define>"BOOST_ASIO_NO_DEPRECATED" ;
+feature.compose <asio.mode>nots : <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>ts : <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+feature.compose <asio.mode>nodep-nots : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>nodep-ts : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+
+using clang :   : clang++ : <stdlib>"libc++" <cxxflags>"-Wno-c99-extensions" ;
+using gcc :   : g++ : <cxxflags>"-Wno-c99-extensions" ;

--- a/.dockers/debian-9/Dockerfile
+++ b/.dockers/debian-9/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:9
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata
+RUN apt-get install -y build-essential
+RUN apt-get install -y git cmake libssl-dev clang libc++-dev libc++abi-dev libbz2-dev zlib1g-dev mlocate
+
+WORKDIR /devel
+RUN git clone -b develop https://github.com/boostorg/boost.git
+COPY .dockers/debian-9/user-config.jam /devel/boost/
+COPY .dockers/debian-9/tests.sh /devel/boost/
+
+WORKDIR /devel/boost
+RUN git submodule update --init --recursive
+COPY . /devel/boost/libs/beast/
+
+RUN ./bootstrap.sh
+RUN ./b2 toolset=gcc variant=release cxxstd=latest headers
+RUN ./tests.sh || true

--- a/.dockers/debian-9/tests.sh
+++ b/.dockers/debian-9/tests.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+# modify cxxstd=2a,17,14,11 
+
+./b2 --user-config=./user-config.jam \
+  toolset=clang,gcc \
+  asio.mode=dflt,nodep,nots,ts,nodep-nots,nodep-ts \
+  variant=release \
+  cxxstd=14,11 \
+  -j`grep processor /proc/cpuinfo | wc -l` \
+  -q \
+  libs/beast/test libs/beast/example

--- a/.dockers/debian-9/user-config.jam
+++ b/.dockers/debian-9/user-config.jam
@@ -1,0 +1,11 @@
+import feature ;
+
+feature.feature asio.mode : dflt nodep nots ts nodep-nots nodep-ts : propagated composite ;
+feature.compose <asio.mode>nodep : <define>"BOOST_ASIO_NO_DEPRECATED" ;
+feature.compose <asio.mode>nots : <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>ts : <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+feature.compose <asio.mode>nodep-nots : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>nodep-ts : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+
+using clang :   : clang++ : <stdlib>"libc++" <cxxflags>"-Wno-c99-extensions" ;
+using gcc :   : g++ : <cxxflags>"-Wno-c99-extensions" ;

--- a/.dockers/fedora-32/Dockerfile
+++ b/.dockers/fedora-32/Dockerfile
@@ -11,13 +11,9 @@ COPY .dockers/fedora-32/tests.sh /devel/boost/
 
 WORKDIR /devel/boost
 RUN git submodule update --init --recursive
-COPY Jamfile /devel/boost/libs/beast/
-COPY doc /devel/boost/libs/beast/doc/
-COPY example /devel/boost/libs/beast/example/
-COPY meta /devel/boost/libs/beast/meta/
-COPY tools /devel/boost/libs/beast/tools/
+COPY . /devel/boost/libs/beast/
 
 #RUN cd libs/beast && git checkout develop && git pull origin develop
 RUN ./bootstrap.sh
 RUN ./b2 toolset=gcc variant=release cxxstd=latest headers
-RUN ./tests.sh
+RUN ./tests.sh || true

--- a/.dockers/ubuntu-16/Dockerfile
+++ b/.dockers/ubuntu-16/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:16.04
+
+RUN apt-get update
+RUN apt-get install -y build-essential
+RUN apt-get install -y git cmake libssl-dev clang libc++-dev libc++abi-dev libbz2-dev zlib1g-dev
+
+WORKDIR /devel
+RUN git clone -b develop https://github.com/boostorg/boost.git
+COPY .dockers/ubuntu-16/user-config.jam /devel/boost/
+COPY .dockers/ubuntu-16/tests.sh /devel/boost/
+
+WORKDIR /devel/boost
+RUN git submodule update --init --recursive
+COPY . /devel/boost/libs/beast/
+
+RUN ./bootstrap.sh
+RUN ./b2 toolset=gcc variant=release cxxstd=latest headers
+RUN ./tests.sh || true

--- a/.dockers/ubuntu-16/tests.sh
+++ b/.dockers/ubuntu-16/tests.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+# cxxstd=2a,17,14,11 \
+
+./b2 --user-config=./user-config.jam \
+  toolset=clang,gcc \
+  asio.mode=dflt,nodep,nots,ts,nodep-nots,nodep-ts \
+  variant=release \
+  cxxstd=14,11 \
+  -j`grep processor /proc/cpuinfo | wc -l` \
+  -q \
+  libs/beast/test libs/beast/example

--- a/.dockers/ubuntu-16/user-config.jam
+++ b/.dockers/ubuntu-16/user-config.jam
@@ -1,0 +1,11 @@
+import feature ;
+
+feature.feature asio.mode : dflt nodep nots ts nodep-nots nodep-ts : propagated composite ;
+feature.compose <asio.mode>nodep : <define>"BOOST_ASIO_NO_DEPRECATED" ;
+feature.compose <asio.mode>nots : <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>ts : <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+feature.compose <asio.mode>nodep-nots : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>nodep-ts : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+
+using clang :   : clang++ : <stdlib>"libc++" <cxxflags>"-Wno-c99-extensions" ;
+using gcc :   : g++ : <cxxflags>"-Wno-c99-extensions" ;

--- a/.dockers/ubuntu-18-cxxstd-17/Dockerfile
+++ b/.dockers/ubuntu-18-cxxstd-17/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:18.04
+
+RUN apt-get update
+RUN apt-get install -y build-essential
+RUN apt-get install -y git cmake libssl-dev clang libc++-10-dev libc++abi-10-dev libbz2-dev zlib1g-dev
+
+WORKDIR /devel
+RUN git clone -b develop https://github.com/boostorg/boost.git
+COPY .dockers/ubuntu-18-cxxstd-17/user-config.jam /devel/boost/
+COPY .dockers/ubuntu-18-cxxstd-17/tests.sh /devel/boost/ 
+
+WORKDIR /devel/boost
+RUN git submodule update --init --recursive
+COPY . /devel/boost/libs/beast/
+
+RUN ./bootstrap.sh
+RUN ./b2 toolset=gcc variant=release cxxstd=latest headers
+RUN ./tests.sh || true

--- a/.dockers/ubuntu-18-cxxstd-17/tests.sh
+++ b/.dockers/ubuntu-18-cxxstd-17/tests.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+# cxxstd=2a,17,14,11 \
+
+./b2 --user-config=./user-config.jam \
+  toolset=clang,gcc \
+  asio.mode=dflt,nodep,nots,ts,nodep-nots,nodep-ts \
+  variant=release \
+  cxxstd=17,14,11 \
+  -j`grep processor /proc/cpuinfo | wc -l` \
+  -q \
+  libs/beast/test libs/beast/example

--- a/.dockers/ubuntu-18-cxxstd-17/user-config.jam
+++ b/.dockers/ubuntu-18-cxxstd-17/user-config.jam
@@ -1,0 +1,11 @@
+import feature ;
+
+feature.feature asio.mode : dflt nodep nots ts nodep-nots nodep-ts : propagated composite ;
+feature.compose <asio.mode>nodep : <define>"BOOST_ASIO_NO_DEPRECATED" ;
+feature.compose <asio.mode>nots : <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>ts : <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+feature.compose <asio.mode>nodep-nots : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>nodep-ts : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+
+using clang :   : clang++ : <stdlib>"libc++" <cxxflags>"-Wno-c99-extensions" ;
+using gcc :   : g++ : <cxxflags>"-Wno-c99-extensions" ;

--- a/.dockers/ubuntu-18/Dockerfile
+++ b/.dockers/ubuntu-18/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:18.04
+
+RUN apt-get update
+RUN apt-get install -y build-essential
+RUN apt-get install -y git cmake libssl-dev clang libc++-10-dev libc++abi-10-dev libbz2-dev zlib1g-dev
+
+WORKDIR /devel
+RUN git clone -b develop https://github.com/boostorg/boost.git
+COPY .dockers/ubuntu-18/user-config.jam /devel/boost/
+COPY .dockers/ubuntu-18/tests.sh /devel/boost/
+
+WORKDIR /devel/boost
+RUN git submodule update --init --recursive
+COPY . /devel/boost/libs/beast/
+
+RUN ./bootstrap.sh
+RUN ./b2 toolset=gcc variant=release cxxstd=latest headers
+RUN ./tests.sh || true

--- a/.dockers/ubuntu-18/tests.sh
+++ b/.dockers/ubuntu-18/tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+./b2 --user-config=./user-config.jam \
+  toolset=clang,gcc \
+  asio.mode=dflt,nodep,nots,ts,nodep-nots,nodep-ts \
+  variant=release \
+  cxxstd=2a,17,14,11 \
+  -j`grep processor /proc/cpuinfo | wc -l` \
+  -q \
+  libs/beast/test libs/beast/example

--- a/.dockers/ubuntu-18/user-config.jam
+++ b/.dockers/ubuntu-18/user-config.jam
@@ -1,0 +1,11 @@
+import feature ;
+
+feature.feature asio.mode : dflt nodep nots ts nodep-nots nodep-ts : propagated composite ;
+feature.compose <asio.mode>nodep : <define>"BOOST_ASIO_NO_DEPRECATED" ;
+feature.compose <asio.mode>nots : <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>ts : <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+feature.compose <asio.mode>nodep-nots : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>nodep-ts : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+
+using clang :   : clang++ : <stdlib>"libc++" <cxxflags>"-Wno-c99-extensions" ;
+using gcc :   : g++ : <cxxflags>"-Wno-c99-extensions" ;

--- a/.dockers/ubuntu-20/Dockerfile
+++ b/.dockers/ubuntu-20/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:20.04
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata
+RUN apt-get install -y build-essential
+RUN apt-get install -y git cmake libssl-dev clang libc++-10-dev libc++abi-10-dev libbz2-dev zlib1g-dev mlocate
+
+WORKDIR /devel
+RUN git clone -b develop https://github.com/boostorg/boost.git
+COPY .dockers/ubuntu-20/user-config.jam /devel/boost/
+COPY .dockers/ubuntu-20/tests.sh /devel/boost/
+
+WORKDIR /devel/boost
+RUN git submodule update --init --recursive
+COPY . /devel/boost/libs/beast/
+
+RUN ./bootstrap.sh
+RUN ./b2 toolset=gcc variant=release cxxstd=latest headers
+RUN ./tests.sh || true

--- a/.dockers/ubuntu-20/tests.sh
+++ b/.dockers/ubuntu-20/tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+./b2 --user-config=./user-config.jam \
+  toolset=clang,gcc \
+  asio.mode=dflt,nodep,nots,ts,nodep-nots,nodep-ts \
+  variant=release \
+  cxxstd=2a,17,14,11 \
+  -j`grep processor /proc/cpuinfo | wc -l` \
+  -q \
+  libs/beast/test libs/beast/example

--- a/.dockers/ubuntu-20/user-config.jam
+++ b/.dockers/ubuntu-20/user-config.jam
@@ -1,0 +1,11 @@
+import feature ;
+
+feature.feature asio.mode : dflt nodep nots ts nodep-nots nodep-ts : propagated composite ;
+feature.compose <asio.mode>nodep : <define>"BOOST_ASIO_NO_DEPRECATED" ;
+feature.compose <asio.mode>nots : <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>ts : <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+feature.compose <asio.mode>nodep-nots : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_NO_TS_EXECUTORS" ;
+feature.compose <asio.mode>nodep-ts : <define>"BOOST_ASIO_NO_DEPRECATED" <define>"BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT" ;
+
+using clang :   : clang++ : <stdlib>"libc++" <cxxflags>"-Wno-c99-extensions" ;
+using gcc :   : g++ : <cxxflags>"-Wno-c99-extensions" ;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Fix portability bug in websocket server sync example.
+
+--------------------------------------------------------------------------------
+
 Version 299:
 
 * Fix race in http-crawl example.

--- a/example/websocket/server/sync/websocket_server_sync.cpp
+++ b/example/websocket/server/sync/websocket_server_sync.cpp
@@ -32,7 +32,7 @@ using tcp = boost::asio::ip::tcp;       // from <boost/asio/ip/tcp.hpp>
 
 // Echoes back all received WebSocket messages
 void
-do_session(tcp::socket& socket)
+do_session(tcp::socket socket)
 {
     try
     {
@@ -108,9 +108,9 @@ int main(int argc, char* argv[])
             acceptor.accept(socket);
 
             // Launch the session, transferring ownership of the socket
-            std::thread{std::bind(
-                &do_session,
-                std::move(socket))}.detach();
+            std::thread{
+                &do_session, std::move(socket)
+            }.detach();
         }
     }
     catch (const std::exception& e)


### PR DESCRIPTION
fixes #2032

Clang 3.8.1 was unhappy with the by-move capture of a socket in `std::thread(std::bind(`.

Thanks to @pdimov for suggesting a much more elegant solution.

