### PR TITLE
[Http examples]Avoid infinite loop when accept is failing due to port already in use

### DIFF
--- a/example/http/server/async-ssl/http_server_async_ssl.cpp
+++ b/example/http/server/async-ssl/http_server_async_ssl.cpp
@@ -500,6 +500,7 @@ private:
         if(ec)
         {
             fail(ec, "accept");
+            return; // To avoid infinite loop
         }
         else
         {

--- a/example/http/server/async/http_server_async.cpp
+++ b/example/http/server/async/http_server_async.cpp
@@ -434,6 +434,7 @@ private:
         if(ec)
         {
             fail(ec, "accept");
+            return; // To avoid infinite loop
         }
         else
         {


### PR DESCRIPTION
When the port is already in use, the http server examples end up in an infinite loop and keep printing this:

```
accept: Invalid argument
```

To avoid this, we should call return if the accept fails.