### PR TITLE
Add request.prepare_payload() to http_client_sync example

### DIFF
--- a/example/http/client/sync/http_client_sync.cpp
+++ b/example/http/client/sync/http_client_sync.cpp
@@ -66,6 +66,7 @@ int main(int argc, char** argv)
         http::request<http::string_body> req{http::verb::get, target, version};
         req.set(http::field::host, host);
         req.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
+        req.prepare_payload();
 
         // Send the HTTP request to the remote host
         http::write(stream, req);


### PR DESCRIPTION
Even though the string_body is empty it should call prepare_payload to avoid an easy mistake for anyone reusing the example,

This is identical in the other client examples as well. If acceptet, this PR could be amended, or I can make similar PRs.