### PR TITLE
Replace internal uses of beast::bind_front_handler with asio::prepend

### DIFF
--- a/include/boost/beast/_experimental/test/impl/stream.ipp
+++ b/include/boost/beast/_experimental/test/impl/stream.ipp
@@ -11,7 +11,6 @@
 #define BOOST_BEAST_TEST_IMPL_STREAM_IPP
 
 #include <boost/beast/_experimental/test/stream.hpp>
-#include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/buffer_traits.hpp>
 #include <boost/make_shared.hpp>
 #include <stdexcept>

--- a/include/boost/beast/_experimental/test/stream.hpp
+++ b/include/boost/beast/_experimental/test/stream.hpp
@@ -11,7 +11,6 @@
 #define BOOST_BEAST_TEST_STREAM_HPP
 
 #include <boost/beast/core/detail/config.hpp>
-#include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/beast/core/role.hpp>
 #include <boost/beast/core/string.hpp>

--- a/include/boost/beast/core/async_base.hpp
+++ b/include/boost/beast/core/async_base.hpp
@@ -11,7 +11,6 @@
 #define BOOST_BEAST_CORE_ASYNC_BASE_HPP
 
 #include <boost/beast/core/detail/config.hpp>
-#include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/detail/allocator.hpp>
 #include <boost/beast/core/detail/async_base.hpp>
 #include <boost/beast/core/detail/filtering_cancellation_slot.hpp>
@@ -24,6 +23,7 @@
 #include <boost/asio/handler_continuation_hook.hpp>
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/post.hpp>
+#include <boost/asio/prepend.hpp>
 #include <boost/core/exchange.hpp>
 #include <boost/core/empty_value.hpp>
 #include <utility>
@@ -425,9 +425,7 @@ public:
             auto const ex = this->get_immediate_executor();
             net::dispatch(
                 ex,
-                beast::bind_front_handler(
-                    std::move(h_),
-                    std::forward<Args>(args)...));
+                net::prepend(std::move(h_), std::forward<Args>(args)...));
             wg1_.reset();
         }
         else

--- a/include/boost/beast/core/detail/impl/read.hpp
+++ b/include/boost/beast/core/detail/impl/read.hpp
@@ -10,7 +10,6 @@
 #ifndef BOOST_BEAST_DETAIL_IMPL_READ_HPP
 #define BOOST_BEAST_DETAIL_IMPL_READ_HPP
 
-#include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/async_base.hpp>
 #include <boost/beast/core/flat_static_buffer.hpp>
 #include <boost/beast/core/read_size.hpp>

--- a/include/boost/beast/core/impl/buffered_read_stream.hpp
+++ b/include/boost/beast/core/impl/buffered_read_stream.hpp
@@ -11,12 +11,12 @@
 #define BOOST_BEAST_IMPL_BUFFERED_READ_STREAM_HPP
 
 #include <boost/beast/core/async_base.hpp>
-#include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/error.hpp>
 #include <boost/beast/core/read_size.hpp>
 #include <boost/beast/core/stream_traits.hpp>
 #include <boost/beast/core/detail/is_invocable.hpp>
 #include <boost/asio/dispatch.hpp>
+#include <boost/asio/prepend.hpp>
 #include <boost/throw_exception.hpp>
 
 namespace boost {
@@ -84,8 +84,7 @@ public:
                 const auto ex = this->get_immediate_executor();
                 return net::dispatch(
                     ex,
-                    beast::bind_front_handler(
-                        std::move(*this), ec, 0));
+                    net::prepend(std::move(*this), ec, 0));
             }
         case 1:
             // upcall

--- a/include/boost/beast/http/impl/file_body_win32.hpp
+++ b/include/boost/beast/http/impl/file_body_win32.hpp
@@ -13,7 +13,6 @@
 #if BOOST_BEAST_USE_WIN32_FILE
 
 #include <boost/beast/core/async_base.hpp>
-#include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/buffers_range.hpp>
 #include <boost/beast/core/detail/clamp.hpp>
 #include <boost/beast/core/detail/is_invocable.hpp>

--- a/include/boost/beast/http/impl/read.hpp
+++ b/include/boost/beast/http/impl/read.hpp
@@ -22,6 +22,7 @@
 #include <boost/asio/error.hpp>
 #include <boost/asio/compose.hpp>
 #include <boost/asio/coroutine.hpp>
+#include <boost/asio/prepend.hpp>
 
 namespace boost {
 namespace beast {
@@ -249,9 +250,7 @@ public:
                         asio::get_associated_immediate_executor(
                             self, s_.get_executor());
 
-                    net::dispatch(
-                        ex,
-                        beast::bind_front_handler(std::move(self), ec));
+                    net::dispatch(ex, net::prepend(std::move(self), ec));
                 }
             }
             self.complete(ec, bytes_transferred_);

--- a/include/boost/beast/http/impl/write.hpp
+++ b/include/boost/beast/http/impl/write.hpp
@@ -12,7 +12,6 @@
 
 #include <boost/beast/http/type_traits.hpp>
 #include <boost/beast/core/async_base.hpp>
