### PR TITLE
Add msvc-14.0 CI jobs

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -21,6 +21,9 @@ def main(ctx):
     linux_cxx("GCC 8, C++17, libstdc++, release", "g++-8", packages=" ".join(addon_base["apt"]["packages"]) + " g++-8", image="ubuntu:16.04", buildtype="boost", environment={  "VARIANT": "release", "TOOLSET": "gcc", "COMPILER": "g++-8", "CXXSTD" : "17" }),
     linux_cxx("Clang 3.8, UBasan", "clang++-3.8", packages=" ".join(addon_base["apt"]["packages"]) + " clang-3.8 libssl-dev", llvm_os="precise", llvm_ver="3.8", image="ubuntu:16.04", buildtype="boost", environment={"VARIANT": "beast_ubasan", "TOOLSET": "clang", "COMPILER": "clang++-3.8", "CXXSTD": "11", "UBSAN_OPTIONS": 'print_stacktrace=1', "DRONE_BEFORE_INSTALL": "UBasan" }),
     linux_cxx("docs", "", packages="docbook docbook-xml docbook-xsl xsltproc libsaxonhe-java default-jre-headless flex libfl-dev bison unzip", image="ubuntu:16.04", buildtype="docs", environment={"COMMENT": "docs"}),
+    windows_cxx("msvc-14.0 test", "", image="cppalliance/dronevs2015:1", buildtype="vs2015-test", environment={ "VARIANT": "release", "TOOLSET": "msvc-14.0", "CXXSTD": "11", "ADDRESS_MODEL": "64"}),
+    windows_cxx("msvc-14.0 run-fat-tests", "", image="cppalliance/dronevs2015:1", buildtype="vs2015-fat-tests", environment={ "VARIANT": "release", "TOOLSET": "msvc-14.0", "CXXSTD": "11", "ADDRESS_MODEL": "64"}),
+    windows_cxx("msvc-14.0 example", "", image="cppalliance/dronevs2015:1", buildtype="vs2015-example", environment={ "VARIANT": "release", "TOOLSET": "msvc-14.0", "CXXSTD": "11", "ADDRESS_MODEL": "64"}),
     windows_cxx("msvc-14.1", "", image="cppalliance/dronevs2017", buildtype="boost", environment={ "VARIANT": "release", "TOOLSET": "msvc-14.1", "CXXSTD": "17", "DEFINE" : "BOOST_BEAST_USE_STD_STRING_VIEW", "ADDRESS_MODEL": "64"}),
     windows_cxx("msvc-14.2", "", image="cppalliance/dronevs2019", buildtype="boost", environment={ "VARIANT": "release", "TOOLSET": "msvc-14.2", "CXXSTD": "17", "DEFINE" : "BOOST_BEAST_USE_STD_STRING_VIEW", "ADDRESS_MODEL": "64"}),
 

--- a/.drone/vs2015-example-script.bat
+++ b/.drone/vs2015-example-script.bat
@@ -1,0 +1,27 @@
+
+@ECHO ON
+setlocal enabledelayedexpansion
+
+echo "============> INSTALL"
+
+SET DRONE_BUILD_DIR=%CD: =%
+choco install --no-progress -y openssl --x64 --version 1.1.1.1000
+mklink /D "C:\OpenSSL" "C:\Program Files\OpenSSL-Win64"
+SET OPENSSL_ROOT=C:\OpenSSL
+SET BOOST_BRANCH=develop
+IF "%DRONE_BRANCH%" == "master" SET BOOST_BRANCH=master
+cp tools\user-config.jam %USERPROFILE%\user-config.jam
+cd ..
+SET GET_BOOST=%DRONE_BUILD_DIR%\tools\get-boost.sh
+bash -c "$GET_BOOST $DRONE_BRANCH $DRONE_BUILD_DIR"
+cd boost-root
+call bootstrap.bat
+b2 headers
+
+echo "============> SCRIPT"
+
+echo "Running libs/beast/example"
+b2 --debug-configuration variant=%VARIANT% cxxstd=%CXXSTD% address-model=%ADDRESS_MODEL% toolset=%TOOLSET% libs/beast/example -j3
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo "============> COMPLETED"

