### PR TITLE
Reduce exe size:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* HTTP Write uses polymorphic buffers.
 * WebSocket uses polymorphic buffers.
 * Add polymorphic buffer sequence types.
 * CML permits finding Boost outside the boost build tree.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* CML permits finding Boost outside the boost build tree.
+s
+--------------------------------------------------------------------------------
+
 Version 307:
 
 * Add executor rebind to test::stream.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* HTTP Read uses polymorphic buffers.
 * HTTP Write uses polymorphic buffers.
 * WebSocket uses polymorphic buffers.
 * Add polymorphic buffer sequence types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
+* Add polymorphic buffer sequence types.
 * CML permits finding Boost outside the boost build tree.
-s
+
 --------------------------------------------------------------------------------
 
 Version 307:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* WebSocket uses polymorphic buffers.
 * Add polymorphic buffer sequence types.
 * CML permits finding Boost outside the boost build tree.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,10 +144,21 @@ if (MSVC)
     include_directories (${BOOST_ROOT})
     link_libraries( bcrypt.lib )
 else()
-    set(BOOST_INCLUDEDIR ${BOOST_ROOT})
-    set(BOOST_LIBRARYDIR ${BOOST_ROOT}/stage/lib)
-    find_package(Boost COMPONENTS coroutine filesystem system REQUIRED)
-    link_libraries(Boost::coroutine Boost::filesystem Boost::system)
+    option(BEAST_ALTERNATE_PATH "" ON)
+    if (BEAST_ALTERNATE_PATH)
+        include_directories(SYSTEM ${BOOST_ROOT})
+        link_libraries(
+                ${BOOST_ROOT}/stage/lib/libboost_coroutine.a
+                ${BOOST_ROOT}/stage/lib/libboost_context.a
+                ${BOOST_ROOT}/stage/lib/libboost_filesystem.a
+                ${BOOST_ROOT}/stage/lib/libboost_system.a
+                ${BOOST_ROOT}/stage/lib/libboost_thread.a)
+    else()
+        set(BOOST_INCLUDEDIR ${BOOST_ROOT})
+        set(BOOST_LIBRARYDIR ${BOOST_ROOT}/stage/lib)
+        find_package(Boost COMPONENTS coroutine filesystem system REQUIRED)
+        link_libraries(Boost::coroutine Boost::filesystem Boost::system)
+    endif()
 endif()
 
 link_directories(${BOOST_ROOT}/stage/lib)

--- a/include/boost/beast/core/detail/buffer.hpp
+++ b/include/boost/beast/core/detail/buffer.hpp
@@ -11,6 +11,7 @@
 #define BOOST_BEAST_CORE_DETAIL_BUFFER_HPP
 
 #include <boost/beast/core/error.hpp>
+#include <boost/beast/core/detail/polymorphic_buffer_sequence.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/optional.hpp>
 #include <stdexcept>
@@ -28,8 +29,8 @@ dynamic_buffer_prepare_noexcept(
     std::size_t size,
     error_code& ec,
     ErrorValue ev) ->
