### PR TITLE
Add missing include for file_body test

### DIFF
--- a/test/beast/http/file_body.cpp
+++ b/test/beast/http/file_body.cpp
@@ -20,6 +20,7 @@
 #include <boost/beast/_experimental/unit_test/suite.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/asio/error.hpp>
+#include <fstream>
 
 namespace boost {
 namespace beast {


### PR DESCRIPTION
I tried running the tests on Linux and macOS. The `file_body` test did not compile on either of those platforms. Adding the `fstream` include fixes it.