### PR TITLE
Fix assert when basic_stream used as underlying of ssl::stream with 0…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version XXX:
+
+*  Fix assert when basic_stream used as underlying of ssl::stream with zero-length write.
+
+--------------------------------------------------------------------------------
+
 Version 301:
 
 * Fix Travis CI bug.

--- a/include/boost/beast/core/detail/stream_base.hpp
+++ b/include/boost/beast/core/detail/stream_base.hpp
@@ -56,19 +56,25 @@ struct stream_base
 
     class pending_guard
     {
-        bool& b_;
+        bool* b_ = nullptr;
         bool clear_ = true;
 
     public:
         ~pending_guard()
         {
-            if(clear_)
-                b_ = false;
+            if(clear_ && b_)
+                *b_ = false;
+        }
+
+        pending_guard()
+        : b_(nullptr)
+        , clear_(true)
+        {
         }
 
         explicit
         pending_guard(bool& b)
-            : b_(b)
+        : b_(&b)
         {
             // If this assert goes off, it means you are attempting
             // to issue two of the same asynchronous I/O operation
@@ -77,8 +83,8 @@ struct stream_base
             // calls to async_read_some. Only one pending call of
             // each I/O type (read and write) is permitted.
             //
-            BOOST_ASSERT(! b_);
-            b_ = true;
+            BOOST_ASSERT(! *b_);
+            *b_ = true;
         }
 
         pending_guard(
@@ -89,11 +95,29 @@ struct stream_base
         {
         }
 
+        void assign(bool& b)
+        {
+            BOOST_ASSERT(!b_);
+            BOOST_ASSERT(clear_);
+            b_ = &b;
+
+            // If this assert goes off, it means you are attempting
+            // to issue two of the same asynchronous I/O operation
+            // at the same time, without waiting for the first one
+            // to complete. For example, attempting two simultaneous
+            // calls to async_read_some. Only one pending call of
+            // each I/O type (read and write) is permitted.
+            //
+            BOOST_ASSERT(! *b_);
+            *b_ = true;
+        }
+
         void
         reset()
         {
             BOOST_ASSERT(clear_);
-            b_ = false;
+            if (b_)
+                *b_ = false;
             clear_ = false;
         }
     };

--- a/test/beast/core/basic_stream.cpp
+++ b/test/beast/core/basic_stream.cpp
@@ -1367,6 +1367,34 @@ public:
     }
 
     void
+    testIssue2065()
+    {
+        using stream_type = basic_stream<tcp,
+            net::io_context::executor_type>;
+
+        char buf[4];
+        net::io_context ioc;
+        std::memset(buf, 0, sizeof(buf));
+        net::mutable_buffer mb(buf, sizeof(buf));
+        auto const ep = net::ip::tcp::endpoint(
+            net::ip::make_address("127.0.0.1"), 0);
+
+            // async_read_some
+
+        {
+            // success
+            test_server srv("*", ep, log);
+            stream_type s(ioc);
+            s.socket().connect(srv.local_endpoint());
+            s.expires_never();
+            s.async_read_some(mb, handler({}, 1));
+            s.async_read_some(net::buffer(buf, 0), handler({}, 0));
+            ioc.run();
+            ioc.restart();
+        }
+    }
+
+    void
     run()
     {
         testSpecialMembers();
@@ -1382,6 +1410,7 @@ public:
         boost::ignore_unused(&basic_stream_test::testAwaitableCompilation);
 #endif
         boost::ignore_unused(&basic_stream_test::testConnectionConditionArgs);
+        testIssue2065();
     }
 };
 


### PR DESCRIPTION
…-length write

Fixes #2065