### PR TITLE
basic_fields handles initializer-lists.

### DIFF
--- a/include/boost/beast/http/fields.hpp
+++ b/include/boost/beast/http/fields.hpp
@@ -31,6 +31,24 @@ namespace boost {
 namespace beast {
 namespace http {
 
+
+/// A reference to initialize a fields structure from an  initializer list.
+struct element_ref
+{
+  /// Usage as `{http::field::user_agent, "Beast"}`
+  element_ref(field f, string_view value) : f_(f), value_(value) {}
+  /// Usage as `{"User-Agent", "Beast"}`
+  element_ref(string_view key, string_view value) : key_(key), value_(value) {}
+
+ private:
+  field f_;
+  string_view key_;
+  string_view value_;
+
+  template<typename >
+  friend class basic_fields;
+};
+
 /** A container for storing HTTP header fields.
 
     This container is designed to store the field value pairs that make
@@ -214,6 +232,19 @@ public:
 
     /// Constructor.
     basic_fields() = default;
+
+    /** Construct from an initializer list.
+
+       @param elements The values to initialize the basic_fields from.
+     */
+    basic_fields(std::initializer_list<element_ref> elements);
+
+    /** Construct from an initializer list.
+       @param elements The values to initialize the basic_fields from.
+       @param alloc The allocator to use.
+     */
+    basic_fields(std::initializer_list<element_ref> elements,
+                 Allocator const &alloc);
 
     /** Constructor.
 

--- a/include/boost/beast/http/impl/fields.hpp
+++ b/include/boost/beast/http/impl/fields.hpp
@@ -394,6 +394,17 @@ basic_fields(basic_fields&& other, Allocator const& alloc)
     }
 }
 
+
+template<class Allocator>
+basic_fields<Allocator>::
+basic_fields(basic_fields const& other,
+             Allocator const& alloc)
+    : boost::empty_value<Allocator>(boost::empty_init_t(), alloc)
+{
+  copy_all(other);
+}
+
+
 template<class Allocator>
 basic_fields<Allocator>::
 basic_fields(basic_fields const& other)
@@ -405,11 +416,27 @@ basic_fields(basic_fields const& other)
 
 template<class Allocator>
 basic_fields<Allocator>::
-basic_fields(basic_fields const& other,
+basic_fields(std::initializer_list<element_ref> elements)
+{
+    for (const auto & elem : elements)
+        if (elem.key_.empty())
+            insert(elem.f_, elem.value_);
+        else
+            insert(elem.key_, elem.value_);
+}
+
+
+template<class Allocator>
+basic_fields<Allocator>::
+basic_fields(std::initializer_list<element_ref> elements,
         Allocator const& alloc)
     : boost::empty_value<Allocator>(boost::empty_init_t(), alloc)
 {
-    copy_all(other);
+    for (const auto & elem : elements)
+        if (elem.key_.empty())
+            insert(elem.f_, elem.value_);
+        else
+            insert(elem.key_, elem.value_);
 }
 
 template<class Allocator>

--- a/test/beast/http/fields.cpp
+++ b/test/beast/http/fields.cpp
@@ -149,6 +149,33 @@ public:
                 BEAST_EXPECT(f.get_allocator() == a1);
                 BEAST_EXPECT(f.get_allocator() != unequal_t{});
             }
+            {
+                fields f = {
+                    {"X-Header", "test"},
+                    {http::field::user_agent, "test-agent"},
+                    {"X-Header2", "tst"}
+                };
+
+                BEAST_EXPECT(std::distance(f.begin(), f.end()) == 3);
+                BEAST_EXPECT(f["X-Header"] == "test");
+                BEAST_EXPECT(f[http::field::user_agent] == "test-agent");
+                BEAST_EXPECT(f["X-Header2"] == "tst");
+
+            }
+            {
+
+                fields f = {{
+                    {"X-Header", "test"},
+                    {http::field::user_agent, "test-agent"},
+                    {"X-Header2", "tst"}
+                }, std::allocator<void>()};
+
+                BEAST_EXPECT(std::distance(f.begin(), f.end()) == 3);
+                BEAST_EXPECT(f["X-Header"] == "test");
+                BEAST_EXPECT(f[http::field::user_agent] == "test-agent");
+                BEAST_EXPECT(f["X-Header2"] == "tst");
+
+            }
         }
 
         // move construction


### PR DESCRIPTION
This is very convenient for my requests library that (for now) uses the fields structure directly.