### PR TITLE
Version 321

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Version XXX:
 
+* Remove test framework's dependency on RTTI.
 * Fix CVE-2016-9840 in zlib implementation.
 * Fix TLS SNI handling in websocket_client_async_ssl example.
 * Fix reuse of sliding window in WebSocket permessage_deflate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version XXX:
+
+* Move library-specific docca configuration to Beast.
+* Remove dependency on RTTI in `test::stream`.
+
+--------------------------------------------------------------------------------
+
 Version 320:
 
 * Fix missing includes in `stream_state`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Version XXX:
 
+* Fix CVE-2016-9840 in zlib implementation.
 * Fix TLS SNI handling in websocket_client_async_ssl example.
 * Fix reuse of sliding window in WebSocket permessage_deflate.
 * Fix accept error handling in http_server_async example.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Version XXX:
 
+* Fix reuse of sliding window in WebSocket permessage_deflate.
 * Fix accept error handling in http_server_async example.
 * Move library-specific docca configuration to Beast.
 * Remove dependency on RTTI in `test::stream`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Version XXX:
 
+* Fix TLS SNI handling in websocket_client_async_ssl example.
 * Fix reuse of sliding window in WebSocket permessage_deflate.
 * Fix accept error handling in http_server_async example.
 * Move library-specific docca configuration to Beast.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version XXX:
+Version 321:
 
 * Remove test framework's dependency on RTTI.
 * Fix CVE-2016-9840 in zlib implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Version XXX:
 
+* Fix accept error handling in http_server_async example.
 * Move library-specific docca configuration to Beast.
 * Remove dependency on RTTI in `test::stream`.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ endfunction()
 #
 #-------------------------------------------------------------------------------
 
-project (Beast VERSION 320)
+project (Beast VERSION 321)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)

--- a/doc/qbk/release_notes.qbk
+++ b/doc/qbk/release_notes.qbk
@@ -11,6 +11,24 @@
 
 [/-----------------------------------------------------------------------------]
 
+[heading Boost 1.78]
+
+[*Fixes]
+
+* Fix CVE-2016-9840 in zlib implementation.
+* Fix TLS SNI handling in websocket_client_async_ssl example.
+* [Issue 2313] Fix reuse of sliding window in WebSocket permessage_deflate.
+* Fix accept error handling in http_server_async example.
+
+[*Miscellaneous]
+
+* Remove test framework's dependency on RTTI.
+* Move library-specific docca configuration to Beast.
+* Remove dependency on RTTI in `test::stream`.
+* Fix missing includes in test headers.
+
+
+
 [heading Boost 1.77]
 
 [*Fixes]

--- a/doc/xsl/custom-overrides.xsl
+++ b/doc/xsl/custom-overrides.xsl
@@ -15,4 +15,41 @@
   <xsl:template mode="convenience-header" match="@file[contains(., 'boost/beast/zlib')]"     >zlib.hpp</xsl:template>
   <xsl:template mode="convenience-header" match="@file"/>
 
+  <xsl:variable name="emphasized-template-parameter-types" select="
+    'Allocator',
+    'AsyncStream',
+    'AsyncReadStream',
+    'AsyncWriteStream',
+    'Body',
+    'BufferSequence',
+    'BufferSequence',  (: TODO: Was this intended to be 'BufferSequence_' ?? :)
+    'CompletionCondition',
+    'CompletionHandler',
+    'CompletionToken',
+    'ConnectCondition',
+    'ConnectHandler',
+    'ConstBufferSequence',
+    'DynamicBuffer',
+    'EndpointSequence',
+    'ExecutionContext',
+    'Executor',
+    'Executor_',
+    'Executor1',
+    'Executor2',
+    'Fields',
+    'Handler',
+    'Handler_',
+    'IteratorConnectHandler',
+    'MutableBufferSequence',
+    'Protocol',
+    'RangeConnectHandler',
+    'RatePolicy',
+    'ReadHandler',
+    'Stream',
+    'SyncStream',
+    'SyncReadStream',
+    'SyncWriteStream',
+    'WriteHandler'
+  "/>
+
 </xsl:stylesheet>

