### PR TITLE
C++17 builds on clang-5 are disabled.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
             supported: true
           - toolset: clang
             compiler: clang++-5.0
-            cxxstd: "11,14,1z"
+            cxxstd: "11,14"
             os: ubuntu-22.04
             container: ubuntu:16.04
             install: clang-5.0


### PR DESCRIPTION
The C++17 stdlib used by clang-5 is not compliant, so asio doesn't compile.