### PR TITLE
The changes in stream_impl.hpp fix a problem where idle_counter != 0 …

### DIFF
--- a/include/boost/beast/websocket/impl/read.hpp
+++ b/include/boost/beast/websocket/impl/read.hpp
@@ -196,6 +196,7 @@ public:
                     }
                     BOOST_ASSERT(impl.rd_block.is_locked(this));
                     impl.rd_buf.commit(bytes_transferred);
+                    if (bytes_transferred) impl.update_timer(this->get_executor());
                     if(impl.check_stop_now(ec))
                         goto upcall;
                     impl.reset_idle();

--- a/include/boost/beast/websocket/impl/stream_impl.hpp
+++ b/include/boost/beast/websocket/impl/stream_impl.hpp
@@ -155,6 +155,7 @@ struct stream<NextLayer, deflateSupported>::impl_type
     {
         // VFALCO TODO analyze and remove dupe code in reset()
         timer.expires_at(never());
+        idle_counter = 0;
         timed_out = false;
         cr.code = close_code::none;
         role = role_;
@@ -192,6 +193,7 @@ struct stream<NextLayer, deflateSupported>::impl_type
     {
         BOOST_ASSERT(status_ != status::open);
         timer.expires_at(never());
+        idle_counter = 0;
         cr.code = close_code::none;
         rd_remain = 0;
         rd_cont = false;


### PR DESCRIPTION
The change in stream_impl.hpp is fixes a bug that occurs when a stream that timed out is reused.  This would often result in the first assert in update_timer (near line 422) getting called erroneously.  This fix is just resetting idle_counter to 0 on open and reset.  This looks (to me) like a very straightforward and completely safe change.

The change in read.hpp is to fix the ping timeout.  The code currently doesn't reset the timeout when a regular (non-ping) message is received. This is  because the coroutine for operator() near line 81 seldom executes the update near line 97 but instead jumps back into the main loop somewhere, bypassing the call to update_timer.  

While the fix I included works (tested), I don't claim it is the best possible fix.  Someone more familiar with the internals may have a better solution.  I'm happy as long as the problem is fixed.  If am happy to test an alternative fix, but may not have time in the short term to provide a test to others (I will do my best, just trying to be honest).

With this fix, the ping timeout behaves as documented, however it is still not ideal when one side cannot send ping (for example Browser).  Filed Issue #2652  with details and proposed solution (but no code).