### PR TITLE
Switched self-posting to the io-object's executor.

### DIFF
--- a/include/boost/beast/core/async_base.hpp
+++ b/include/boost/beast/core/async_base.hpp
@@ -389,11 +389,13 @@ public:
         if(! is_continuation)
         {
             auto const ex = get_executor();
-            net::post(net::bind_executor(
-                ex,
-                beast::bind_front_handler(
-                    std::move(h_),
-                    std::forward<Args>(args)...)));
+            net::post(
+                wg1_.get_executor(),
+                net::bind_executor(
+                  ex,
+                  beast::bind_front_handler(
+                      std::move(h_),
+                      std::forward<Args>(args)...)));
             wg1_.reset();
         }
         else

--- a/include/boost/beast/http/impl/read.hpp
+++ b/include/boost/beast/http/impl/read.hpp
@@ -245,6 +245,7 @@ public:
                         "http::async_read_some"));
 
                     net::post(
+                        s_.get_executor(),
                         beast::bind_front_handler(std::move(self), ec));
                 }
             }
@@ -284,7 +285,7 @@ public:
                         __FILE__, __LINE__,
                         "http::async_read"));
 
-                    net::post(std::move(self));
+                    net::post(s_.get_executor(), std::move(self));
                 }
             }
             else

--- a/include/boost/beast/websocket/impl/close.hpp
+++ b/include/boost/beast/websocket/impl/close.hpp
@@ -106,7 +106,7 @@ public:
                         __FILE__, __LINE__,
                         "websocket::async_close"));
 
-                    net::post(std::move(*this));
+                    net::post(sp->stream().get_executor(), std::move(*this));
                 }
                 BOOST_ASSERT(impl.wr_block.is_locked(this));
             }
@@ -167,7 +167,7 @@ public:
                         __FILE__, __LINE__,
                         "websocket::async_close"));
 
-                    net::post(std::move(*this));
+                    net::post(sp->stream().get_executor(), std::move(*this));
                 }
                 BOOST_ASSERT(impl.rd_block.is_locked(this));
                 if(impl.check_stop_now(ec))

--- a/include/boost/beast/websocket/impl/ping.hpp
+++ b/include/boost/beast/websocket/impl/ping.hpp
@@ -99,7 +99,7 @@ public:
                         __FILE__, __LINE__,
                         "websocket::async_ping"));
 
-                    net::post(std::move(*this));
+                    net::post(sp->stream().get_executor(), std::move(*this));
                 }
                 BOOST_ASSERT(impl.wr_block.is_locked(this));
             }
@@ -208,8 +208,7 @@ public:
                         __FILE__, __LINE__,
                         "websocket::async_ping"));
 
-                    net::post(
-                        this->get_executor(), std::move(*this));
+                    net::post(sp->stream().get_executor(), std::move(*this));
                 }
                 BOOST_ASSERT(impl.wr_block.is_locked(this));
             }

--- a/include/boost/beast/websocket/impl/read.hpp
+++ b/include/boost/beast/websocket/impl/read.hpp
@@ -122,7 +122,7 @@ public:
                         __FILE__, __LINE__,
                         "websocket::async_read_some"));
 
-                    net::post(std::move(*this));
+                    net::post(sp->stream().get_executor(), std::move(*this));
                 }
                 BOOST_ASSERT(impl.rd_block.is_locked(this));
 
@@ -238,7 +238,7 @@ public:
                                         __FILE__, __LINE__,
                                         "websocket::async_read_some"));
 
-                                    net::post(std::move(*this));
+                                    net::post(sp->stream().get_executor(), std::move(*this));
                                 }
                                 BOOST_ASSERT(cont);
                                 // VFALCO call check_stop_now() here?
@@ -291,7 +291,7 @@ public:
                                     __FILE__, __LINE__,
                                     "websocket::async_read_some"));
 
-                                net::post(std::move(*this));
+                                net::post(sp->stream().get_executor(), std::move(*this));
                             }
                             BOOST_ASSERT(impl.wr_block.is_locked(this));
                             if(impl.check_stop_now(ec))
@@ -335,7 +335,7 @@ public:
                                         __FILE__, __LINE__,
                                         "websocket::async_read_some"));
 
-                                    net::post(std::move(*this));
+                                    net::post(sp->stream().get_executor(), std::move(*this));
                                 }
                                 BOOST_ASSERT(cont);
                             }
@@ -366,7 +366,7 @@ public:
                                         __FILE__, __LINE__,
                                         "websocket::async_read_some"));
 
-                                    net::post(std::move(*this));
+                                    net::post(sp->stream().get_executor(), std::move(*this));
                                 }
                                 BOOST_ASSERT(cont);
                             }
@@ -648,7 +648,7 @@ public:
                         __FILE__, __LINE__,
                         "websocket::async_read_some"));
 
-                    net::post(std::move(*this));
+                    net::post(sp->stream().get_executor(), std::move(*this));
                 }
                 BOOST_ASSERT(impl.wr_block.is_locked(this));
                 if(impl.check_stop_now(ec))

--- a/include/boost/beast/websocket/impl/teardown.hpp
+++ b/include/boost/beast/websocket/impl/teardown.hpp
@@ -128,7 +128,7 @@ public:
                         "websocket::tcp::async_teardown"
                         ));
 
