### PR TITLE
WIP: Add handler tracking location information

### DIFF
--- a/include/boost/beast/core/impl/basic_stream.hpp
+++ b/include/boost/beast/core/impl/basic_stream.hpp
@@ -296,7 +296,14 @@ public:
             {
                 // make sure we perform the no-op
                 BOOST_ASIO_CORO_YIELD
-                async_perform(0, is_read{});
+                {
+                    BOOST_ASIO_HANDLER_LOCATION((
+                        __FILE__, __LINE__,
+                        (isRead ? "basic_stream::async_read_some"
+                            : "basic_stream::async_write_some")));
+
+                    async_perform(0, is_read{});
+                }
                 // apply the timeout manually, otherwise
                 // behavior varies across platforms.
                 if(state().timer.expiry() <= clock_type::now())
@@ -309,12 +316,19 @@ public:
 
             // if a timeout is active, wait on the timer
             if(state().timer.expiry() != never())
+            {
+                BOOST_ASIO_HANDLER_LOCATION((
+                    __FILE__, __LINE__,
+                    (isRead ? "basic_stream::async_read_some"
+                        : "basic_stream::async_write_some")));
+
                 state().timer.async_wait(
                     timeout_handler<decltype(this->get_executor())>{
                         state(),
                         impl_,
                         state().tick,
                         this->get_executor()});
+            }
 
             // check rate limit, maybe wait
             std::size_t amount;
@@ -323,7 +337,14 @@ public:
             {
                 ++impl_->waiting;
                 BOOST_ASIO_CORO_YIELD
-                impl_->timer.async_wait(std::move(*this));
+                {
+                    BOOST_ASIO_HANDLER_LOCATION((
+                        __FILE__, __LINE__,
+                        (isRead ? "basic_stream::async_read_some"
+                            : "basic_stream::async_write_some")));
+
+                    impl_->timer.async_wait(std::move(*this));
+                }
                 if(ec)
                 {
                     // socket was closed, or a timeout
@@ -347,7 +368,14 @@ public:
             }
 
             BOOST_ASIO_CORO_YIELD
-            async_perform(amount, is_read{});
+            {
+                BOOST_ASIO_HANDLER_LOCATION((
+                    __FILE__, __LINE__,
+                    (isRead ? "basic_stream::async_read_some"
+                        : "basic_stream::async_write_some")));
+
+                async_perform(amount, is_read{});
+            }
 
             if(state().timer.expiry() != never())
             {
@@ -408,12 +436,22 @@ public:
         , pg1_(impl_->write.pending)
     {
         if(state().timer.expiry() != stream_base::never())
+        {
+            BOOST_ASIO_HANDLER_LOCATION((
+                __FILE__, __LINE__,
+                "basic_stream::async_connect"));
+
             impl_->write.timer.async_wait(
                 timeout_handler<decltype(this->get_executor())>{
                     state(),
                     impl_,
                     state().tick,
                     this->get_executor()});
+        }
+
+        BOOST_ASIO_HANDLER_LOCATION((
+            __FILE__, __LINE__,
+            "basic_stream::async_connect"));
 
         impl_->socket.async_connect(
             ep, std::move(*this));
@@ -435,12 +473,22 @@ public:
         , pg1_(impl_->write.pending)
     {
         if(state().timer.expiry() != stream_base::never())
+        {
+            BOOST_ASIO_HANDLER_LOCATION((
+                __FILE__, __LINE__,
+                "basic_stream::async_connect"));
+
             impl_->write.timer.async_wait(
                 timeout_handler<decltype(this->get_executor())>{
                     state(),
                     impl_,
                     state().tick,
                     this->get_executor()});
+        }
+
+        BOOST_ASIO_HANDLER_LOCATION((
+            __FILE__, __LINE__,
+            "basic_stream::async_connect"));
 
         net::async_connect(impl_->socket,
             eps, cond, std::move(*this));
@@ -462,12 +510,22 @@ public:
         , pg1_(impl_->write.pending)
     {
         if(state().timer.expiry() != stream_base::never())
+        {
+            BOOST_ASIO_HANDLER_LOCATION((
+                __FILE__, __LINE__,
+                "basic_stream::async_connect"));
+
             impl_->write.timer.async_wait(
                 timeout_handler<decltype(this->get_executor())>{
                     state(),
                     impl_,
                     state().tick,
                     this->get_executor()});
+        }
+
+        BOOST_ASIO_HANDLER_LOCATION((
+            __FILE__, __LINE__,
+            "basic_stream::async_connect"));
 
         net::async_connect(impl_->socket,
             begin, end, cond, std::move(*this));

--- a/include/boost/beast/http/impl/read.hpp
+++ b/include/boost/beast/http/impl/read.hpp
@@ -97,6 +97,10 @@ public:
         , d_(beast::allocate_stable<data>(
             *this, s, m))
     {
+        BOOST_ASIO_HANDLER_LOCATION((
+            __FILE__, __LINE__,
+            "http::async_read(msg)"));
+
         http::async_read(d_.s, b, d_.p, std::move(*this));
     }
 
@@ -203,6 +207,11 @@ public:
                             b_, size, ec, error::buffer_overflow);
                     if(ec)
                         goto upcall;
+
+                    BOOST_ASIO_HANDLER_LOCATION((
+                        __FILE__, __LINE__,
+                        "http::async_read_some"));
+
                     s_.async_read_some(*mb, std::move(self));
                 }
                 b_.commit(bytes_transferred);
@@ -230,8 +239,14 @@ public:
             if(! cont_)
             {
                 BOOST_ASIO_CORO_YIELD
+                {
+                    BOOST_ASIO_HANDLER_LOCATION((
+                        __FILE__, __LINE__,
+                        "http::async_read_some"));
+
                     net::post(
                         beast::bind_front_handler(std::move(self), ec));
+                }
             }
             self.complete(ec, bytes_transferred_);
         }
@@ -264,15 +279,27 @@ public:
             if (Condition{}(p_))
             {
                 BOOST_ASIO_CORO_YIELD
+                {
+                    BOOST_ASIO_HANDLER_LOCATION((
+                        __FILE__, __LINE__,
+                        "http::async_read"));
+
                     net::post(std::move(self));
+                }
             }
             else
             {
                 do
                 {
                     BOOST_ASIO_CORO_YIELD
+                    {
+                        BOOST_ASIO_HANDLER_LOCATION((
+                            __FILE__, __LINE__,
+                            "http::async_read"));
+
                         async_read_some(
                             s_, b_, p_, std::move(self));
+                    }
                     bytes_transferred_ += bytes_transferred;
                 } while (!ec &&
                          !Condition{}(p_));

--- a/include/boost/beast/http/impl/write.hpp
+++ b/include/boost/beast/http/impl/write.hpp
@@ -60,6 +60,10 @@ class write_some_op
             error_code& ec,
             ConstBufferSequence const& buffers)
         {
+            BOOST_ASIO_HANDLER_LOCATION((
+                __FILE__, __LINE__,
+                "http::async_write_some"));
+
             invoked = true;
             ec = {};
             op_.s_.async_write_some(
@@ -93,6 +97,11 @@ public:
             if(ec)
             {
                 BOOST_ASSERT(! f.invoked);
+
+                BOOST_ASIO_HANDLER_LOCATION((
+                    __FILE__, __LINE__,
+                    "http::async_write_some"));
+
                 return net::post(
                     s_.get_executor(),
                     beast::bind_front_handler(
@@ -106,6 +115,10 @@ public:
             // What else could it be?
             BOOST_ASSERT(sr_.is_done());
         }
+
+        BOOST_ASIO_HANDLER_LOCATION((
+            __FILE__, __LINE__,
+            "http::async_write_some"));
 
         return net::post(
             s_.get_executor(),
@@ -191,16 +204,28 @@ public:
             if(Predicate{}(sr_))
             {
                 BOOST_ASIO_CORO_YIELD
-                net::post(
-                    s_.get_executor(),
-                    std::move(*this));
+                {
+                    BOOST_ASIO_HANDLER_LOCATION((
+                        __FILE__, __LINE__,
+                        "http::async_write"));
+
+                    net::post(
+                        s_.get_executor(),
+                        std::move(*this));
+                }
                 goto upcall;
             }
             for(;;)
             {
                 BOOST_ASIO_CORO_YIELD
-                beast::http::async_write_some(
-                    s_, sr_, std::move(*this));
+                {
+                    BOOST_ASIO_HANDLER_LOCATION((
+                        __FILE__, __LINE__,
+                        "http::async_write"));
+
+                    beast::http::async_write_some(
+                        s_, sr_, std::move(*this));
+                }
                 bytes_transferred_ += bytes_transferred;
                 if(ec)
                     goto upcall;
@@ -248,6 +273,10 @@ public:
     void
     operator()()
     {
+        BOOST_ASIO_HANDLER_LOCATION((
+            __FILE__, __LINE__,
+            "http::async_write(msg)"));
+
         async_write(s_, sr_, std::move(*this));
     }
 


### PR DESCRIPTION
These changes use the new `BOOST_ASIO_HANDLER_LOCATION` macro to add more context to handler tracking. For example, the following is a snippet of the output produced by the http-client-async-ssl example:

```
@asio|1597543084.233257|>33|
@asio|1597543084.233273|33|deadline_timer@0x7fa6cac25218.cancel
@asio|1597543084.233681|33^34|in 'basic_stream::async_write_some' (../../../../../../boost/beast/core/impl/basic_stream.hpp:321)
@asio|1597543084.233681|33^34|called from 'async_write' (../../../../../../boost/asio/impl/write.hpp:331)
@asio|1597543084.233681|33^34|called from 'ssl::stream<>::async_write_some' (../../../../../../boost/asio/ssl/detail/io.hpp:201)
@asio|1597543084.233681|33^34|called from 'http::async_write_some' (../../../../../../boost/beast/http/impl/write.hpp:64)
@asio|1597543084.233681|33^34|called from 'http::async_write' (../../../../../../boost/beast/http/impl/write.hpp:223)
@asio|1597543084.233681|33^34|called from 'http::async_write(msg)' (../../../../../../boost/beast/http/impl/write.hpp:277)
@asio|1597543084.233681|33*34|deadline_timer@0x7fa6cac25298.async_wait
@asio|1597543084.233801|33^35|in 'basic_stream::async_write_some' (../../../../../../boost/beast/core/impl/basic_stream.hpp:373)
@asio|1597543084.233801|33^35|called from 'async_write' (../../../../../../boost/asio/impl/write.hpp:331)
@asio|1597543084.233801|33^35|called from 'ssl::stream<>::async_write_some' (../../../../../../boost/asio/ssl/detail/io.hpp:201)
@asio|1597543084.233801|33^35|called from 'http::async_write_some' (../../../../../../boost/beast/http/impl/write.hpp:64)
@asio|1597543084.233801|33^35|called from 'http::async_write' (../../../../../../boost/beast/http/impl/write.hpp:223)
@asio|1597543084.233801|33^35|called from 'http::async_write(msg)' (../../../../../../boost/beast/http/impl/write.hpp:277)
@asio|1597543084.233801|33*35|socket@0x7fa6cac251c8.async_send
@asio|1597543084.233910|.35|non_blocking_send,ec=system:0,bytes_transferred=103
@asio|1597543084.233949|<33|
@asio|1597543084.233983|<31|
@asio|1597543084.234031|>30|ec=system:89
@asio|1597543084.234045|30*36|strand_executor@0x7fa6cac24bd0.execute
@asio|1597543084.234054|>36|
@asio|1597543084.234064|<36|
@asio|1597543084.234072|<30|
@asio|1597543084.234086|>35|ec=system:0,bytes_transferred=103
@asio|1597543084.234100|35*37|strand_executor@0x7fa6cac24bd0.execute
@asio|1597543084.234109|>37|
@asio|1597543084.234119|37|deadline_timer@0x7fa6cac25298.cancel
@asio|1597543084.234198|37^38|in 'basic_stream::async_read_some' (../../../../../../boost/beast/core/impl/basic_stream.hpp:321)
@asio|1597543084.234198|37^38|called from 'ssl::stream<>::async_read_some' (../../../../../../boost/asio/ssl/detail/io.hpp:168)
@asio|1597543084.234198|37^38|called from 'http::async_read_some' (../../../../../../boost/beast/http/impl/read.hpp:212)
@asio|1597543084.234198|37^38|called from 'http::async_read' (../../../../../../boost/beast/http/impl/read.hpp:297)
@asio|1597543084.234198|37^38|called from 'http::async_read(msg)' (../../../../../../boost/beast/http/impl/read.hpp:101)
@asio|1597543084.234198|37*38|deadline_timer@0x7fa6cac25218.async_wait
@asio|1597543084.234288|37^39|in 'basic_stream::async_read_some' (../../../../../../boost/beast/core/impl/basic_stream.hpp:373)
@asio|1597543084.234288|37^39|called from 'ssl::stream<>::async_read_some' (../../../../../../boost/asio/ssl/detail/io.hpp:168)
@asio|1597543084.234288|37^39|called from 'http::async_read_some' (../../../../../../boost/beast/http/impl/read.hpp:212)
@asio|1597543084.234288|37^39|called from 'http::async_read' (../../../../../../boost/beast/http/impl/read.hpp:297)
@asio|1597543084.234288|37^39|called from 'http::async_read(msg)' (../../../../../../boost/beast/http/impl/read.hpp:101)
@asio|1597543084.234288|37*39|socket@0x7fa6cac251c8.async_receive
@asio|1597543084.234334|.39|non_blocking_recv,ec=system:35,bytes_transferred=0
@asio|1597543084.234353|<37|
@asio|1597543084.234364|<35|
@asio|1597543084.234380|>34|ec=system:89
@asio|1597543084.234392|34*40|strand_executor@0x7fa6cac24bd0.execute
@asio|1597543084.234401|>40|
@asio|1597543084.234408|<40|
@asio|1597543084.234416|<34|
@asio|1597543084.427594|.39|non_blocking_recv,ec=system:0,bytes_transferred=534
@asio|1597543084.427680|>39|ec=system:0,bytes_transferred=534
```

Marked as work-in-progress as this PR doesn't currently cover the websocket implementation. I can look at that if there's interest in this feature.