### PR TITLE
typo in the json client comment

### DIFF
--- a/example/http/client/body/json_client.cpp
+++ b/example/http/client/body/json_client.cpp
@@ -30,7 +30,7 @@ int main(int argc, char ** argv)
     // Make the connection on the IP address we get from a lookup
     stream.connect(results);
 
-    // Set up an HTTP GET request message
+    // Set up an HTTP POST request message
     http::request<json_body> req{http::verb::post, target, 11};
     req.set(http::field::host, host);
     req.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);


### PR DESCRIPTION
Tiny typo in example comments but confused a search I was doing. Enjoying learning beast, thanks.