--- a/.drone/vs2015-fat-tests-script.bat
+++ b/.drone/vs2015-fat-tests-script.bat
@@ -1,0 +1,27 @@
+
+@ECHO ON
+setlocal enabledelayedexpansion
+
+echo "============> INSTALL"
+
+SET DRONE_BUILD_DIR=%CD: =%
+choco install --no-progress -y openssl --x64 --version 1.1.1.1000
+mklink /D "C:\OpenSSL" "C:\Program Files\OpenSSL-Win64"
+SET OPENSSL_ROOT=C:\OpenSSL
+SET BOOST_BRANCH=develop
+IF "%DRONE_BRANCH%" == "master" SET BOOST_BRANCH=master
+cp tools\user-config.jam %USERPROFILE%\user-config.jam
+cd ..
+SET GET_BOOST=%DRONE_BUILD_DIR%\tools\get-boost.sh
+bash -c "$GET_BOOST $DRONE_BRANCH $DRONE_BUILD_DIR"
+cd boost-root
+call bootstrap.bat
+b2 headers
+
+echo "============> SCRIPT"
+
+echo "Running run-fat-tests"
+b2 --debug-configuration variant=%VARIANT% cxxstd=%CXXSTD% address-model=%ADDRESS_MODEL% toolset=%TOOLSET% --verbose-test libs/beast/test//run-fat-tests -j3
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo "============> COMPLETED"

--- a/.drone/vs2015-test-script.bat
+++ b/.drone/vs2015-test-script.bat
@@ -1,0 +1,27 @@
+
+@ECHO ON
+setlocal enabledelayedexpansion
+
+echo "============> INSTALL"
+
+SET DRONE_BUILD_DIR=%CD: =%
+choco install --no-progress -y openssl --x64 --version 1.1.1.1000
+mklink /D "C:\OpenSSL" "C:\Program Files\OpenSSL-Win64"
+SET OPENSSL_ROOT=C:\OpenSSL
+SET BOOST_BRANCH=develop
+IF "%DRONE_BRANCH%" == "master" SET BOOST_BRANCH=master
+cp tools\user-config.jam %USERPROFILE%\user-config.jam
+cd ..
+SET GET_BOOST=%DRONE_BUILD_DIR%\tools\get-boost.sh
+bash -c "$GET_BOOST $DRONE_BRANCH $DRONE_BUILD_DIR"
+cd boost-root
+call bootstrap.bat
+b2 headers
+
+echo "============> SCRIPT"
+
+echo "Running tests"
+b2 --debug-configuration variant=%VARIANT% cxxstd=%CXXSTD% address-model=%ADDRESS_MODEL% toolset=%TOOLSET% --verbose-test libs/beast/test -j3
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo "============> COMPLETED"


### PR DESCRIPTION
For discussion - not ready to merge.
Of the three groups of tests (tests, run-fat-tests, example), one of them completes successfully, the others reach 99% completion and then hang. 
Attempting to debug, I've tried these steps:
- Run the same test in gh actions. Same result.
- Add a series of "echo", or "true" commands at the end of the test script. However, it does not get to those final commands.
- Turn on debugging on the drone agent. No messages.
- Directly observe the docker logs of the running jobs. However, they are the same as usual log output.
The Dockerfiles are at https://github.com/CPPAlliance/droneconverter/tree/master/dockers
@madmongo1, could the main beast test suite be broken into ten smaller pieces? And run as separate jobs. That would be a "git bisect" type strategy for debugging.
Or, @grisumbras just commented: "I discovered the source of msvc-14.0 problem: it doesn't like template <void* = nullptr> You have to replace it with template <class = void>"