### PR TITLE
Remove unused failure reporting code

### DIFF
--- a/example/websocket/client/awaitable/websocket_client_awaitable.cpp
+++ b/example/websocket/client/awaitable/websocket_client_awaitable.cpp
@@ -35,13 +35,6 @@ using tcp = boost::asio::ip::tcp;       // from <boost/asio/ip/tcp.hpp>
 
 //------------------------------------------------------------------------------
 
-// Report a failure
-void
-fail(beast::error_code ec, char const* what)
-{
-    std::cerr << what << ": " << ec.message() << "\n";
-}
-
 // Sends a WebSocket message and prints the response
 net::awaitable<void>
 do_session(


### PR DESCRIPTION
The `fail` function is used in the other websocket examples, and presumably was included here for that reason.  However, it is not actually used in this example.

This PR removes the unused function.