### PR TITLE
Add 418 "I'm a teapot" HTTP status

### DIFF
--- a/include/boost/beast/http/impl/status.ipp
+++ b/include/boost/beast/http/impl/status.ipp
@@ -72,6 +72,7 @@ int_to_status(unsigned v)
     case status::unsupported_media_type:
     case status::range_not_satisfiable:
     case status::expectation_failed:
+    case status::i_am_a_teapot:
     case status::misdirected_request:
     case status::unprocessable_entity:
     case status::locked:
@@ -178,6 +179,7 @@ obsolete_reason(status v)
     case status::unsupported_media_type:                return "Unsupported Media Type";
     case status::range_not_satisfiable:                 return "Range Not Satisfiable";
     case status::expectation_failed:                    return "Expectation Failed";
+    case status::i_am_a_teapot:                         return "I'm a teapot";
     case status::misdirected_request:                   return "Misdirected Request";
     case status::unprocessable_entity:                  return "Unprocessable Entity";
     case status::locked:                                return "Locked";

--- a/include/boost/beast/http/status.hpp
+++ b/include/boost/beast/http/status.hpp
@@ -80,6 +80,7 @@ enum class status : unsigned
     unsupported_media_type              = 415,
     range_not_satisfiable               = 416,
     expectation_failed                  = 417,
+    i_am_a_teapot                       = 418,
     misdirected_request                 = 421,
     unprocessable_entity                = 422,
     locked                              = 423,

--- a/test/beast/http/status.cpp
+++ b/test/beast/http/status.cpp
@@ -72,6 +72,7 @@ public:
         check(status::unsupported_media_type                ,415, status_class::client_error);
         check(status::range_not_satisfiable                 ,416, status_class::client_error);
         check(status::expectation_failed                    ,417, status_class::client_error);
+        check(status::i_am_a_teapot                         ,418, status_class::client_error);
         check(status::misdirected_request                   ,421, status_class::client_error);
         check(status::unprocessable_entity                  ,422, status_class::client_error);
         check(status::locked                                ,423, status_class::client_error);
@@ -143,6 +144,7 @@ public:
         good(status::unsupported_media_type);
         good(status::range_not_satisfiable);
         good(status::expectation_failed);
+        good(status::i_am_a_teapot);
         good(status::misdirected_request);
         good(status::unprocessable_entity);
         good(status::locked);


### PR DESCRIPTION
Though this HTTP status is just a joke, it is supported by numerous HTTP implementations, including (but not limited to):

* [Python](https://github.com/python/cpython/blob/f79ffc879b919604ed5de22ece83825006cf9a17/Lib/http/__init__.py#L130)
* [POCO](https://github.com/pocoproject/poco/blob/bc29f30e5cf035e860b3d2c1fc5df570f01513ea/Net/include/Poco/Net/HTTPResponse.h#L90)
* [Golang](https://pkg.go.dev/net/http#StatusTeapot)
* [Rust `actix-web` crate](https://docs.rs/actix-web/4.6.0/actix_web/http/struct.StatusCode.html#associatedconstant.IM_A_TEAPOT)

So, I think it's also a good idea to support this HTTP status code in Beast.

Also, C++ is occasionally used for embedded programming, such as smart teapots, and I think it also justifies adding this status code :) :)