### PR TITLE
change upgrade to Upgrade as connection header value

### DIFF
--- a/include/boost/beast/websocket/impl/accept.hpp
+++ b/include/boost/beast/websocket/impl/accept.hpp
@@ -145,7 +145,7 @@ build_response(
     res.result(http::status::switching_protocols);
     res.version(req.version());
     res.set(http::field::upgrade, "websocket");
-    res.set(http::field::connection, "upgrade");
+    res.set(http::field::connection, "Upgrade");
     {
         detail::sec_ws_accept_type acc;
         detail::make_sec_ws_accept(acc, key);

--- a/include/boost/beast/websocket/impl/stream_impl.hpp
+++ b/include/boost/beast/websocket/impl/stream_impl.hpp
@@ -632,7 +632,7 @@ build_request(
     req.method(http::verb::get);
     req.set(http::field::host, host);
     req.set(http::field::upgrade, "websocket");
-    req.set(http::field::connection, "upgrade");
+    req.set(http::field::connection, "Upgrade");
     detail::make_sec_ws_key(key);
     req.set(http::field::sec_websocket_key, to_string_view(key));
     req.set(http::field::sec_websocket_version, "13");


### PR DESCRIPTION
Boost beast uses "upgrade" as the token for the "Connection" header, however rfc6455 defines otherwise.
https://www.rfc-editor.org/rfc/rfc6455#page-18
```
6.   The request MUST contain a |Connection| header field whose value MUST include the "Upgrade" token.
```

Confusingly other rfc's are not consistent in using it like this.
The server side should accept the value as case-insensitive but not all implementations honor this.
I've had issues with this in the field (Samsung TV's for example)

The other implementations I investigated all use "Upgrade".

C (libwebsockets)
https://github.com/warmcat/libwebsockets/blob/e8eb7d6bd66dde2156dbcd37b0e9048ed4006320/lib/roles/ws/client-ws.c#L168

Python (websockets)
https://github.com/aaugustin/websockets/blob/6dcac04c10c61dde9aa5be0374965c31f16e77f4/src/websockets/client.py#L118

Python (websocket-client)
https://github.com/websocket-client/websocket-client/blob/6ff442c6b11b56d98583056c4832d48f284246dc/websocket/_handshake.py#L112

Node.js (WS)
https://github.com/websockets/ws/blob/45e17acea791d865df6b255a55182e9c42e5877a/lib/websocket.js#L721