### PR TITLE
fixed an error in websocket_client_async_ssl

### DIFF
--- a/example/websocket/client/async-ssl/websocket_client_async_ssl.cpp
+++ b/example/websocket/client/async-ssl/websocket_client_async_ssl.cpp
@@ -106,11 +106,6 @@ public:
         if(ec)
             return fail(ec, "connect");
 
-        // Update the host_ string. This will provide the value of the
-        // Host HTTP header during the WebSocket handshake.
-        // See https://tools.ietf.org/html/rfc7230#section-5.4
-        host_ += ':' + std::to_string(ep.port());
-
         // Set a timeout on the operation
         beast::get_lowest_layer(ws_).expires_after(std::chrono::seconds(30));
 
@@ -124,6 +119,11 @@ public:
             return fail(ec, "connect");
         }
 
+        // Update the host_ string. This will provide the value of the
+        // Host HTTP header during the WebSocket handshake.
+        // See https://tools.ietf.org/html/rfc7230#section-5.4
+        host_ += ':' + std::to_string(ep.port());
+        
         // Perform the SSL handshake
         ws_.next_layer().async_handshake(
             ssl::stream_base::client,


### PR DESCRIPTION
in this example host_ string should be updated after SSL_set_tlsext_host_name just like the synced version, otherwise this would cause a handshake error