### PR TITLE
Specialize asio::associator for bind_wrapper and bind_front_wrapper

### DIFF
--- a/include/boost/beast/_experimental/test/impl/stream.hpp
+++ b/include/boost/beast/_experimental/test/impl/stream.hpp
@@ -15,6 +15,7 @@
 #include <boost/beast/core/detail/service_base.hpp>
 #include <boost/beast/core/detail/is_invocable.hpp>
 #include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/associated_cancellation_slot.hpp>
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/post.hpp>
 #include <mutex>

--- a/include/boost/beast/core/async_base.hpp
+++ b/include/boost/beast/core/async_base.hpp
@@ -17,6 +17,7 @@
 #include <boost/beast/core/detail/filtering_cancellation_slot.hpp>
 #include <boost/beast/core/detail/work_guard.hpp>
 #include <boost/asio/associated_allocator.hpp>
+#include <boost/asio/associated_cancellation_slot.hpp>
 #include <boost/asio/associated_executor.hpp>
 #include <boost/asio/associated_immediate_executor.hpp>
 #include <boost/asio/bind_executor.hpp>

--- a/test/beast/websocket/close.cpp
+++ b/test/beast/websocket/close.cpp
@@ -775,7 +775,7 @@ public:
 
             BEAST_EXPECT(ioc.run() == 0);
             BEAST_EXPECT(count == 3);
-            BEAST_EXPECT(ic == 6);
+            BEAST_EXPECT(ic == 3);
         });
     }
 


### PR DESCRIPTION
The existing code attempts to customize `asio::associated_executor` and other associators for `bind_wrapper` and `bind_front_wrapper`, leading to a situation where Asio consistently assumes the presence of an associated executor with the bound handlers. This results in [asio::detail::is_work_dispatcher_required](https://github.com/boostorg/asio/blob/2e49b21732e5d1bb3bb98f209164c30816b0bc79/include/boost/asio/detail/work_dispatcher.hpp#L42) always being set to true. Consequently, Asio wraps the bound handlers in [asio::detail::work_dispatcher](https://github.com/boostorg/asio/blob/2e49b21732e5d1bb3bb98f209164c30816b0bc79/include/boost/asio/detail/initiate_post.hpp#L148) before execution.

Consequently, everything wrapped in a `bind_wrapper` or `bind_front_wrapper` is scheduled twice on the executor:
```C++
#include <boost/asio/bind_immediate_executor.hpp>
#include <boost/asio/dispatch.hpp>
#include <boost/beast/core/bind_handler.hpp>

#include <iostream>

using namespace boost;

class immediate_executor
{
  std::size_t& count_;

public:
  immediate_executor(std::size_t& count) noexcept
    : count_(count)
  {
  }

  asio::execution_context& query(asio::execution::context_t) const
  {
    BOOST_ASSERT(false);
    return *static_cast<asio::execution_context*>(nullptr);
  }

  constexpr static asio::execution::blocking_t query(asio::execution::blocking_t) noexcept
  {
    return asio::execution::blocking_t::never_t{};
  }

  constexpr static asio::execution::relationship_t query(asio::execution::relationship_t) noexcept
  {
    return asio::execution::relationship_t::fork_t{};
  }

  template<class F>
  void execute(F f) const
  {
    count_++;
    std::forward<F>(f)();
  }

  bool operator==(immediate_executor const&) const noexcept
  {
    return true;
  }

  bool operator!=(immediate_executor const&) const noexcept
  {
    return false;
  }
};

int main()
{
  std::size_t ic = 0;
  immediate_executor imex{ ic };

  asio::dispatch(imex, beast::bind_handler([] {}));

  std::cout << ic << std::endl; // prints 2
}

```
Open in Compiler Explorer: [Link](https://godbolt.org/z/91r73EaMd)