-                    net::post(bind_front_handler(
+                    net::post(s_.get_executor(), bind_front_handler(
                         std::move(*this), ec));
                 }
             }

--- a/include/boost/beast/websocket/impl/write.hpp
+++ b/include/boost/beast/websocket/impl/write.hpp
@@ -199,7 +199,7 @@ operator()(
                         "websocket::async_write_some"
                     ));
 
-                net::post(std::move(*this));
+                net::post(sp->stream().get_executor(), std::move(*this));
             }
             BOOST_ASSERT(impl.wr_block.is_locked(this));
         }

--- a/test/beast/core/async_base.cpp
+++ b/test/beast/core/async_base.cpp
@@ -596,7 +596,7 @@ public:
                     ioc1.get_executor());
             op->complete(false);
             delete op;
-            BEAST_EXPECT(ioc1.run() == 0);
+            BEAST_EXPECT(ioc1.run() == 1);
             BEAST_EXPECT(ioc2.run() == 1);
         }
         {

--- a/test/beast/http/CMakeLists.txt
+++ b/test/beast/http/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable (tests-beast-http
     ${BOOST_BEAST_FILES}
     ${EXTRAS_FILES}
     Jamfile
+    any_completion_handler.cpp
     message_fuzz.hpp
     test_parser.hpp
     basic_dynamic_body.cpp

--- a/test/beast/http/Jamfile
+++ b/test/beast/http/Jamfile
@@ -8,6 +8,7 @@
 #
 
 local SOURCES =
+    any_completion_handler.cpp
     basic_dynamic_body.cpp
     basic_file_body.cpp
     basic_parser.cpp

--- a/test/beast/http/any_completion_handler.cpp
+++ b/test/beast/http/any_completion_handler.cpp
@@ -1,0 +1,34 @@
+//
+// Copyright (c) 2022 Klemens Morgenstern (klemens.morgenstern@gmx.net)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/asio/any_completion_handler.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/beast/http.hpp>
+
+using namespace boost;
+namespace http = boost::beast::http;
+
+// just compile this.
+void test_any_comletion_handler_for_http(
+    asio::ip::tcp::socket & stream,
+    beast::flat_static_buffer_base & buf,
+    http::basic_parser<true> & parser,
+    http::serializer<true, http::empty_body> & ser,
+    http::message<false, http::empty_body> & msg,
+    asio::any_completion_handler<void(system::error_code, std::size_t)> handler)
+{
+  http::async_read(stream, buf, parser, std::move(handler));
+  http::async_read(stream, buf, msg, std::move(handler));
+  http::async_read_some(stream, buf, parser, std::move(handler));
+  http::async_read_header(stream, buf, parser, std::move(handler));
+
+  http::async_write(stream, ser, std::move(handler));
+  http::async_write(stream, msg, std::move(handler));
+  http::async_write_header(stream, ser, std::move(handler));
+  http::async_write_some(stream, ser, std::move(handler));
+}
+

--- a/test/beast/websocket/CMakeLists.txt
+++ b/test/beast/websocket/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable (tests-beast-websocket
     _detail_impl_base.cpp
     test.hpp
     _detail_prng.cpp
+    any_completion_handler.cpp
     accept.cpp
     cancel.cpp
     close.cpp

--- a/test/beast/websocket/Jamfile
+++ b/test/beast/websocket/Jamfile
@@ -11,6 +11,7 @@ local SOURCES =
     _detail_decorator.cpp
     _detail_impl_base.cpp
     _detail_prng.cpp
+    any_completion_handler.cpp
     accept.cpp
     cancel.cpp
     close.cpp

--- a/test/beast/websocket/any_completion_handler.cpp
+++ b/test/beast/websocket/any_completion_handler.cpp
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2022 Klemens Morgenstern (klemens.morgenstern@gmx.net)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/asio/any_completion_handler.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/beast/websocket.hpp>
+
+using namespace boost;
+namespace websocket = boost::beast::websocket;
+
+// just compile this.
+void test_any_comletion_handler_for_http(
+    websocket::stream<asio::ip::tcp::socket> & stream,
+    beast::flat_static_buffer_base & buf,
+    beast::http::request<beast::http::empty_body> & req,
+    websocket::response_type & res,
+    asio::any_completion_handler<void(system::error_code, std::size_t)> handler,
+    asio::any_completion_handler<void(system::error_code)> handler2)
+{
+  stream.async_accept(std::move(handler2));
+  stream.async_accept(asio::const_buffer(), std::move(handler2));
+  stream.async_accept(req, std::move(handler2));
+  stream.async_close(websocket::close_code::bad_payload, std::move(handler2));
+
+  stream.async_handshake("", "/", std::move(handler2));
+  stream.async_handshake(res, "", "/", std::move(handler2));
+
+  stream.async_ping(websocket::ping_data{}, std::move(handler2));
+  stream.async_pong(websocket::ping_data{}, std::move(handler2));
+
+  stream.async_read(buf, std::move(handler));
+  stream.async_read_some(buf.data(), std::move(handler));
+
+  stream.async_write(buf.cdata(), std::move(handler));
+  stream.async_write_some(true, buf.cdata(), std::move(handler));
+
+}
+


### PR DESCRIPTION
This is a conceptual change in the recent asio version that is reflected in any_completion_handler.

1.82 change, as it's behaviour changing.