-#include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/buffers_range.hpp>
 #include <boost/beast/core/make_printable.hpp>
 #include <boost/beast/core/stream_traits.hpp>
@@ -20,6 +19,7 @@
 #include <boost/asio/coroutine.hpp>
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/write.hpp>
+#include <boost/asio/prepend.hpp>
 #include <boost/optional.hpp>
 #include <boost/throw_exception.hpp>
 #include <ostream>
@@ -102,11 +102,8 @@ public:
                     __FILE__, __LINE__,
                     "http::async_write_some"));
 
-                auto ex = asio::get_associated_immediate_executor(*this, s_.get_executor());
-                return net::dispatch(
-                    ex,
-                    beast::bind_front_handler(
-                        std::move(*this), ec, 0));
+                const auto ex = asio::get_associated_immediate_executor(*this, s_.get_executor());
+                return net::dispatch(ex, net::prepend(std::move(*this), ec, 0));
             }
             if(f.invoked)
             {
@@ -122,10 +119,7 @@ public:
             "http::async_write_some"));
 
         const auto ex = this->get_immediate_executor();
-        return net::dispatch(
-            ex,
-            beast::bind_front_handler(
-                std::move(*this), ec, 0));
+        return net::dispatch(ex, net::prepend(std::move(*this), ec, 0));
     }
 
     void

--- a/include/boost/beast/websocket/impl/ping.hpp
+++ b/include/boost/beast/websocket/impl/ping.hpp
@@ -11,7 +11,6 @@
 #define BOOST_BEAST_WEBSOCKET_IMPL_PING_HPP
 
 #include <boost/beast/core/async_base.hpp>
-#include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/stream_traits.hpp>
 #include <boost/beast/core/detail/bind_continuation.hpp>
 #include <boost/beast/websocket/detail/frame.hpp>

--- a/include/boost/beast/websocket/impl/read.hpp
+++ b/include/boost/beast/websocket/impl/read.hpp
@@ -15,7 +15,6 @@
 #include <boost/beast/websocket/detail/mask.hpp>
 #include <boost/beast/websocket/impl/stream_impl.hpp>
 #include <boost/beast/core/async_base.hpp>
-#include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/buffers_prefix.hpp>
 #include <boost/beast/core/buffers_suffix.hpp>
 #include <boost/beast/core/flat_static_buffer.hpp>

--- a/include/boost/beast/websocket/impl/teardown.hpp
+++ b/include/boost/beast/websocket/impl/teardown.hpp
@@ -11,12 +11,12 @@
 #define BOOST_BEAST_WEBSOCKET_IMPL_TEARDOWN_HPP
 
 #include <boost/beast/core/async_base.hpp>
-#include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/stream_traits.hpp>
 #include <boost/beast/core/detail/bind_continuation.hpp>
 #include <boost/beast/core/detail/is_invocable.hpp>
 #include <boost/asio/coroutine.hpp>
 #include <boost/asio/dispatch.hpp>
+#include <boost/asio/prepend.hpp>
 #include <memory>
 
 namespace boost {
@@ -129,8 +129,7 @@ public:
                         ));
 
                     const auto ex = this->get_immediate_executor();
-                    net::dispatch(ex, bind_front_handler(
-                        std::move(*this), ec));
+                    net::dispatch(ex, net::prepend(std::move(*this), ec));
                 }
             }
             {

--- a/include/boost/beast/websocket/impl/write.hpp
+++ b/include/boost/beast/websocket/impl/write.hpp
@@ -12,7 +12,6 @@
 
 #include <boost/beast/websocket/detail/mask.hpp>
 #include <boost/beast/core/async_base.hpp>
-#include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/buffer_traits.hpp>
 #include <boost/beast/core/buffers_cat.hpp>
 #include <boost/beast/core/buffers_prefix.hpp>

--- a/test/beast/core/basic_stream.cpp
+++ b/test/beast/core/basic_stream.cpp
@@ -13,6 +13,7 @@
 #include "stream_tests.hpp"
 
 #include <boost/beast/_experimental/unit_test/suite.hpp>
+#include <boost/beast/core/bind_handler.hpp>
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/beast/core/stream_traits.hpp>
 #include <boost/beast/core/string.hpp>


### PR DESCRIPTION
We cannot deprecate `beast::bind_front_handler` in favor of `asio::prepend` or `asio::append` because it has a [special overload](https://github.com/boostorg/beast/blob/667e9ea251e862fa7b62a3ee94054faef201702e/include/boost/beast/core/detail/bind_handler.hpp#L240) for cases when the handler is a member function pointer which enables code like this to work:

```C++
ws_.async_accept(
    req,
    beast::bind_front_handler(
        &websocket_session::on_accept,
        shared_from_this()));
```
While this pattern is only employed in examples and tests, all instances within the library itself can be replaces with `asio::prepend`.
