### PR TITLE
Use BUILD_TESTING as the default value for Beast_BUILD_TESTS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ project (Beast VERSION 353)
 
 set_property (GLOBAL PROPERTY USE_FOLDERS ON)
 option (Beast_BUILD_EXAMPLES "Build examples" ON)
-option (Beast_BUILD_TESTS "Build tests" ON)
+option (Beast_BUILD_TESTS "Build tests" ${BUILD_TESTING})
 option (Beast_ENABLE_HANDLER_TRACKING "Define BOOST_ASIO_ENABLE_HANDLER_TRACKING when building libraries" OFF)
 option (Boost_USE_STATIC_LIBS "Use Static Boost libraries" ON)
 


### PR DESCRIPTION
This is the variable most other boost libraries use for initial selection of whether to build their tests [or they default to OFF].

To me this makes usage as a third_party, where I don't necessarily want to run all tests with every build, more consistent.