-        boost::optional<typename
-        DynamicBuffer::mutable_buffers_type>
+        boost::optional<
+            beast::detail::polymorphic_mutable_buffer_sequence>
 {
     if(buffer.max_size() - buffer.size() < size)
     {
@@ -37,8 +38,9 @@ dynamic_buffer_prepare_noexcept(
         ec = ev;
         return boost::none;
     }
-    boost::optional<typename
-        DynamicBuffer::mutable_buffers_type> result;
+    boost::optional<
+        beast::detail::polymorphic_mutable_buffer_sequence>
+            result;
     result.emplace(buffer.prepare(size));
     ec = {};
     return result;
@@ -53,14 +55,16 @@ dynamic_buffer_prepare(
     std::size_t size,
     error_code& ec,
     ErrorValue ev) ->
-        boost::optional<typename
-        DynamicBuffer::mutable_buffers_type>
+        boost::optional<
+            beast::detail::polymorphic_mutable_buffer_sequence>
 {
 #ifndef BOOST_NO_EXCEPTIONS
     try
     {
-        boost::optional<typename
-            DynamicBuffer::mutable_buffers_type> result;
+        boost::optional<
+            beast::detail::polymorphic_mutable_buffer_sequence>
+                result;
+
         result.emplace(buffer.prepare(size));
         ec = {};
         return result;

--- a/include/boost/beast/core/detail/polymorphic_buffer_sequence.hpp
+++ b/include/boost/beast/core/detail/polymorphic_buffer_sequence.hpp
@@ -1,0 +1,317 @@
+//
+// Copyright (c) 2020 Richard Hodges (hodges.r@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#ifndef BOOST_BEAST_DETAIL_POLYMORPHIC_BUFFER_SEQUENCE_HPP
+#define BOOST_BEAST_DETAIL_POLYMORPHIC_BUFFER_SEQUENCE_HPP
+
+#include <boost/beast/core/detail/config.hpp>
+#include <boost/asio/buffer.hpp>
+#include <boost/assert.hpp>
+#include <boost/core/exchange.hpp>
+#include <algorithm>
+#include <iterator>
+
+namespace boost {
+namespace beast {
+namespace detail {
+
+template<class T>
+struct polymorphic_buffer_sequence_rule;
+
+template<>
+struct polymorphic_buffer_sequence_rule<net::const_buffer>
+{
+    template<class T>
+    struct check : net::is_const_buffer_sequence<T> {};
+
+    using value_type = net::const_buffer;
+};
+
+template<>
+struct polymorphic_buffer_sequence_rule<net::mutable_buffer>
+{
+    template<class T>
+    struct check : net::is_mutable_buffer_sequence<T> {};
+
+    using value_type = net::mutable_buffer;
+};
+
+template<class, class=void>
+struct is_forward_iterator : std::false_type {};
+template<class Iter>
+struct is_forward_iterator<
+    Iter, typename std::enable_if<
+    std::is_base_of<
+        std::forward_iterator_tag, typename
+        std::iterator_traits<Iter>::iterator_category>::value
+    >::type> : std::true_type {};
+
+template<class T>
+class basic_polymorphic_buffer_sequence
+    : private polymorphic_buffer_sequence_rule<T>
+{
+    using typename polymorphic_buffer_sequence_rule<T>::value_type;
+    using polymorphic_buffer_sequence_rule<T>::check;
+
+    enum { capacity_value = 15 };
+
+    union
+    {
+        value_type static_[capacity_value];
+        std::vector<value_type> dynamic_;
+    };
+
+    std::size_t size_ = 0;
+
+public:
+
+    using iterator = value_type*;
+
+    using const_iterator = value_type const*;
+
+    static constexpr
+    std::size_t
+    static_capacity()
+    {
+        return capacity_value;
+    }
+
+    static constexpr
+    bool
+    is_dynamic(std::size_t required)
+    {
+        return required > static_capacity();
+    }
+
+    template<class BufferSequence,
+        typename std::enable_if<
+            polymorphic_buffer_sequence_rule<T>::template
+                check<BufferSequence>::value>::type* = nullptr,
+        typename std::enable_if<
+            !std::is_base_of<basic_polymorphic_buffer_sequence<T>, typename
+                std::decay<BufferSequence>::type>::value>::type* = nullptr
+            >
+    basic_polymorphic_buffer_sequence(BufferSequence const& sequence);
+
+    basic_polymorphic_buffer_sequence() noexcept;
+
+    basic_polymorphic_buffer_sequence(value_type v1, value_type v2) noexcept;
+
+    template<
+        class Iter,
+        typename std::enable_if<
+            is_forward_iterator<Iter>::value>::type* = nullptr>
+    basic_polymorphic_buffer_sequence(Iter first , Iter last);
+
+    basic_polymorphic_buffer_sequence(
+        basic_polymorphic_buffer_sequence&& other) noexcept;
+
+    basic_polymorphic_buffer_sequence(
+        basic_polymorphic_buffer_sequence const& other);
+
+    basic_polymorphic_buffer_sequence&
+    operator=(basic_polymorphic_buffer_sequence&& other) noexcept;
+
+    basic_polymorphic_buffer_sequence&
+    operator=(basic_polymorphic_buffer_sequence const& other);
+
+    ~basic_polymorphic_buffer_sequence();
+
+    template<
+        class Iter,
+        typename std::enable_if<
+            is_forward_iterator<Iter>::value
+            >::type* = nullptr>
+    basic_polymorphic_buffer_sequence&
+    append(Iter first , Iter last);
+
+    template<class BufferSequence,
+        typename std::enable_if<
+            polymorphic_buffer_sequence_rule<T>::template
+                check<BufferSequence>::value>::type* = nullptr
+        >
+    basic_polymorphic_buffer_sequence&
+    append(BufferSequence const& sequence);
+
+    BOOST_BEAST_DECL
+    basic_polymorphic_buffer_sequence&
+    clear();
+
+    BOOST_BEAST_DECL
+    const_iterator
+    begin() const;
+
+    BOOST_BEAST_DECL
+    iterator
+    begin();
+
+    BOOST_BEAST_DECL
+    const_iterator
+    end() const;
+
+    BOOST_BEAST_DECL
+    iterator
+    end();
+
+    BOOST_BEAST_DECL
+    void
+    consume(std::size_t n);
+
+    BOOST_BEAST_DECL
+    BOOST_ATTRIBUTE_NODISCARD
+    auto
+    prefix_copy(std::size_t n) const &
+        -> basic_polymorphic_buffer_sequence;
+
+    BOOST_BEAST_DECL
+    BOOST_ATTRIBUTE_NODISCARD
+    auto
+    prefix_copy(std::size_t n) &&
+        -> basic_polymorphic_buffer_sequence&&;
+
+    BOOST_BEAST_DECL
+    auto
+    prefix(std::size_t n)
+    -> basic_polymorphic_buffer_sequence&;
+
+    BOOST_BEAST_DECL
+    void shrink(std::size_t n);
+
+    BOOST_BEAST_DECL
+    std::size_t
+    size() const
+    {
+        if (is_dynamic(size_))
+            return dynamic_.size();
+        else
+            return size_;
+    }
+
+    // mutates the polymorphic buffer
+    BOOST_BEAST_DECL
+    void
+    push_front(value_type buf) &;
+
+    BOOST_BEAST_DECL
+    auto
+    append(value_type buf) & -> basic_polymorphic_buffer_sequence&;
+
+    // copies the buffer sequence
+
+    BOOST_BEAST_DECL
+    auto
+    push_front_copy(value_type buf) const &
+    -> basic_polymorphic_buffer_sequence;
+
+    BOOST_BEAST_DECL
+    auto
+    push_front_copy(value_type buf) &&
+    -> basic_polymorphic_buffer_sequence&&;
+
+    BOOST_BEAST_DECL
+    auto
+    operator+(value_type r) const &
+    -> basic_polymorphic_buffer_sequence;
+
+    BOOST_BEAST_DECL
+    auto
+    operator+(value_type r) &&
+    -> basic_polymorphic_buffer_sequence&&;
+
+    BOOST_BEAST_DECL
+    auto
+    front() const
+    -> value_type;
+};
+
+using polymorphic_const_buffer_sequence =
+    basic_polymorphic_buffer_sequence<net::const_buffer>;
+
+using polymorphic_mutable_buffer_sequence =
+    basic_polymorphic_buffer_sequence<net::mutable_buffer>;
+
+template<class T>
+template<
+    class BufferSequence, typename std::enable_if<
+        polymorphic_buffer_sequence_rule<T>::template
+            check<BufferSequence>::value>::type*,
+    typename std::enable_if<
+        !std::is_base_of<basic_polymorphic_buffer_sequence<T>, typename
+            std::decay<BufferSequence>::type>::value>::type*
+>
+basic_polymorphic_buffer_sequence<T>::
+    basic_polymorphic_buffer_sequence(const BufferSequence &sequence)
+    : size_(std::distance(boost::asio::buffer_sequence_begin(sequence),
+                        boost::asio::buffer_sequence_end(sequence)))
+{
+    if (is_dynamic(size_))
+    {
+        new (&dynamic_) std::vector<value_type> (
+            boost::asio::buffer_sequence_begin(sequence),
+            boost::asio::buffer_sequence_end(sequence));
+    }
+    else
+    {
+        std::copy(boost::asio::buffer_sequence_begin(sequence),
+            boost::asio::buffer_sequence_end(sequence),
+            static_);
+    }
+}
+
+template<class T>
+template<
+    class BufferSequence,
+    typename std::enable_if<
+        polymorphic_buffer_sequence_rule<T>::template check<BufferSequence>::value>::type*>
+basic_polymorphic_buffer_sequence<T> &
+basic_polymorphic_buffer_sequence<T>::append(const BufferSequence &sequence)
+{
+    return append(net::buffer_sequence_begin(sequence),
+                  net::buffer_sequence_end(sequence));
+}
+
+template<class T>
+template<
+    class Iter, typename std::enable_if<
+    is_forward_iterator<Iter>::value>::type*>
+basic_polymorphic_buffer_sequence<T>::
+basic_polymorphic_buffer_sequence(Iter first , Iter last)
+: size_(std::min(std::size_t(std::distance(first, last)),
+                 static_capacity() + 1))
+{
+    if (is_dynamic(size_))
+        new (&dynamic_) std::vector<value_type>(first, last);
+    else
+        std::copy(first, last, static_);
+}
+
+template<class T>
+template<
+    class Iter,
+    typename std::enable_if<
+        is_forward_iterator<Iter>::value
+        >::type*>
+basic_polymorphic_buffer_sequence<T>&
+basic_polymorphic_buffer_sequence<T>::append(Iter first , Iter last)
+{
+    while(first != last)
+        append(*first++);
+    return *this;
+}
+
+} // detail
+} // beast
+} // boost
+
+#ifdef BOOST_BEAST_HEADER_ONLY
+#include <boost/beast/core/detail/polymorphic_buffer_sequence.ipp>
+#endif
+
+#endif
+

--- a/include/boost/beast/core/detail/polymorphic_buffer_sequence.ipp
+++ b/include/boost/beast/core/detail/polymorphic_buffer_sequence.ipp
@@ -1,0 +1,477 @@
+#ifndef BOOST_BEAST_CORE_DETAIL_POLYMORPHIC_BUFFER_SEQUENCE_HPP
+#define BOOST_BEAST_CORE_DETAIL_POLYMORPHIC_BUFFER_SEQUENCE_HPP
+
+#include <boost/beast/core/detail/polymorphic_buffer_sequence.hpp>
+
+namespace boost {
+namespace beast {
+namespace detail {
+
+template<class T>
+auto
+basic_polymorphic_buffer_sequence<T>::begin() const
+    -> const_iterator
+{
+    if (is_dynamic(size_))
+        return dynamic_.data();
+    else
+        return static_;
+}
+
+template<class T>
+auto
+basic_polymorphic_buffer_sequence<T>::begin()
+    -> iterator
+{
+    if (is_dynamic(size_))
+        return dynamic_.data();
+    else
+        return static_;
+}
+
+template<class T>
+auto
+basic_polymorphic_buffer_sequence<T>::end() const
+    -> const_iterator
+{
+    if (is_dynamic(size_))
+        return dynamic_.data() + dynamic_.size();
+    else
+        return static_ + size_;
+}
+
+template<class T>
+auto
+basic_polymorphic_buffer_sequence<T>::end()
+    -> iterator
+{
+    if (is_dynamic(size_))
+        return dynamic_.data() + dynamic_.size();
+    else
+        return static_ + size_;
+}
+
+template<class T>
+void
+basic_polymorphic_buffer_sequence<T>::consume(std::size_t n)
+{
+    if (is_dynamic(size_))
+    {
+        while(n && dynamic_.size())
+        {
+            auto& front = dynamic_.front();
+            auto m = std::min(n, front.size());
+            if (m < front.size())
+            {
+                front += m;
+            }
+            else
+            {
+                dynamic_.erase(dynamic_.begin());
+            }
+            n -= m;
+        }
+    }
+    else
+    {
+        while(n && size_)
+        {
+            auto& front = static_[0];
+            auto m = std::min(n, front.size());
+            if (m < front.size())
+            {
+                front += m;
+            }
+            else
+            {
+                std::copy(static_ + 1, static_ + size_, static_);
+                size_ -= 1;
+            }
+            n -= m;
+        }
+    }
+}
+
+template<class T>
+void
+basic_polymorphic_buffer_sequence<T>::
+push_front(value_type buf) &
+{
+    if(is_dynamic(size_))
+    {
+        dynamic_.insert(dynamic_.begin(), buf);
+    }
+    else if (is_dynamic(size_ + 1))
+    {
+        auto dyn = std::vector<value_type>(size_ + 1);
+        dyn[0] = buf;
+        std::copy(static_, static_ + size_, &dyn[1]);
+        size_ += 1;
+        new (&dynamic_) std::vector<value_type>(std::move(dyn));
+    }
+    else
+    {
+        std::copy_backward(static_,
+            static_ + size_,
+            static_ + size_ + 1);
+        size_ += 1;
+        static_[0] = buf;
+    }
+}
+
+template<class T>
+auto
+basic_polymorphic_buffer_sequence<T>::
+push_front_copy(value_type buf) const&
+    -> basic_polymorphic_buffer_sequence
+{
+    auto result = basic_polymorphic_buffer_sequence();
+
+    if (is_dynamic(size_ + 1))
+    {
+        new (&result.dynamic_) std::vector<value_type> (size_ + 1);
+        // defer the size until after new in case of exceptions
+        result.size_ = size_ + 1;
+        result.dynamic_[0] = buf;
+        std::copy(begin(), end(), result.dynamic_.begin() + 1);
+    }
+    else
+    {
+        result.size_ = size_ + 1;
+        result.static_[0] = buf;
+        std::copy(begin(), end(), &result.static_[1]);
+    }
+
+    return result;
+}
+
+template<class T>
+auto
+basic_polymorphic_buffer_sequence<T>::
+push_front_copy(value_type buf) &&
+    -> basic_polymorphic_buffer_sequence&&
+{
+    push_front(buf);
+    return std::move(*this);
+}
+
+
+template<class T>
+auto
+basic_polymorphic_buffer_sequence<T>::
+prefix_copy(std::size_t n) const &
+    -> basic_polymorphic_buffer_sequence
+{
+    std::size_t tot = 0;
+    auto first = begin();
+    auto last =
+        std::find_if(first, end(), [&tot, &n](value_type const& buf)
+        {
+            if (tot >= n)
+                return true;
+
+            tot += buf.size();
+            return false;
+        });
+    auto result = basic_polymorphic_buffer_sequence(begin(), last);
+    result.shrink(tot - std::min(n, tot));
+    return result;
+}
+
+// specialisation where *this is an rvalue - mutate in-place
+// and return an rvalue to self
+template<class T>
+auto
+basic_polymorphic_buffer_sequence<T>::
+prefix_copy(std::size_t n) &&
+    -> basic_polymorphic_buffer_sequence&&
+{
+    return std::move(this->prefix(n));
+}
+
+template<class T>
+auto
+basic_polymorphic_buffer_sequence<T>::
+prefix(std::size_t n)
+-> basic_polymorphic_buffer_sequence&
+{
+    std::size_t tot = 0;
+    auto pred = [&tot, &n](value_type const& buf)
+    {
+        if (tot >= n)
+            return true;
+
+        tot += buf.size();
+        return false;
+    };
+
+    if (is_dynamic(size_))
+    {
+        auto last =
+            std::find_if(dynamic_.begin(),
+                         dynamic_.end(),
+                         pred);
+        dynamic_.erase(last, dynamic_.end());
+    }
+    else
+    {
+        auto last =
+            std::find_if(static_,
+                         static_ + size_,
+                         pred);
+        size_ -= std::distance(last, static_ + size_);
+    }
+
+    shrink(tot - std::min(n, tot));
+    return *this;
+}
+
+template<class T>
+void
+basic_polymorphic_buffer_sequence<T>::
+shrink(std::size_t n)
+{
+    auto first = begin();
+    auto last = end();
+    while (first != last && n)
+    {
+        --last;
+        auto x = std::min(n, last->size());
+        n -= x;
+        *last = value_type(last->data(), last->size() - x);
+        if(last->size() == 0)
+        {
+            if(is_dynamic(size_))
+            {
+                dynamic_.pop_back();
+            }
+            else
+            {
+                size_ -= 1;
+            }
+        }
+    }
+}
+
+template<class T>
+basic_polymorphic_buffer_sequence<T>::basic_polymorphic_buffer_sequence() noexcept
+: size_(0)
+{
+}
+
+template<class T>
+basic_polymorphic_buffer_sequence<T>::~basic_polymorphic_buffer_sequence()
+{
+    if (is_dynamic(size_))
+        dynamic_.~vector();
+}
+
+template<class T>
+basic_polymorphic_buffer_sequence<T>::
+basic_polymorphic_buffer_sequence(value_type v1 , value_type v2) noexcept
+: size_(2)
+{
+    BOOST_ASSERT(!is_dynamic(size_));
+    static_[0] = v1;
+    static_[1] = v2;
+}
+
+template<class T>
+basic_polymorphic_buffer_sequence<T>::
+    basic_polymorphic_buffer_sequence(
+        const basic_polymorphic_buffer_sequence &other)
+: size_(0)
+{
+    if (is_dynamic(other.size_))
+    {
+        new (&dynamic_) std::vector<value_type>(other.dynamic_);
+    }
+    else
+    {
+        std::copy(other.begin(), other.end(), static_);
+    }
+
+    // size deferred until after the vector copy, which could throw
+    size_ = other.size_;
+}
+
+template<class T>
+basic_polymorphic_buffer_sequence<T>::
+    basic_polymorphic_buffer_sequence(
+        basic_polymorphic_buffer_sequence &&other) noexcept
+: size_(boost::exchange(other.size_, 0))
+{
+    if (is_dynamic(size_))
+    {
+        new (&dynamic_) std::vector<value_type>(std::move(other.dynamic_));
+        other.dynamic_.~vector();
+    }
+    else
+    {
+        std::copy(other.static_, other.static_ + size_, static_);
+    }
+}
+
+template<class T>
+auto
+basic_polymorphic_buffer_sequence<T>::
+    operator=(
+        const basic_polymorphic_buffer_sequence &other)
+    -> basic_polymorphic_buffer_sequence&
+{
+    if(is_dynamic(size_))
+    {
+        if(is_dynamic(other.size_))
+        {
+            dynamic_.assign(other.dynamic_.begin(), other.dynamic_.end());
+        }
+        else
+        {
+            dynamic_.assign(other.static_, other.static_ + other.size_);
+        }
+    }
+    else
+    {
+        if (is_dynamic(other.size_))
+        {
+            new (&dynamic_) std::vector<value_type>(other.dynamic_.begin(), other.dynamic_.end());
+            size_ = other.size_;
+        }
+        else
+        {
+            std::copy(other.static_, other.static_ + other.size_, static_);
+            size_ = other.size_;
+        }
+    }
+    return *this;
+}
+
+template<class T>
+auto
+basic_polymorphic_buffer_sequence<T>::
+    operator=(
+        basic_polymorphic_buffer_sequence &&other) noexcept
+    -> basic_polymorphic_buffer_sequence&
+{
+    if(is_dynamic(size_))
+    {
+        if(is_dynamic(other.size_))
+        {
+            dynamic_ = std::move(other.dynamic_);
+        }
+        else
+        {
+            dynamic_.assign(other.static_, other.static_ + other.size_);
+        }
+    }
+    else
+    {
+        if (is_dynamic(other.size_))
+        {
+            new (&dynamic_) std::vector<value_type>(std::move(other.dynamic_));
+            size_ = other.size_;
+        }
+        else
+        {
+            std::copy(other.static_, other.static_ + other.size_, static_);
+            size_ = other.size_;
+        }
+    }
+    return *this;
+}
+
+template<class T>
+auto
+basic_polymorphic_buffer_sequence<T>::
+append(value_type buf) &
+-> basic_polymorphic_buffer_sequence&
+{
+    if (is_dynamic(size_))
+    {
+#ifdef BOOST_BEAST_POLYMORPHIC_BUFFER_METRICS
+        assert(dynamic_.capacity() > dynamic_.size());
+#endif
+        dynamic_.push_back(buf);
+    }
+    else
+    {
+        if (is_dynamic(size_ + 1))
+        {
+            std::vector<value_type> vec;
+            vec.reserve(size_ * 2);
+            vec.assign(static_, static_ + size_);
+            vec.push_back(buf);
+            new (&dynamic_) std::vector<value_type>(std::move(vec));
+            size_ += 1;
+        }
+        else
+        {
+            static_[size_] = buf;
+            size_ += 1;
+        }
+    }
+    return *this;
+}
+
+template<class T>
+auto
+basic_polymorphic_buffer_sequence<T>::operator+(value_type r) const &
+-> basic_polymorphic_buffer_sequence
+{
+    auto l = *this;
+    l.append(r);
+    return l;
+}
+
+template<class T>
+auto
+basic_polymorphic_buffer_sequence<T>::operator+(value_type r) &&
+-> basic_polymorphic_buffer_sequence&&
+{
+    append(r);
+    return std::move(*this);
+}
+
+template<class T>
+auto
+basic_polymorphic_buffer_sequence<T>::front() const
+-> value_type
+{
+    if (size_ == 0)
+    {
+        return value_type {};
+    }
+    else if (is_dynamic(size_))
+    {
+        if (dynamic_.begin() == dynamic_.end())
+            return value_type {};
+        return dynamic_.front();
+    }
+    else
+    {
+        return static_[0];
+    }
+}
+
+template<class T>
+basic_polymorphic_buffer_sequence<T>&
+basic_polymorphic_buffer_sequence<T>::clear()
+{
+    if (is_dynamic(size_))
+        dynamic_.clear();
+    else
+        size_ = 0;
+    return *this;
+}
+
+#ifndef BOOST_BEAST_HEADER_ONLY
+
+template class basic_polymorphic_buffer_sequence<net::mutable_buffer>;
+template class basic_polymorphic_buffer_sequence<net::const_buffer>;
+
+#endif // BOOST_BEAST_HEADER_ONLY
+} // detail
+} // beast
+} // boost
+
+#endif // BOOST_BEAST_CORE_DETAIL_POLYMORPHIC_BUFFER_SEQUENCE_HPP

--- a/include/boost/beast/http/detail/chunk_encode.hpp
+++ b/include/boost/beast/http/detail/chunk_encode.hpp
@@ -118,6 +118,13 @@ public:
     {
     }
 
+    /** Construct an uninitialised chunk header
+
+    */
+    chunk_size()
+        : sp_()
+    {}
+
     const_iterator
     begin() const
     {

--- a/include/boost/beast/http/impl/write.hpp
+++ b/include/boost/beast/http/impl/write.hpp
@@ -17,6 +17,7 @@
 #include <boost/beast/core/make_printable.hpp>
 #include <boost/beast/core/stream_traits.hpp>
 #include <boost/beast/core/detail/is_invocable.hpp>
+#include <boost/beast/core/detail/polymorphic_buffer_sequence.hpp>
 #include <boost/asio/coroutine.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/asio/write.hpp>
@@ -455,10 +456,9 @@ public:
     {
     }
 
-    template<class ConstBufferSequence>
     void
     operator()(error_code& ec,
-        ConstBufferSequence const& buffers)
+        beast::detail::polymorphic_const_buffer_sequence const& buffers)
     {
         invoked = true;
         bytes_transferred = net::write(
@@ -903,16 +903,15 @@ public:
     {
     }
 
-    template<class ConstBufferSequence>
     void
     operator()(error_code& ec,
-        ConstBufferSequence const& buffers) const
+        beast::detail::polymorphic_const_buffer_sequence const& buffers) const
     {
         ec = {};
         if(os_.fail())
             return;
         std::size_t bytes_transferred = 0;
-        for(auto b : beast::buffers_range_ref(buffers))
+        for(auto b : buffers)
         {
             os_.write(static_cast<char const*>(
                 b.data()), b.size());

--- a/include/boost/beast/src.hpp
+++ b/include/boost/beast/src.hpp
@@ -31,6 +31,7 @@ the program, with the macro BOOST_BEAST_SEPARATE_COMPILATION defined.
 #include <boost/beast/_experimental/test/detail/stream_state.ipp>
 
 #include <boost/beast/core/detail/base64.ipp>
+#include <boost/beast/core/detail/polymorphic_buffer_sequence.ipp>
 #include <boost/beast/core/detail/sha1.ipp>
 #include <boost/beast/core/detail/impl/temporary_buffer.ipp>
 #include <boost/beast/core/impl/error.ipp>

--- a/include/boost/beast/websocket/detail/frame.hpp
+++ b/include/boost/beast/websocket/detail/frame.hpp
@@ -11,6 +11,7 @@
 #define BOOST_BEAST_WEBSOCKET_DETAIL_FRAME_HPP
 
 #include <boost/beast/core/buffer_traits.hpp>
+#include <boost/beast/core/detail/polymorphic_buffer_sequence.hpp>
 #include <boost/beast/websocket/error.hpp>
 #include <boost/beast/websocket/rfc6455.hpp>
 #include <boost/beast/websocket/detail/utf8_checker.hpp>
@@ -178,9 +179,11 @@ write(DynamicBuffer& db, frame_header const& fh)
 // Read data from buffers
 // This is for ping and pong payloads
 //
-template<class Buffers>
+
+inline
 void
-read_ping(ping_data& data, Buffers const& bs)
+read_ping(ping_data& data,
+      beast::detail::polymorphic_const_buffer_sequence const& bs)
 {
     BOOST_ASSERT(buffer_bytes(bs) <= data.max_size());
     data.resize(buffer_bytes(bs));
@@ -191,11 +194,11 @@ read_ping(ping_data& data, Buffers const& bs)
 // Read close_reason, return true on success
 // This is for the close payload
 //
-template<class Buffers>
+inline
 void
 read_close(
     close_reason& cr,
-    Buffers const& bs,
+    beast::detail::polymorphic_const_buffer_sequence const& bs,
     error_code& ec)
 {
     auto const n = buffer_bytes(bs);

--- a/include/boost/beast/websocket/detail/impl_base.hpp
+++ b/include/boost/beast/websocket/detail/impl_base.hpp
@@ -15,6 +15,7 @@
 #include <boost/beast/websocket/detail/pmd_extension.hpp>
 #include <boost/beast/core/buffer_traits.hpp>
 #include <boost/beast/core/role.hpp>
+#include <boost/beast/core/detail/polymorphic_buffer_sequence.hpp>
 #include <boost/beast/http/empty_body.hpp>
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/http/string_body.hpp>
@@ -78,11 +79,11 @@ struct impl_base<true>
     // Compress a buffer sequence
     // Returns: `true` if more calls are needed
     //
-    template<class ConstBufferSequence>
+    inline
     bool
     deflate(
         net::mutable_buffer& out,
-        buffers_suffix<ConstBufferSequence>& cb,
+        beast::detail::polymorphic_const_buffer_sequence& cb,
         bool fin,
         std::size_t& total_in,
         error_code& ec)
@@ -358,11 +359,11 @@ struct impl_base<false>
         return ! rsv1;
     }
 
-    template<class ConstBufferSequence>
+    inline
     bool
     deflate(
         net::mutable_buffer&,
-        buffers_suffix<ConstBufferSequence>&,
+        beast::detail::polymorphic_const_buffer_sequence&,
         bool,
         std::size_t&,
         error_code&)

--- a/include/boost/beast/websocket/detail/mask.hpp
+++ b/include/boost/beast/websocket/detail/mask.hpp
@@ -11,7 +11,7 @@
 #define BOOST_BEAST_WEBSOCKET_DETAIL_MASK_HPP
 
 #include <boost/beast/core/detail/config.hpp>
-#include <boost/beast/core/buffers_range.hpp>
+#include <boost/beast/core/detail/polymorphic_buffer_sequence.hpp>
 #include <boost/asio/buffer.hpp>
 #include <array>
 #include <climits>
@@ -38,16 +38,11 @@ mask_inplace(net::mutable_buffer const& b, prepared_key& key);
 
 // Apply mask in place
 //
-template<class MutableBufferSequence>
+BOOST_BEAST_DECL
 void
 mask_inplace(
-    MutableBufferSequence const& buffers,
-    prepared_key& key)
-{
-    for(net::mutable_buffer b :
-            beast::buffers_range_ref(buffers))
-        detail::mask_inplace(b, key);
-}
+    beast::detail::polymorphic_mutable_buffer_sequence const& buffers,
+    prepared_key& key);
 
 } // detail
 } // websocket

--- a/include/boost/beast/websocket/detail/mask.ipp
+++ b/include/boost/beast/websocket/detail/mask.ipp
@@ -58,6 +58,16 @@ mask_inplace(net::mutable_buffer const& b, prepared_key& key)
     }
 }
 
+void
+mask_inplace(
+    beast::detail::polymorphic_mutable_buffer_sequence const& buffers,
+    prepared_key& key)
+{
+    for(net::mutable_buffer b : buffers)
+        detail::mask_inplace(b, key);
+}
+
+
 } // detail
 } // websocket
 } // beast

