### PR TITLE
Address bind_handler ambiguous overload error when boost/bind/std_placeholders.hpp is included

### DIFF
--- a/include/boost/beast/core/detail/bind_handler.hpp
+++ b/include/boost/beast/core/detail/bind_handler.hpp
@@ -70,8 +70,25 @@ class bind_wrapper
     template<class Arg, class Vals>
     static
     typename std::enable_if<
-        boost::is_placeholder<typename
+        std::is_placeholder<typename
             std::decay<Arg>::type>::value != 0,
+        tuple_element<std::is_placeholder<
+            typename std::decay<Arg>::type>::value - 1,
+        Vals>>::type&&
+    extract(Arg&&, Vals&& vals)
+    {
+        return detail::get<std::is_placeholder<
+            typename std::decay<Arg>::type>::value - 1>(
+                std::forward<Vals>(vals));
+    }
+
+    template<class Arg, class Vals>
+    static
+    typename std::enable_if<
+        boost::is_placeholder<typename
+            std::decay<Arg>::type>::value != 0 &&
+        std::is_placeholder<typename
+            std::decay<Arg>::type>::value == 0,
         tuple_element<boost::is_placeholder<
             typename std::decay<Arg>::type>::value - 1,
         Vals>>::type&&

--- a/include/boost/beast/core/detail/bind_handler.hpp
+++ b/include/boost/beast/core/detail/bind_handler.hpp
@@ -20,6 +20,7 @@
 #include <boost/asio/handler_invoke_hook.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/mp11/integer_sequence.hpp>
+#include <boost/bind/std_placeholders.hpp>
 #include <boost/is_placeholder.hpp>
 #include <functional>
 #include <type_traits>
@@ -64,21 +65,6 @@ class bind_wrapper
     {
         boost::ignore_unused(vals);
         return std::forward<Arg>(arg);
-    }
-
-    template<class Arg, class Vals>
-    static
-    typename std::enable_if<
-        std::is_placeholder<typename
-            std::decay<Arg>::type>::value != 0,
-        tuple_element<std::is_placeholder<
-            typename std::decay<Arg>::type>::value - 1,
-        Vals>>::type&&
-    extract(Arg&&, Vals&& vals)
-    {
-        return detail::get<std::is_placeholder<
-            typename std::decay<Arg>::type>::value - 1>(
-                std::forward<Vals>(vals));
     }
 
     template<class Arg, class Vals>

--- a/test/beast/core/bind_handler.cpp
+++ b/test/beast/core/bind_handler.cpp
@@ -23,6 +23,7 @@
 #include <boost/asio/post.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/bind/placeholders.hpp>
+#include <boost/bind/std_placeholders.hpp>
 #include <boost/core/exchange.hpp>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Previously, the implementation of `bind_handler` made the assumption that the trait `boost::is_placeholder` would be false for types corresponding to values in the `std::placeholders` namespace.

However, boost/bind commit `c85b31e3d200dda2a73cf0027a82c6d8e29066f8`, `Support use of standard placeholders with boost::bind`, added a new header, `boost/bind/std_placeholders.hpp`, which adds specializations to
 `boost::is_placeholder` for `std::placeholders` types.

When this header is included before a use of `boost::bind_handler`, it results in compiler errors like the following, due to an internal helper function having overloads for
`enable_if<boost::is_placeholder...>` and
`enable_if<std::is_placeholder...>`, which were previously assumed to be mutually exclusive, but for which both conditions now are true:

```
../../../boost/beast/core/detail/bind_handler.hpp:126:18: error: call of overloaded 'extract(std::_Placeholder<1>, boost::beast::detail::tuple<int&&>)' is ambiguous
  126 |         h(extract(detail::get<S>(std::move(args)),
      |           ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  127 |             std::forward<ValsTuple>(vals))...);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This header is included in `boost/bind/bind.hpp`, and is transitively included by headers in many boost libraries including:

algorithm
asio
atomic
graph
msm
multi_index
property_tree
ptr_container
python
signals2
test
thread

Making it possible that an include from one of these libraries will randomly cause `bind_handler` to fail to compile.

This change addresses the issue by ensuring that `boost/bind/std_placeholders.hpp` is included in the bind_handler implementation file, and adjusting the SFINAE for the boost::is_placeholder overload so that it triggers only
if std::is_placeholder is false. This approach is necessary over simply removing the std::is_placeholder overload because std_placeholders.hpp might have had its functionality suppressed by feature guards. This change also explicitly adds a `boost/bind/std_placeholders.hpp` include to the `bind_handler` unit test file to prevent this issue from regressing.