### PR TITLE
Update host string after SSL_set_tlsext_host_name

### DIFF
--- a/example/websocket/client/async-ssl-system-executor/websocket_client_async_ssl_system_executor.cpp
+++ b/example/websocket/client/async-ssl-system-executor/websocket_client_async_ssl_system_executor.cpp
@@ -114,11 +114,6 @@ public:
         if(ec)
             return fail(ec, "connect");
 
-        // Update the host_ string. This will provide the value of the
-        // Host HTTP header during the WebSocket handshake.
-        // See https://tools.ietf.org/html/rfc7230#section-5.4
-        host_ += ':' + std::to_string(ep.port());
-
         // Set a timeout on the operation
         beast::get_lowest_layer(ws_).expires_after(std::chrono::seconds(30));
 
@@ -131,6 +126,11 @@ public:
                                  net::error::get_ssl_category());
           return fail(ec, "connect");
         }
+
+        // Update the host_ string. This will provide the value of the
+        // Host HTTP header during the WebSocket handshake.
+        // See https://tools.ietf.org/html/rfc7230#section-5.4
+        host_ += ':' + std::to_string(ep.port());
 
         // Perform the SSL handshake
         ws_.next_layer().async_handshake(


### PR DESCRIPTION
`host_` string should be updated after its usage in SSL_set_tlsext_host_name, otherwise this would cause an SSL handshake error.