### PR TITLE
Set reserved bytes to zero

### DIFF
--- a/include/boost/beast/websocket/impl/write.hpp
+++ b/include/boost/beast/websocket/impl/write.hpp
@@ -85,14 +85,8 @@ public:
 
         // Set up the outgoing frame header
         if(! impl.wr_cont)
-        {
             impl.begin_msg();
-            fh_.rsv1 = impl.wr_compress;
-        }
-        else
-        {
-            fh_.rsv1 = false;
-        }
+        fh_.rsv1 = false;
         fh_.rsv2 = false;
         fh_.rsv3 = false;
         fh_.op = impl.wr_cont ?
@@ -621,14 +615,8 @@ write_some(bool fin,
         return bytes_transferred;
     detail::frame_header fh;
     if(! impl.wr_cont)
-    {
         impl.begin_msg();
-        fh.rsv1 = impl.wr_compress;
-    }
-    else
-    {
-        fh.rsv1 = false;
-    }
+    fh.rsv1 = false;
     fh.rsv2 = false;
     fh.rsv3 = false;
     fh.op = impl.wr_cont ?


### PR DESCRIPTION
Hello, first of all I would like to thank you very much for developing and maintaining beast - it has been very useful for me for a couple years now.

Recently I've been trying to add compression to a websocket server implemented with beast through the `websocket::permessage_deflate` option. The problem is that beast assigns the first reserved bit to 1, which is not compatible with most client libraries, such as [System.Net.WebSockets](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.WebSockets/src/Resources/Strings.resx#L118) in .NET, which throws `The WebSocket received a frame with one or more reserved bits set` upon receiving the first compressed message.

This exception appears to agree with [section 5.2 of RFC6455](https://tools.ietf.org/html/rfc6455#section-5.2):

>    RSV1, RSV2, RSV3:  1 bit each
> 
>       MUST be 0 unless an extension is negotiated that defines meanings
>       for non-zero values.  If a nonzero value is received and none of
>       the negotiated extensions defines the meaning of such a nonzero
>       value, the receiving endpoint MUST _Fail the WebSocket
>       Connection_.

If I simply set `rsv1` to zero then the C# client can process the incoming deflated messages without any issue. I believe that this should be the default behavior in boost, which is why I am submitting this pull request.

In order for me to better understand why the code was implemented in this way, and to prime the discussion on this pull request, I would like to ask you the following questions.

1. What was the rationale for setting the value of `rsv1` to 0 in case of uncompressed and 1 in case of a compressed stream?

2. RFC6455 says that `rsv1` "MUST be 0 unless an extension is negotiated that defines meanings for non-zero values". Does beast implicitly negotiate such an extension; and if so, what is the nature of this extension?

3. Is there a better way to adhere to the default requirement of setting `rsv1` to 0 to be compatible with client implementations; say perhaps by introducing a new option in [boost/beast/websocket/option.hpp](https://github.com/boostorg/beast/blob/develop/include/boost/beast/websocket/option.hpp)?