--- a/include/boost/beast/websocket/detail/utf8_checker.hpp
+++ b/include/boost/beast/websocket/detail/utf8_checker.hpp
@@ -10,7 +10,7 @@
 #ifndef BOOST_BEAST_WEBSOCKET_DETAIL_UTF8_CHECKER_HPP
 #define BOOST_BEAST_WEBSOCKET_DETAIL_UTF8_CHECKER_HPP
 
-#include <boost/beast/core/buffers_range.hpp>
+#include <boost/beast/core/detail/polymorphic_buffer_sequence.hpp>
 #include <boost/asio/buffer.hpp>
 
 #include <cstdint>
@@ -57,21 +57,17 @@ public:
 
         @return `true` if the text is valid utf8 or false otherwise.
     */
-    template<class ConstBufferSequence>
+    inline
     bool
-    write(ConstBufferSequence const& bs);
+    write(beast::detail::polymorphic_const_buffer_sequence const& bs);
 };
 
 
-template<class ConstBufferSequence>
 bool
 utf8_checker::
-write(ConstBufferSequence const& buffers)
+write(beast::detail::polymorphic_const_buffer_sequence const& buffers)
 {
-    static_assert(
-        net::is_const_buffer_sequence<ConstBufferSequence>::value,
-        "ConstBufferSequence type requirements not met");
-    for(auto b : beast::buffers_range_ref(buffers))
+    for(auto b : buffers)
         if(! write(static_cast<
             std::uint8_t const*>(b.data()),
                 b.size()))

--- a/include/boost/beast/websocket/impl/accept.hpp
+++ b/include/boost/beast/websocket/impl/accept.hpp
@@ -254,12 +254,12 @@ class stream<NextLayer, deflateSupported>::accept_op
     Decorator d_;
 
 public:
-    template<class Handler_, class Buffers>
+    template<class Handler_>
     accept_op(
         Handler_&& h,
         boost::shared_ptr<impl_type> const& sp,
         Decorator const& decorator,
-        Buffers const& buffers)
+        beast::detail::polymorphic_const_buffer_sequence const& buffers)
         : stable_async_base<Handler,
             beast::executor_type<stream>>(
                 std::forward<Handler_>(h),
@@ -372,14 +372,13 @@ struct stream<NextLayer, deflateSupported>::
 {
     template<
         class AcceptHandler,
-        class Decorator,
-        class Buffers>
+        class Decorator>
     void
     operator()(
         AcceptHandler&& h,
         boost::shared_ptr<impl_type> const& sp,
         Decorator const& d,
-        Buffers const& b)
+        beast::detail::polymorphic_const_buffer_sequence const& b)
     {
         // If you get an error on the following line it means
         // that your handler does not meet the documented type
@@ -432,11 +431,11 @@ do_accept(
 }
 
 template<class NextLayer, bool deflateSupported>
-template<class Buffers, class Decorator>
+template<class Decorator>
 void
 stream<NextLayer, deflateSupported>::
 do_accept(
-    Buffers const& buffers,
+    beast::detail::polymorphic_const_buffer_sequence const& buffers,
     Decorator const& decorator,
     error_code& ec)
 {

--- a/include/boost/beast/websocket/impl/ping.hpp
+++ b/include/boost/beast/websocket/impl/ping.hpp
@@ -110,8 +110,9 @@ public:
                     __FILE__, __LINE__,
                     "websocket::async_ping"));
 
-                net::async_write(impl.stream(), fb_.data(),
-                    beast::detail::bind_continuation(std::move(*this)));
+                net::async_write(impl.stream(),
+                    beast::detail::polymorphic_const_buffer_sequence (fb_.data()),
+                        beast::detail::bind_continuation(std::move(*this)));
             }
             if(impl.check_stop_now(ec))
                 goto upcall;
