### PR TITLE
Reimplement (C++23) deprecated std::aligned_storage

### DIFF
--- a/include/boost/beast/core/detail/type_traits.hpp
+++ b/include/boost/beast/core/detail/type_traits.hpp
@@ -10,6 +10,7 @@
 #ifndef BOOST_BEAST_DETAIL_TYPE_TRAITS_HPP
 #define BOOST_BEAST_DETAIL_TYPE_TRAITS_HPP
 
+#include <boost/type_traits/aligned_storage.hpp>
 #include <boost/type_traits/make_void.hpp>
 #include <type_traits>
 #include <new>
@@ -56,16 +57,6 @@ using make_void = boost::make_void<Ts...>;
 template<class... Ts>
 using void_t = boost::void_t<Ts...>;
 
-// deprecated in C++23
-template<std::size_t Len, std::size_t Align>
-struct aligned_storage
-{
-    struct type
-    {
-        alignas(Align) unsigned char data[Len];
-    };
-};
-
 // (since C++11) missing from g++4.8
 template<std::size_t Len, class... Ts>
 struct aligned_union
@@ -74,7 +65,7 @@ struct aligned_union
     std::size_t constexpr alignment_value =
         max_alignof<Ts...>();
 
-    using type = typename aligned_storage<
+    using type = typename boost::aligned_storage<
         (Len > max_sizeof<Ts...>()) ? Len : (max_sizeof<Ts...>()),
             alignment_value>::type;
 };

--- a/include/boost/beast/core/detail/type_traits.hpp
+++ b/include/boost/beast/core/detail/type_traits.hpp
@@ -56,6 +56,16 @@ using make_void = boost::make_void<Ts...>;
 template<class... Ts>
 using void_t = boost::void_t<Ts...>;
 
+// deprecated in C++23
+template<std::size_t Len, std::size_t Align>
+struct aligned_storage
+{
+    struct type
+    {
+        alignas(Align) unsigned char data[Len];
+    };
+};
+
 // (since C++11) missing from g++4.8
 template<std::size_t Len, class... Ts>
 struct aligned_union
@@ -64,7 +74,7 @@ struct aligned_union
     std::size_t constexpr alignment_value =
         max_alignof<Ts...>();
 
-    using type = typename std::aligned_storage<
+    using type = typename aligned_storage<
         (Len > max_sizeof<Ts...>()) ? Len : (max_sizeof<Ts...>()),
             alignment_value>::type;
 };

--- a/include/boost/beast/websocket/detail/decorator.hpp
+++ b/include/boost/beast/websocket/detail/decorator.hpp
@@ -10,9 +10,9 @@
 #ifndef BOOST_BEAST_WEBSOCKET_DETAIL_DECORATOR_HPP
 #define BOOST_BEAST_WEBSOCKET_DETAIL_DECORATOR_HPP
 
-#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/beast/websocket/rfc6455.hpp>
 #include <boost/core/exchange.hpp>
+#include <boost/type_traits/aligned_storage.hpp>
 #include <boost/type_traits/make_void.hpp>
 #include <algorithm>
 #include <memory>
@@ -63,7 +63,7 @@ class decorator
     {
         void* p_;
         void (*fn_)();
-        typename beast::detail::aligned_storage<
+        typename beast::aligned_storage<
             sizeof(exemplar),
             alignof(exemplar)>::type buf_;
     };

--- a/include/boost/beast/websocket/detail/decorator.hpp
+++ b/include/boost/beast/websocket/detail/decorator.hpp
@@ -10,6 +10,7 @@
 #ifndef BOOST_BEAST_WEBSOCKET_DETAIL_DECORATOR_HPP
 #define BOOST_BEAST_WEBSOCKET_DETAIL_DECORATOR_HPP
 
+#include <boost/beast/core/detail/type_traits.hpp>
 #include <boost/beast/websocket/rfc6455.hpp>
 #include <boost/core/exchange.hpp>
 #include <boost/type_traits/make_void.hpp>
@@ -62,7 +63,7 @@ class decorator
     {
         void* p_;
         void (*fn_)();
-        typename std::aligned_storage<
+        typename beast::detail::aligned_storage<
             sizeof(exemplar),
             alignof(exemplar)>::type buf_;
     };

--- a/include/boost/beast/websocket/detail/decorator.hpp
+++ b/include/boost/beast/websocket/detail/decorator.hpp
@@ -63,7 +63,7 @@ class decorator
     {
         void* p_;
         void (*fn_)();
-        typename beast::aligned_storage<
+        typename boost::aligned_storage<
             sizeof(exemplar),
             alignof(exemplar)>::type buf_;
     };


### PR DESCRIPTION
cf. https://github.com/boostorg/beast/issues/2535