### PR TITLE
Avoid the need for floating point arithmetic

### DIFF
--- a/include/boost/beast/core/impl/multi_buffer.hpp
+++ b/include/boost/beast/core/impl/multi_buffer.hpp
@@ -912,13 +912,12 @@ prepare(size_type n) ->
         destroy(reuse);
         if(n > 0)
         {
-            auto const growth_factor = 2.0f;
+            std::size_t const growth_factor = 2;
             auto const size =
                 (std::min<std::size_t>)(
                     max_ - total,
                     (std::max<std::size_t>)({
-                        static_cast<std::size_t>(
-                            in_size_ * growth_factor - in_size_),
+                        in_size_ * growth_factor - in_size_,
                         512,
                         n}));
             auto& e = alloc(size);

--- a/include/boost/beast/core/impl/multi_buffer.hpp
+++ b/include/boost/beast/core/impl/multi_buffer.hpp
@@ -913,13 +913,16 @@ prepare(size_type n) ->
         if(n > 0)
         {
             std::size_t const growth_factor = 2;
+            std::size_t altn = in_size_ * growth_factor;
+	    // Overflow detection:
+            if(in_size_ > altn)
+                altn = std::numeric_limits<std::size_t>::max();
+            else
+                altn = (std::max<std::size_t>)(512, altn);
             auto const size =
                 (std::min<std::size_t>)(
                     max_ - total,
-                    (std::max<std::size_t>)({
-                        in_size_ * growth_factor - in_size_,
-                        512,
-                        n}));
+                    (std::max<std::size_t>)(n, altn));
             auto& e = alloc(size);
             list_.push_back(e);
             if(out_ == list_.end())


### PR DESCRIPTION
The intent of the code maybe to other, non-integer growth factors (e.g. 1.5 or 2.5) but, as is, the `float` value is both unnecessary and introduces the need for a `static_cast`. Note that this could be further simplified, since `x * 2 - x` will _always_ yield `x`.