### PR TITLE
Fix #2445 Remove mention of ptree

### DIFF
--- a/doc/qbk/04_http/09_custom_body.qbk
+++ b/doc/qbk/04_http/09_custom_body.qbk
@@ -73,16 +73,15 @@ something that is not a container for body octets, such as a
 [@boost:/libs/filesystem/doc/reference.html#class-path `boost::filesystem::path`].
 Or, a more structured container may be chosen. This declares a body's
 value type as a JSON tree structure produced from a
-[@boost:/doc/html/property_tree/parsers.html#property_tree.parsers.json_parser `boost::property_tree::json_parser`]:
+[@boost:/doc/html/json/input_output.html#json.input_output.parsing.streaming_parser `boost::json::stream_parser`]:
 ```
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include <boost/json/stream_parser.hpp>
 
 struct Body
 {
-    using value_type = boost::property_tree::ptree;
+    using value_type = boost::json::value;
 
-    class reader
+    class reader;
     class writer;
 };
 ```


### PR DESCRIPTION
Actually, one mention still remains, which I cannot remove [unless
DigiCert changes their G4 Trusted Root CA certificate](https://github.com/boostorg/beast/blob/develop/example/common/root_certificates.hpp#L1134:~:text=pTREE)...