### PR TITLE
Exclude unused zlib sources from build

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,27 +23,27 @@ endif()
 set (ZLIB_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/crc32.h
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/deflate.h
-    ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/gzguts.h
+   #${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/gzguts.h
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/inffast.h
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/inffixed.h
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/inflate.h
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/inftrees.h
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/trees.h
-    ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/zconf.h
+   #${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/zconf.h
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/zlib.h
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/zutil.h
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/adler32.c
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/compress.c
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/crc32.c
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/deflate.c
-    ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/gzclose.c
-    ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/gzlib.c
-    ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/gzread.c
-    ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/gzwrite.c
-    ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/inflate.c
+   #${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/gzclose.c
+   #${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/gzlib.c
+   #${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/gzread.c
+   #${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/gzwrite.c
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/infback.c
-    ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/inftrees.c
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/inffast.c
+    ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/inflate.c
+    ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/inftrees.c
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/trees.c
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/uncompr.c
     ${CMAKE_CURRENT_LIST_DIR}/extern/zlib-1.2.12/zutil.c

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -44,14 +44,14 @@ path-constant ZLIB_SOURCES :
     extern/zlib-1.2.12/compress.c
     extern/zlib-1.2.12/crc32.c
     extern/zlib-1.2.12/deflate.c
-    extern/zlib-1.2.12/gzclose.c
-    extern/zlib-1.2.12/gzlib.c
-    extern/zlib-1.2.12/gzread.c
-    extern/zlib-1.2.12/gzwrite.c
-    extern/zlib-1.2.12/inflate.c
+   #extern/zlib-1.2.12/gzclose.c
+   #extern/zlib-1.2.12/gzlib.c
+   #extern/zlib-1.2.12/gzread.c
+   #extern/zlib-1.2.12/gzwrite.c
     extern/zlib-1.2.12/infback.c
-    extern/zlib-1.2.12/inftrees.c
     extern/zlib-1.2.12/inffast.c
+    extern/zlib-1.2.12/inflate.c
+    extern/zlib-1.2.12/inftrees.c
     extern/zlib-1.2.12/trees.c
     extern/zlib-1.2.12/uncompr.c
     extern/zlib-1.2.12/zutil.c


### PR DESCRIPTION
Recent update zlib-1.2.11->1.2.12 included included a number of source
files in the Bjam/CMake changes that were previously excluded.

This leads to a bunch of C99 violation warnings (implicit function
declarations).

This commit excludes the culprits again, but leaves them actively
commented-out so the same mistake is less likely to happen by accident
in the future.