### PR TITLE
Replace use of context valgrind feature.

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -38,9 +38,12 @@ variant beast_coverage
     <linkflags>"--coverage"
   ;
 
+feature.feature boost.beast.valgrind : on : optional propagated composite ;
+feature.compose <boost.beast.valgrind>on : <define>BOOST_USE_VALGRIND ;
+
 variant beast_valgrind
   : release
-  : <valgrind>on # Boost.Context uses this property
+  : <boost.beast.valgrind>on
   ;
 
 variant beast_ubasan


### PR DESCRIPTION
Declare our own b2 feature for valgrind and adding the BOOST_USE_VALGRIND predef. This avoids dependency ordering problems since Beast doesn't depend on Boost.Context. Which is the lib that defines the other valgrind feature.

This change is needed to avoid build errors for this PR https://github.com/boostorg/boost/pull/854