@@ -220,8 +221,9 @@ public:
                     __FILE__, __LINE__,
                     "websocket::async_ping"));
 
-                net::async_write(impl.stream(), fb_->data(),
-                    std::move(*this));
+                net::async_write(impl.stream(),
+                    beast::detail::polymorphic_mutable_buffer_sequence(fb_->data()),
+                        std::move(*this));
             }
             if(impl.check_stop_now(ec))
                 goto upcall;
@@ -291,7 +293,10 @@ ping(ping_data const& payload, error_code& ec)
     detail::frame_buffer fb;
     impl_->template write_ping<flat_static_buffer_base>(
         fb, detail::opcode::ping, payload);
-    net::write(impl_->stream(), fb.data(), ec);
+    net::write(impl_->stream(),
+        beast::detail::polymorphic_const_buffer_sequence(
+            fb.data()),
+        ec);
     if(impl_->check_stop_now(ec))
         return;
 }
@@ -317,7 +322,9 @@ pong(ping_data const& payload, error_code& ec)
     detail::frame_buffer fb;
     impl_->template write_ping<flat_static_buffer_base>(
         fb, detail::opcode::pong, payload);
-    net::write(impl_->stream(), fb.data(), ec);
+    net::write(impl_->stream(),
+        beast::detail::polymorphic_const_buffer_sequence(fb.data()),
+        ec);
     if(impl_->check_stop_now(ec))
         return;
 }

