### PR TITLE
set minimum gcc version to 5.0.

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -30,7 +30,7 @@ def main(ctx):
 
   generatedjobs = generate(
         # Compilers
-        ['gcc >=4.8',
+        ['gcc >=5.0',
          'clang >=3.8',
          # 'msvc >=14.1',
          'arm64-gcc latest',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-# gcc 4.7 not supported by beast
-# minimum requirement is gcc 4.8
-          - toolset: gcc-4.8
-            cxxstd: "11"
-            os: ubuntu-22.04
-            container: ubuntu:16.04
-            install: g++-4.8
-            supported: true
-# gcc 4.9 not supported by beast
-# It dies with ICE when compiling
           - toolset: gcc-5
             cxxstd: "11,14,1z"
             os: ubuntu-22.04

--- a/doc/qbk/01_intro/_intro.qbk
+++ b/doc/qbk/01_intro/_intro.qbk
@@ -60,7 +60,7 @@ Beast requires:
 * [*Boost:] Beast only works with Boost, not stand-alone Asio
 * [*OpenSSL:] Version 1.0.2 or higher. Required to build the tests, examples, and to use TLS/Secure sockets.
 
-Tested with these compilers: msvc-14+, gcc 4.8.4+, clang 3.6+.
+Tested with these compilers: msvc-14+, gcc 5.0+, clang 3.6+.
 
 Sources are [*header-only]. Adding additional libraries to the
 linking step for your programs to use Beast is normally not

--- a/include/boost/beast/core/detail/config.hpp
+++ b/include/boost/beast/core/detail/config.hpp
@@ -41,8 +41,8 @@ namespace net = boost::asio;
 # endif
 
 #elif defined(BOOST_GCC)
-# if(BOOST_GCC < 40801)
-#  error Beast requires C++11: gcc version 4.8 or later needed
+# if(BOOST_GCC < 50000)
+#  error Beast requires C++11: gcc version 5 or later needed
 # endif
 
 #else


### PR DESCRIPTION
This is due to C++98 support being dropped, so 4.8 fails other libraries C++11 detection.