--- a/example/http/server/async-ssl/http_server_async_ssl.cpp
+++ b/example/http/server/async-ssl/http_server_async_ssl.cpp
@@ -500,6 +500,7 @@ private:
         if(ec)
         {
             fail(ec, "accept");
+            return; // To avoid infinite loop
         }
         else
         {

--- a/example/http/server/async/http_server_async.cpp
+++ b/example/http/server/async/http_server_async.cpp
@@ -434,6 +434,7 @@ private:
         if(ec)
         {
             fail(ec, "accept");
+            return; // To avoid infinite loop
         }
         else
         {

--- a/example/websocket/client/async-ssl/websocket_client_async_ssl.cpp
+++ b/example/websocket/client/async-ssl/websocket_client_async_ssl.cpp
@@ -106,11 +106,6 @@ public:
         if(ec)
             return fail(ec, "connect");
 
-        // Update the host_ string. This will provide the value of the
-        // Host HTTP header during the WebSocket handshake.
-        // See https://tools.ietf.org/html/rfc7230#section-5.4
-        host_ += ':' + std::to_string(ep.port());
-
         // Set a timeout on the operation
         beast::get_lowest_layer(ws_).expires_after(std::chrono::seconds(30));
 
@@ -124,6 +119,11 @@ public:
             return fail(ec, "connect");
         }
 
+        // Update the host_ string. This will provide the value of the
+        // Host HTTP header during the WebSocket handshake.
+        // See https://tools.ietf.org/html/rfc7230#section-5.4
+        host_ += ':' + std::to_string(ep.port());
+        
         // Perform the SSL handshake
         ws_.next_layer().async_handshake(
             ssl::stream_base::client,

--- a/include/boost/beast/_experimental/test/stream.hpp
+++ b/include/boost/beast/_experimental/test/stream.hpp
@@ -214,7 +214,7 @@ public:
     : in_(std::move(other.in_))
     , out_(std::move(other.out_))
     {
-        assert(in_->exec.target_type() == typeid(Executor2));
+        BOOST_ASSERT(in_->exec.template target<Executor2>() != nullptr);
         in_->exec = executor_type(*in_->exec.template target<Executor2>());
     }
 

--- a/include/boost/beast/_experimental/unit_test/suite_list.hpp
+++ b/include/boost/beast/_experimental/unit_test/suite_list.hpp
@@ -13,6 +13,8 @@
 #include <boost/beast/_experimental/unit_test/suite_info.hpp>
 #include <boost/beast/_experimental/unit_test/detail/const_container.hpp>
 #include <boost/assert.hpp>
+#include <boost/type_index.hpp>
+#include <boost/functional/hash.hpp>
 #include <typeindex>
 #include <set>
 #include <unordered_set>
@@ -28,7 +30,9 @@ class suite_list
 private:
 #ifndef NDEBUG
     std::unordered_set<std::string> names_;
-    std::unordered_set<std::type_index> classes_;
+
+    using type_index = boost::typeindex::type_index;
+    std::unordered_set<type_index, boost::hash<type_index>> classes_;
 #endif
 
 public:
@@ -65,7 +69,7 @@ suite_list::insert(
 
     {
         auto const result(classes_.insert(
-            std::type_index(typeid(Suite))));
+            boost::typeindex::type_id<Suite>()));
         BOOST_ASSERT(result.second); // Duplicate type
     }
 #endif

--- a/include/boost/beast/version.hpp
+++ b/include/boost/beast/version.hpp
@@ -20,7 +20,7 @@
     This is a simple integer that is incremented by one every
     time a set of code changes is merged to the develop branch.
 */
-#define BOOST_BEAST_VERSION 320
+#define BOOST_BEAST_VERSION 321
 
 #define BOOST_BEAST_VERSION_STRING "Boost.Beast/" BOOST_STRINGIZE(BOOST_BEAST_VERSION)
 

--- a/include/boost/beast/websocket/detail/impl_base.hpp
+++ b/include/boost/beast/websocket/detail/impl_base.hpp
@@ -137,7 +137,7 @@ struct impl_base<true>
                     return false;
                 if(zs.avail_out >= 6)
                 {
-                    zo.write(zs, zlib::Flush::full, ec);
+                    zo.write(zs, zlib::Flush::sync, ec);
                     BOOST_ASSERT(! ec);
                     // remove flush marker
                     zs.total_out -= 4;


### PR DESCRIPTION
* Remove test framework's dependency on RTTI.
* Fix CVE-2016-9840 in zlib implementation.
* Fix TLS SNI handling in websocket_client_async_ssl example.
* Fix reuse of sliding window in WebSocket permessage_deflate.
* Fix accept error handling in http_server_async example.
* Move library-specific docca configuration to Beast.
* Remove dependency on RTTI in `test::stream`.
