### PR TITLE
Fix buffer overflow handling in dynamic_buffer_prepare

### DIFF
--- a/include/boost/beast/core/detail/buffer.hpp
+++ b/include/boost/beast/core/detail/buffer.hpp
@@ -65,7 +65,7 @@ dynamic_buffer_prepare(
         ec = {};
         return result;
     }
-    catch(std::length_error const&)
+    catch(std::exception const&)
     {
         BOOST_BEAST_ASSIGN_EC(ec, ev);
     }


### PR DESCRIPTION
I experienced a bad_alloc exception using WebSocket server with enabled compression. A malformed message with a very big length led to the following address sanitizer report:

```
==1739459==ERROR: AddressSanitizer: requested allocation size 0x4000000ffff073e (0x4000000ffff1740 after adjustments for alignment, red zones etc.) exceeds maximum supported size of 0x10000000000 (thread T0)
    #0 0x7f494ecf91e7 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x5561b0a62199 in __gnu_cxx::new_allocator<char>::allocate(unsigned long, void const*) /usr/include/c++/11/ext/new_allocator.h:127
    #2 0x5561b0a54840 in std::allocator_traits<std::allocator<char> >::allocate(std::allocator<char>&, unsigned long) /usr/include/c++/11/bits/alloc_traits.h:464
    #3 0x5561b0a8bd68 in boost::beast::basic_flat_buffer<std::allocator<char> >::alloc(unsigned long) boost/include/boost/beast/core/impl/flat_buffer.hpp:538
    #4 0x5561b0a7a840 in boost::beast::basic_flat_buffer<std::allocator<char> >::prepare(unsigned long) boost/include/boost/beast/core/impl/flat_buffer.hpp:351
    #5 0x5561b0a6b9e4 in boost::optional<boost::beast::basic_flat_buffer<std::allocator<char> >::mutable_buffers_type> boost::beast::detail::dynamic_buffer_prepare<boost::beast::basic_flat_buffer<std::allocator<char> >, boost::beast::websocket::error>(boost::beast::basic_flat_buffer<std::allocator<char> >&, unsigned long, boost::system::error_code&, boost::beast::websocket::error) boost/include/boost/beast/core/detail/buffer.hpp:64
    #6 0x5561b0a5b230 in boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<boost::beast::detail::bind_front_wrapper<void (session::*)(boost::system::error_code, unsigned long), std::shared_ptr<session> >, boost::beast::basic_flat_buffer<std::allocator<char> > >::operator()(boost::system::error_code, unsigned long, bool) boost/include/boost/beast/websocket/impl/read.hpp:791
    #7 0x5561b0b53d95 in void boost::asio::detail::prepend_handler<boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<boost::beast::detail::bind_front_wrapper<void (session::*)(boost::system::error_code, unsigned long), std::shared_ptr<session> >, boost::beast::basic_flat_buffer<std::allocator<char> > >, boost::system::error_code, unsigned long>::invoke<0ul, 1ul>(std::integer_sequence<unsigned long, 0ul, 1ul>) boost/include/boost/asio/impl/prepend.hpp:56
    #8 0x5561b0b42861 in void boost::asio::detail::prepend_handler<boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<boost::beast::detail::bind_front_wrapper<void (session::*)(boost::system::error_code, unsigned long), std::shared_ptr<session> >, boost::beast::basic_flat_buffer<std::allocator<char> > >, boost::system::error_code, unsigned long>::operator()<>() boost/include/boost/asio/impl/prepend.hpp:48
    #9 0x5561b0b34679 in boost::asio::detail::binder0<boost::asio::detail::prepend_handler<boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<boost::beast::detail::bind_front_wrapper<void (session::*)(boost::system::error_code, unsigned long), std::shared_ptr<session> >, boost::beast::basic_flat_buffer<std::allocator<char> > >, boost::system::error_code, unsigned long> >::operator()() boost/include/boost/asio/detail/bind_handler.hpp:56
    #10 0x5561b0b34b7a in void boost::asio::detail::executor_function::complete<boost::asio::detail::binder0<boost::asio::detail::prepend_handler<boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<boost::beast::detail::bind_front_wrapper<void (session::*)(boost::system::error_code, unsigned long), std::shared_ptr<session> >, boost::beast::basic_flat_buffer<std::allocator<char> > >, boost::system::error_code, unsigned long> >, std::allocator<void> >(boost::asio::detail::executor_function::impl_base*, bool) boost/include/boost/asio/detail/executor_function.hpp:113
    #11 0x5561b09bfefe in boost::asio::detail::executor_function::operator()() boost/include/boost/asio/detail/executor_function.hpp:61
    #12 0x5561b0b9740b in void boost::asio::detail::strand_executor_service::do_execute<boost::asio::io_context::basic_executor_type<std::allocator<void>, 4ul> const, boost::asio::detail::executor_function, std::allocator<void> >(std::shared_ptr<boost::asio::detail::strand_executor_service::strand_impl> const&, boost::asio::io_context::basic_executor_type<std::allocator<void>, 4ul> const&, boost::asio::detail::executor_function&&, std::allocator<void> const&) boost/include/boost/asio/detail/impl/strand_executor_service.hpp:233
    #13 0x5561b0b822d3 in void boost::asio::detail::strand_executor_service::execute<boost::asio::io_context::basic_executor_type<std::allocator<void>, 4ul> const, boost::asio::detail::executor_function>(std::shared_ptr<boost::asio::detail::strand_executor_service::strand_impl> const&, boost::asio::io_context::basic_executor_type<std::allocator<void>, 4ul> const&, boost::asio::detail::executor_function&&, std::enable_if<boost::asio::can_query<boost::asio::io_context::basic_executor_type<std::allocator<void>, 4ul> const, boost::asio::execution::allocator_t<void> >::value, void>::type*) boost/include/boost/asio/detail/impl/strand_executor_service.hpp:201
    #14 0x5561b0b72ece in boost::asio::constraint<boost::asio::traits::execute_member<boost::asio::io_context::basic_executor_type<std::allocator<void>, 4ul> const&, boost::asio::detail::executor_function, void>::is_valid, void>::type boost::asio::strand<boost::asio::io_context::basic_executor_type<std::allocator<void>, 4ul> >::execute<boost::asio::detail::executor_function>(boost::asio::detail::executor_function&&) const boost/include/boost/asio/strand.hpp:269
    #15 0x5561b0b66916 in void boost::asio::execution::detail::any_executor_base::execute_ex<boost::asio::strand<boost::asio::io_context::basic_executor_type<std::allocator<void>, 4ul> > >(boost::asio::execution::detail::any_executor_base const&, boost::asio::detail::executor_function&&) boost/include/boost/asio/execution/any_executor.hpp:900
    #16 0x5561b0b0e5f5 in void boost::asio::execution::detail::any_executor_base::execute<boost::asio::detail::binder0<boost::asio::detail::prepend_handler<boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<boost::beast::detail::bind_front_wrapper<void (session::*)(boost::system::error_code, unsigned long), std::shared_ptr<session> >, boost::beast::basic_flat_buffer<std::allocator<char> > >, boost::system::error_code, unsigned long> > >(boost::asio::detail::binder0<boost::asio::detail::prepend_handler<boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<boost::beast::detail::bind_front_wrapper<void (session::*)(boost::system::error_code, unsigned long), std::shared_ptr<session> >, boost::beast::basic_flat_buffer<std::allocator<char> > >, boost::system::error_code, unsigned long> >&&) const boost/include/boost/asio/execution/any_executor.hpp:681
    #17 0x5561b0b00303 in boost::asio::detail::work_dispatcher<boost::asio::detail::prepend_handler<boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<boost::beast::detail::bind_front_wrapper<void (session::*)(boost::system::error_code, unsigned long), std::shared_ptr<session> >, boost::beast::basic_flat_buffer<std::allocator<char> > >, boost::system::error_code, unsigned long>, boost::asio::any_io_executor, void>::operator()() boost/include/boost/asio/detail/work_dispatcher.hpp:81
    #18 0x5561b0b008d4 in void boost::asio::detail::executor_function::complete<boost::asio::detail::work_dispatcher<boost::asio::detail::prepend_handler<boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<boost::beast::detail::bind_front_wrapper<void (session::*)(boost::system::error_code, unsigned long), std::shared_ptr<session> >, boost::beast::basic_flat_buffer<std::allocator<char> > >, boost::system::error_code, unsigned long>, boost::asio::any_io_executor, void>, std::allocator<void> >(boost::asio::detail::executor_function::impl_base*, bool) boost/include/boost/asio/detail/executor_function.hpp:113
    #19 0x5561b09bfefe in boost::asio::detail::executor_function::operator()() boost/include/boost/asio/detail/executor_function.hpp:61
    #20 0x5561b0aabfd7 in boost::asio::detail::executor_op<boost::asio::detail::executor_function, std::allocator<void>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) boost/include/boost/asio/detail/executor_op.hpp:70
    #21 0x5561b09c61dc in boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) boost/include/boost/asio/detail/scheduler_operation.hpp:40
    #22 0x5561b09d37a7 in boost::asio::detail::strand_executor_service::run_ready_handlers(std::shared_ptr<boost::asio::detail::strand_executor_service::strand_impl>&) boost/include/boost/asio/detail/impl/strand_executor_service.ipp:150
    #23 0x5561b0b7316e in boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> const, void>::operator()() boost/include/boost/asio/detail/impl/strand_executor_service.hpp:121
    #24 0x5561b0bc83ac in boost::asio::detail::executor_op<boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> const, void>, boost::asio::detail::recycling_allocator<void, boost::asio::detail::thread_info_base::default_tag>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) boost/include/boost/asio/detail/executor_op.hpp:70
    #25 0x5561b09c61dc in boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) boost/include/boost/asio/detail/scheduler_operation.hpp:40
    #26 0x5561b09d1fcf in boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) boost/include/boost/asio/detail/impl/scheduler.ipp:493
    #27 0x5561b09d1193 in boost::asio::detail::scheduler::run(boost::system::error_code&) boost/include/boost/asio/detail/impl/scheduler.ipp:210
    #28 0x5561b09d945d in boost::asio::io_context::run() boost/include/boost/asio/impl/io_context.ipp:64
    #29 0x5561b09bc0df in main ws_server.cpp:235
```

It's possible to reproduce it with the [official example](https://www.boost.org/doc/libs/1_85_0/libs/beast/example/websocket/server/async/websocket_server_async.cpp) with just one change - enabling compression for the server.

I believe it's a good idea to fix this in the library instead of catching the exception on the user side. I used a similar MR as a base for my one - https://github.com/boostorg/beast/pull/558 . This is my first MR for this repository so I would appreciate your feedback. 