--- a/include/boost/beast/websocket/impl/stream_impl.hpp
+++ b/include/boost/beast/websocket/impl/stream_impl.hpp
@@ -22,9 +22,6 @@
 #include <boost/beast/http/read.hpp>
 #include <boost/beast/http/write.hpp>
 #include <boost/beast/http/rfc7230.hpp>
-#include <boost/beast/core/buffers_cat.hpp>
-#include <boost/beast/core/buffers_prefix.hpp>
-#include <boost/beast/core/buffers_suffix.hpp>
 #include <boost/beast/core/flat_static_buffer.hpp>
 #include <boost/beast/core/saved_handler.hpp>
 #include <boost/beast/core/static_buffer.hpp>
@@ -706,9 +703,8 @@ parse_fh(
         ec = {};
         return false;
     }
-    buffers_suffix<typename
-        DynamicBuffer::const_buffers_type> cb{
-            b.data()};
+    beast::detail::polymorphic_const_buffer_sequence
+        cb(b.data());
     std::size_t need;
     {
         std::uint8_t tmp[2];

--- a/include/boost/beast/websocket/stream.hpp
+++ b/include/boost/beast/websocket/stream.hpp
@@ -11,6 +11,7 @@
 #define BOOST_BEAST_WEBSOCKET_STREAM_HPP
 
 #include <boost/beast/core/detail/config.hpp>
+#include <boost/beast/core/detail/polymorphic_buffer_sequence.hpp>
 #include <boost/beast/websocket/error.hpp>
 #include <boost/beast/websocket/option.hpp>
 #include <boost/beast/websocket/rfc6455.hpp>
@@ -2543,10 +2544,10 @@ private:
     template<class>         class handshake_op;
     template<class>         class ping_op;
     template<class>         class idle_ping_op;
-    template<class, class>  class read_some_op;
+    template<class>         class read_some_op;
     template<class, class>  class read_op;
     template<class>         class response_op;
-    template<class, class>  class write_some_op;
+    template<class>         class write_some_op;
     template<class, class>  class write_op;
 
     struct run_accept_op;
@@ -2567,10 +2568,10 @@ private:
     // accept / handshake
     //
 
-    template<class Buffers, class Decorator>
+    template<class Decorator>
     void
     do_accept(
-        Buffers const& buffers,
+        beast::detail::polymorphic_const_buffer_sequence const& buffers,
         Decorator const& decorator,
         error_code& ec);
 
@@ -2599,6 +2600,21 @@ private:
     do_fail(
         std::uint16_t code,
         error_code ev,
+        error_code& ec);
+
+    //
+    // write
+    //
+    std::size_t
+    do_write_some(bool fin,
+        beast::detail::polymorphic_const_buffer_sequence buffers,
+            error_code& ec);
+
+    //
+    // read
+    //
+    std::size_t
+    do_read_some(beast::detail::polymorphic_mutable_buffer_sequence buffers,
         error_code& ec);
 };
 

