### PR TITLE
Update GitHub Actions CI file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,22 @@ jobs:
 # minimum requirement is gcc 4.8
           - toolset: gcc-4.8
             cxxstd: "11"
-            os: ubuntu-16.04
+            os: ubuntu-20.04
+            container: ubuntu:16.04
             install: g++-4.8
-            supported: true
+            supported: false
 # gcc 4.9 not supported by beast
 # It dies with ICE when compiling
           - toolset: gcc-5
             cxxstd: "11,14,1z"
-            os: ubuntu-16.04
+            os: ubuntu-20.04
+            container: ubuntu:16.04
             install: g++-5
             supported: true
           - toolset: gcc-6
             cxxstd: "11,14,1z"
-            os: ubuntu-16.04
+            os: ubuntu-20.04
+            container: ubuntu:16.04
             install: g++-6
             supported: true
           - toolset: gcc-7
@@ -56,37 +59,43 @@ jobs:
           - toolset: clang
             compiler: clang++-3.6
             cxxstd: "11,14"
-            os: ubuntu-16.04
+            os: ubuntu-20.04
+            container: ubuntu:16.04
             install: clang-3.6
             supported: true
           - toolset: clang
             compiler: clang++-3.7
             cxxstd: "11,14"
-            os: ubuntu-16.04
+            os: ubuntu-20.04
+            container: ubuntu:16.04
             install: clang-3.7
             supported: true
           - toolset: clang
             compiler: clang++-3.8
             cxxstd: "11,14"
-            os: ubuntu-16.04
+            os: ubuntu-20.04
+            container: ubuntu:16.04
             install: clang-3.8
             supported: true
           - toolset: clang
             compiler: clang++-3.9
             cxxstd: "11,14"
-            os: ubuntu-16.04
+            os: ubuntu-20.04
+            container: ubuntu:16.04
             install: clang-3.9
             supported: true
           - toolset: clang
             compiler: clang++-4.0
             cxxstd: "11,14"
-            os: ubuntu-16.04
+            os: ubuntu-20.04
+            container: ubuntu:16.04
             install: clang-4.0
             supported: true
           - toolset: clang
             compiler: clang++-5.0
             cxxstd: "11,14,1z"
-            os: ubuntu-16.04
+            os: ubuntu-20.04
+            container: ubuntu:16.04
             install: clang-5.0
             supported: true
           - toolset: clang
@@ -141,16 +150,34 @@ jobs:
             os: macos-10.15
             supported: true
 
-    runs-on: ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
 
     steps:
+      - name: Check if running in container
+        if: matrix.container != ''
+        run: echo "GHA_CONTAINER=${{ matrix.container }}" >> $GITHUB_ENV
+      - name: If running in container, upgrade packages
+        if: matrix.container != ''
+        run: |
+            apt-get -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata && apt-get -o Acquire::Retries=3 install -y sudo software-properties-common wget curl apt-transport-https make apt-file sudo unzip libssl-dev build-essential autotools-dev autoconf automake g++ libc++-helpers python ruby cpio gcc-multilib g++-multilib pkgconf python3 ccache libpython-dev locales
+            sudo apt-add-repository ppa:git-core/ppa
+            sudo apt-get -o Acquire::Retries=3 update && apt-get -o Acquire::Retries=3 -y install git
+            python_version=$(python3 -c 'import sys; print("{0.major}.{0.minor}".format(sys.version_info))')
+            sudo wget https://bootstrap.pypa.io/pip/$python_version/get-pip.py
+            sudo python3 get-pip.py
+            sudo /usr/local/bin/pip install cmake
       - uses: actions/checkout@v2
 
       - name: Install packages
         if: matrix.install
-        run: sudo apt install ${{matrix.install}}
+        run: |
+          for i in {1..3}; do sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test" && break || sleep 2; done
+          sudo apt-get update
+          sudo apt-get install -y ${{matrix.install}}
 
       - name: Setup Boost
+        shell: bash
         run: |
           if [[ $(uname) =~ [Ll]inux ]]; then
             echo Installing locales for ${TRAVIS_OS_NAME} ...
@@ -201,6 +228,7 @@ jobs:
           echo "using ${{matrix.toolset}} : : ${{matrix.compiler}} ;" >> ~/user-config.jam
 
       - name: Run tests
+        shell: bash
         run: |
           cd ../boost-root
           if [[ "${{matrix.supported}}" != "true" ]] ; then


### PR DESCRIPTION
The Ubuntu 16.04 environment is scheduled to be removed from GitHub Actions in September 2021. Migrating those jobs to Docker containers or Ubuntu 18.04.

One small error appears on gcc-4.8.   In order for the tests to display "passing", I have set "supported: false" on gcc-4.8.    If you could review that error, and possibly fix it, then the job could be re-enabled. 