### PR TITLE
Handle expired timers in basic_stream transfer_op

### DIFF
--- a/include/boost/beast/core/detail/stream_base.hpp
+++ b/include/boost/beast/core/detail/stream_base.hpp
@@ -132,6 +132,11 @@ struct stream_base
         return (time_point::max)();
     }
 
+    static time_point now() noexcept
+    {
+        return clock_type::now();
+    }
+
     static std::size_t constexpr no_limit =
         (std::numeric_limits<std::size_t>::max)();
 };

--- a/test/beast/core/basic_stream.cpp
+++ b/test/beast/core/basic_stream.cpp
@@ -656,6 +656,17 @@ public:
             ioc.restart();
         }
 
+        {
+            // non-empty buffer, timeout
+            test_server srv("*", ep, log);
+            stream_type s(ioc);
+            s.socket().connect(srv.local_endpoint());
+            s.expires_after(std::chrono::seconds(0));
+            s.async_write_some(cb, handler(error::timeout, 0));
+            ioc.run();
+            ioc.restart();
+        }
+
         // abandoned operation
         {
             stream_type s(ioc);


### PR DESCRIPTION
Previously, the code only handled expired timers when the buffer was empty.