### PR TITLE
Limit the number of net::async_write instantiations by using a common buffer sequence type.

### DIFF
--- a/include/boost/beast/websocket/impl/read.hpp
+++ b/include/boost/beast/websocket/impl/read.hpp
@@ -294,7 +294,7 @@ public:
                                 "websocket::async_read_some"));
 
                             net::async_write(
-                                impl.stream(), impl.rd_fb.data(),
+                                impl.stream(), net::const_buffer(impl.rd_fb.data()),
                                 beast::detail::bind_continuation(std::move(*this)));
                         }
                         BOOST_ASSERT(impl.wr_block.is_locked(this));
@@ -661,7 +661,7 @@ public:
                         __FILE__, __LINE__,
                         "websocket::async_read_some"));
 
-                    net::async_write(impl.stream(), impl.rd_fb.data(),
+                    net::async_write(impl.stream(), net::const_buffer(impl.rd_fb.data()),
                         beast::detail::bind_continuation(std::move(*this)));
                 }
                 BOOST_ASSERT(impl.wr_block.is_locked(this));


### PR DESCRIPTION
Reduces the size of generated code for websockets. E.g. on macOS for websocket/client/async example:

before:
```
__TEXT	__DATA	__OBJC	others	dec	hex
933888	32768	0	4296146944	4297113600	10020c000
```

after:
```
__TEXT	__DATA	__OBJC	others	dec	hex
884736	32768	0	4296048640	4296966144	1001e8000
```