### PR TITLE
Fix compatibility with -fno-exceptions

### DIFF
--- a/include/boost/beast/core/impl/basic_stream.hpp
+++ b/include/boost/beast/core/impl/basic_stream.hpp
@@ -149,13 +149,8 @@ close() noexcept
         error_code ec;
         socket.close(ec);
     }
-    try
-    {
-        timer.cancel();
-    }
-    catch(...)
-    {
-    }
+    error_code ec;
+    timer.cancel(ec);
 }
 
 //------------------------------------------------------------------------------

--- a/include/boost/beast/core/impl/buffers_cat.hpp
+++ b/include/boost/beast/core/impl/buffers_cat.hpp
@@ -100,12 +100,8 @@ struct buffers_cat_view_iterator_base
         net::mutable_buffer
         operator*() const
         {
-        #if 1
-            throw std::logic_error("");
-        #else
-            BOOST_BEAST_LOGIC_ERROR_RETURN({},
+            BOOST_BEAST_LOGIC_ERROR(
                 "Dereferencing a one-past-the-end iterator");
-        #endif
         }
 
         operator bool() const noexcept
@@ -192,12 +188,8 @@ private:
         reference
         operator()(mp11::mp_size_t<0>)
         {
-        #if 1
-            throw std::logic_error("");
-        #else
-            BOOST_BEAST_LOGIC_ERROR_RETURN({},
+            BOOST_BEAST_LOGIC_ERROR(
                 "Dereferencing a default-constructed iterator");
-        #endif
         }
 
         template<class I>


### PR DESCRIPTION
When I'm trying to compile a simple C++ code using boost/beast and clang with `-fno-exceptions` I got the following error. This patch is intended to fix these compilation errors.
```
/path/to/include/boost/beast/core/impl/basic_stream.hpp:152:5: error: cannot use 'try' with exceptions disabled
    try

/path/to/include/boost/beast/include/boost/beast/core/impl/buffers_cat.hpp:104:13: error: cannot use 'throw' with exceptions disabled
            throw std::logic_error("");
```