### PR TITLE
Allow test::stream to be used with nortti

### DIFF
--- a/include/boost/beast/_experimental/test/stream.hpp
+++ b/include/boost/beast/_experimental/test/stream.hpp
@@ -214,7 +214,7 @@ public:
     : in_(std::move(other.in_))
     , out_(std::move(other.out_))
     {
-        assert(in_->exec.target_type() == typeid(Executor2));
+        BOOST_ASSERT(in_->exec.template target<Executor2>() != nullptr);
         in_->exec = executor_type(*in_->exec.template target<Executor2>());
     }
 


### PR DESCRIPTION
Currently, the test stream code doesn't compile when both debug builds
(namely assertions) are enabled along with disabling rtti.  The current
code directly uses type_id(), which isn't available without rtti.  A
quick search through the asio codebase came up with a couple possible
solutions.  The first is here:
https://github.com/boostorg/asio/blob/97d8a5686e0eed8e53b77f3c225c328a812ac833/include/boost/asio/detail/handler_work.hpp#L225

Which essentially wraps the check in an

This is possible, but seems like it would lose the value of the
assertion.

The second possible solution is here:
https://github.com/boostorg/asio/blob/c77f3b603bf2cd180945184a664c6a05d3bebd3b/include/boost/asio/impl/executor.hpp#L282

It seems that asio::executor has created its own template-based type_id
class that is able to switch on BOOST_ASIO_NO_TYPEID, and fallback to a
void* for type_id_result_type.
https://github.com/boostorg/asio/blob/c77f3b603bf2cd180945184a664c6a05d3bebd3b/include/boost/asio/executor.hpp#L271

This patch currently opts for the second solution, pulling in
executor.hpp, and uses its implementation.  This solves the error, and
allows the test stream to compile with -fnortti set.  Given my limited
knowledge of executors, it's not clear if putting a hard dependency on
executor.hpp in beast is desired or recommended here.

Signed-off-by: Ed Tanous <ed@tanous.net>