### PR TITLE
Avoid warnings about unused variable

### DIFF
--- a/include/boost/beast/websocket/detail/impl_base.hpp
+++ b/include/boost/beast/websocket/detail/impl_base.hpp
@@ -452,7 +452,7 @@ struct impl_base<false>
         return false;
     }
 
-    bool should_compress(std::size_t n_bytes) const
+    bool should_compress(std::size_t) const
     {
         return false;
     }


### PR DESCRIPTION
A fix for #2574.

```
C:\PathTo\boost\libs\beast\include\boost/beast/websocket/detail/impl_base.hpp(455,38): error C2220: the following warning is treated as an error
C:\PathTo\boost\libs\beast\include\boost/beast/websocket/detail/impl_base.hpp(455,38): warning C4100: 'n_bytes': unreferenced formal parameter
```