### PR TITLE
Add missing header from stream_state header

### DIFF
--- a/include/boost/beast/_experimental/test/detail/stream_state.hpp
+++ b/include/boost/beast/_experimental/test/detail/stream_state.hpp
@@ -13,6 +13,7 @@
 
 #include <boost/asio/any_io_executor.hpp>
 #include <boost/beast/core/detail/service_base.hpp>
+#include <boost/smart_ptr/make_shared.hpp>
 #include <boost/smart_ptr/weak_ptr.hpp>
 
 #include <condition_variable>


### PR DESCRIPTION
The stream_service class in stream_state makes use of
boost::make_shared so ensure the header is included.

This is required to include <beast/test/stream.hpp> from thirdparty
code that hasn't included the make_shared header already.