### PR TITLE
removes unused parameter to avoid compiler warning

### DIFF
--- a/include/boost/beast/websocket/impl/ssl.hpp
+++ b/include/boost/beast/websocket/impl/ssl.hpp
@@ -62,7 +62,7 @@ struct ssl_shutdown_op
 
     template<class Self>
     void
-    operator()(Self& self, error_code ec = {}, std::size_t bytes_transferred = 0)
+    operator()(Self& self, error_code ec = {}, std::size_t)
     {
         BOOST_ASIO_CORO_REENTER(*this)
         {


### PR DESCRIPTION
Removes the name of unused parameter "bytes_transferred" to avoid compiler warnings.
Related issue #2152 