--- a/test/beast/core/CMakeLists.txt
+++ b/test/beast/core/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable (tests-beast-core
     _detail_clamp.cpp
     _detail_get_io_context.cpp
     _detail_is_invocable.cpp
+    _detail_polymorphic_buffer_sequence.cpp
     _detail_read.cpp
     _detail_sha1.cpp
     _detail_tuple.cpp

--- a/test/beast/core/Jamfile
+++ b/test/beast/core/Jamfile
@@ -14,6 +14,7 @@ local SOURCES =
     _detail_clamp.cpp
     _detail_get_io_context.cpp
     _detail_is_invocable.cpp
+    _detail_polymorphic_buffer_sequence.cpp
     _detail_read.cpp
     _detail_sha1.cpp
     _detail_tuple.cpp

--- a/test/beast/core/_detail_polymorphic_buffer_sequence.cpp
+++ b/test/beast/core/_detail_polymorphic_buffer_sequence.cpp
@@ -1,0 +1,135 @@
+//
+// Copyright (c) 2020 Richard Hodges (hodges.r@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+// Test that header file is self-contained.
+#include <boost/beast/core/detail/polymorphic_buffer_sequence.hpp>
+
+#include <boost/beast/_experimental/unit_test/suite.hpp>
+#include <boost/beast/core/buffers_to_string.hpp>
+#include <boost/beast/core/buffers_prefix.hpp>
+#include <numeric>
+#include <algorithm>
+
+namespace boost {
+namespace beast {
+namespace detail {
+
+class polymorphic_buffer_sequence_test : public unit_test::suite
+{
+    void
+    testInvariants()
+    {
+        BEAST_EXPECT(net::is_const_buffer_sequence<polymorphic_const_buffer_sequence>());
+        BEAST_EXPECT(net::is_mutable_buffer_sequence<polymorphic_mutable_buffer_sequence>());
+    }
+
+    void testPushFront()
+    {
+        std::string s1 = "This black cat";
+        std::string s2 = " ate a doormat";
+
+        polymorphic_const_buffer_sequence pb{ net::buffer(s2) };
+        pb.push_front(net::buffer(s1));
+        auto first = pb.begin();
+        auto last = pb.end();
+        BEAST_EXPECT(std::distance(first, last) == 2);
+        BEAST_EXPECTS(boost::beast::buffer_bytes(pb) == 28, std::to_string(boost::beast::buffer_bytes(pb)));
+        BEAST_EXPECT(boost::beast::buffers_to_string(pb) == (s1 + s2));
+
+
+        std::vector<std::string> strings;
+        for(int count = 0 ; pb.size() + strings.size() <= pb.static_capacity() ; ++count)
+            strings.push_back(std::string("buffer: ") + std::to_string(count));
+        std::reverse(strings.begin(), strings.end());
+        for(auto& s : strings)
+            pb.push_front(net::buffer(s));
+
+        BEAST_EXPECT(pb.size() == pb.static_capacity() + 1);
+        auto expected = std::accumulate(strings.rbegin(), strings.rend(), std::string()) + s1 + s2;
+        BEAST_EXPECTS(buffers_to_string(pb) == expected,
+            buffers_to_string(pb) + " != " + expected);
+    }
+
+    void
+    testConsume()
+    {
+        std::string s1 = "This black cat";
+        std::string s2 = " ate a doormat";
+
+        polymorphic_const_buffer_sequence pb{ net::buffer(s2) };
+        pb.push_front(net::buffer(s1));
+        pb.consume(7);
+        auto first = pb.begin();
+        auto last = pb.end();
+        BEAST_EXPECT(std::distance(first, last) == 2);
+        BEAST_EXPECTS(boost::beast::buffer_bytes(pb) == 21, std::to_string(boost::beast::buffer_bytes(pb)));
+        BEAST_EXPECT(boost::beast::buffers_to_string(pb) == (s1.substr(7) + s2));
+
+        pb.consume(7);
+        first = pb.begin();
+        last = pb.end();
+        BEAST_EXPECT(std::distance(first, last) == 1);
+        BEAST_EXPECTS(boost::beast::buffer_bytes(pb) == 14, std::to_string(boost::beast::buffer_bytes(pb)));
+        BEAST_EXPECT(boost::beast::buffers_to_string(pb) == s2);
+    }
+
+    void
+    testPrefix()
+    {
+        std::vector<std::string> strings(polymorphic_const_buffer_sequence::static_capacity() + 1);
+        std::vector<net::const_buffer> buffers(strings.size());
+        char c = 'a';
+        for (std::size_t i = 0 ; i < strings.size() ; ++i)
+        {
+            strings[i] = std::string(c, i % 2 == 0 ? 1 : 2);
+            ++c;
+        }
+        std::transform(strings.begin(), strings.end(), buffers.begin(),
+                       [](std::string const& x) { return net::buffer(x); });
+
+        auto check = [](polymorphic_const_buffer_sequence const& pb, std::size_t i)
+        {
+            auto orig = buffers_to_string(pb);
+            auto expected = orig.substr(0, std::min(i, orig.size()));
+            auto prefix = pb.prefix_copy(i);
+            auto str = buffers_to_string(prefix);
+            BEAST_EXPECTS(str == expected, std::to_string(pb.size()) + " : " +
+                std::to_string(i) + " : " +
+                str + " != " + expected);
+
+            // same as buffers_prefix?
+
+            BEAST_EXPECT(str == buffers_to_string(buffers_prefix(i, pb)));
+        };
+
+        auto grind = [check](polymorphic_const_buffer_sequence const& pb)
+        {
+            for (std::size_t i = 0 ; i <= buffer_bytes(pb) + 1 ; ++i)
+                check(pb, i);
+        };
+
+        auto first = buffers.begin();
+        for (auto last = first ; last != buffers.end() ; ++last)
+            grind(polymorphic_const_buffer_sequence(first, last));
+    }
+
+public:
+    void run()
+    {
+        testInvariants();
+        testPushFront();
+        testConsume();
+        testPrefix();
+    }
+
+};
+
+BEAST_DEFINE_TESTSUITE(beast,core,polymorphic_buffer_sequence);
+
+}}}

--- a/test/beast/http/write.cpp
+++ b/test/beast/http/write.cpp
@@ -306,26 +306,6 @@ public:
     {
         {
             response<string_body> m;
-            m.version(10);
-            m.result(status::ok);
-            m.set(field::server, "test");
-            m.set(field::content_length, "5");
-            m.body() = "*****";
-            error_code ec;
-            test::stream ts{ioc_}, tr{ioc_};
-            ts.connect(tr);
-            async_write(ts, m, do_yield[ec]);
-            BEAST_EXPECT(! m.keep_alive());
-            if(BEAST_EXPECTS(! ec, ec.message()))
-                BEAST_EXPECT(tr.str() ==
-                    "HTTP/1.0 200 OK\r\n"
-                    "Server: test\r\n"
-                    "Content-Length: 5\r\n"
-                    "\r\n"
-                    "*****");
-        }
-        {
-            response<string_body> m;
             m.version(11);
             m.result(status::ok);
             m.set(field::server, "test");
@@ -344,6 +324,26 @@ public:
                     "5\r\n"
                     "*****\r\n"
                     "0\r\n\r\n");
+        }
+        {
+            response<string_body> m;
+            m.version(10);
+            m.result(status::ok);
+            m.set(field::server, "test");
+            m.set(field::content_length, "5");
+            m.body() = "*****";
+            error_code ec;
+            test::stream ts{ioc_}, tr{ioc_};
+            ts.connect(tr);
+            async_write(ts, m, do_yield[ec]);
+            BEAST_EXPECT(! m.keep_alive());
+            if(BEAST_EXPECTS(! ec, ec.message()))
+                BEAST_EXPECT(tr.str() ==
+                    "HTTP/1.0 200 OK\r\n"
+                    "Server: test\r\n"
+                    "Content-Length: 5\r\n"
+                    "\r\n"
+                    "*****");
         }
     }
 
@@ -1054,13 +1054,13 @@ public:
     void
     run() override
     {
-        testIssue655();
         yield_to(
             [&](yield_context yield)
             {
-                testAsyncWrite(yield);
                 testFailures(yield);
+                testAsyncWrite(yield);
             });
+        testIssue655();
         testOutput();
         test_std_ostream();
         testIoService();


### PR DESCRIPTION
Use polymorphic buffers type to reduce template expansions.
