### PR TITLE
Remove unnecessary constant_time_size

### DIFF
--- a/include/boost/beast/core/impl/multi_buffer.hpp
+++ b/include/boost/beast/core/impl/multi_buffer.hpp
@@ -779,7 +779,7 @@ shrink_to_fit()
         };
 
     // partial last buffer
-    if(list_.size() > 1 && out_ != list_.end())
+    if(out_ != list_.begin() && out_ != list_.end())
     {
         BOOST_ASSERT(out_ ==
             list_.iterator_to(list_.back()));
@@ -815,7 +815,8 @@ shrink_to_fit()
         }
         else
         {
-            BOOST_ASSERT(list_.size() == 1);
+            BOOST_ASSERT(out_ ==
+                list_.iterator_to(list_.back()));
             BOOST_ASSERT(out_pos_ > in_pos_);
             auto const n = out_pos_ - in_pos_;
             auto& e = alloc(n);

--- a/include/boost/beast/core/multi_buffer.hpp
+++ b/include/boost/beast/core/multi_buffer.hpp
@@ -127,7 +127,7 @@ class basic_multi_buffer
         beast::detail::allocator_traits<rebind_type>;
 
     using list_type = typename boost::intrusive::make_list<
-        element, boost::intrusive::constant_time_size<true>>::type;
+        element, boost::intrusive::constant_time_size<false>>::type;
 
     using iter = typename list_type::iterator;
 

--- a/include/boost/beast/http/fields.hpp
+++ b/include/boost/beast/http/fields.hpp
@@ -190,7 +190,7 @@ private:
 
     using set_t = typename boost::intrusive::make_multiset<
         element,
-        boost::intrusive::constant_time_size<true>,
+        boost::intrusive::constant_time_size<false>,
         boost::intrusive::compare<key_compare>
             >::type;
 


### PR DESCRIPTION
http::basic_fields::set_t::size() is unused
core::multi_buffer::list_type::size() is only compared to 1 (in shrink_to_fit()); compare iterators instead.