### PR TITLE
Fix missing check for error code after header is parsed

### DIFF
--- a/include/boost/beast/http/impl/basic_parser.ipp
+++ b/include/boost/beast/http/impl/basic_parser.ipp
@@ -164,6 +164,8 @@ loop:
             goto done;
         }
         finish_header(ec, is_request{});
+        if(ec)
+            goto done;
         break;
 
     case state::body0:

--- a/test/beast/http/basic_parser.cpp
+++ b/test/beast/http/basic_parser.cpp
@@ -1517,6 +1517,23 @@ public:
         BEAST_EXPECTS(!ec, ec.message());
     }
 
+    void
+    testIssue2201()
+    {
+        const char data[] =
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Length: 5\r\n"
+            "\r\n"
+            "*****";
+
+        test_parser<false> p;
+        p.eager(true);
+        p.body_limit(3);
+        error_code ec;
+        p.put(net::buffer(data, strlen(data)), ec);
+        BEAST_EXPECT(ec == error::body_limit);
+    }
+
     //--------------------------------------------------------------------------
 
     void
@@ -1546,6 +1563,7 @@ public:
         testChunkedOverflow();
         testChunkedBodySize();
         testUnlimitedBody();
+        testIssue2201();
     }
 };
 

--- a/test/beast/http/test_parser.hpp
+++ b/test/beast/http/test_parser.hpp
@@ -104,6 +104,8 @@ public:
         boost::optional<std::uint64_t> const& content_length_,
         error_code& ec)
     {
+        // The real implementation clears out the error code in basic_string_body::reader::init
+        ec = {};
         ++got_on_body;
         got_content_length =
             static_cast<bool>(content_length_);


### PR DESCRIPTION
The missing error check leads to completely ignoring the body limit,
as the body limit is compared to the "Content-Length" header inside
the "finish_header" method.

This is my first pull request to beast, or boost in general. Please let me 
know if it works for you, or if you prefer me opening an issue instead.
We found this issue as a regression when we wanted to upgrade from 
Boost 1.72.0 to 1.75.0