### PR TITLE
`const`-qualify trivial getters

### DIFF
--- a/include/boost/beast/http/serializer.hpp
+++ b/include/boost/beast/http/serializer.hpp
@@ -248,7 +248,7 @@ public:
 
     /// Returns the serialized buffer size limit
     std::size_t
-    limit()
+    limit() const
     {
         return limit_;
     }
@@ -274,7 +274,7 @@ public:
     /** Returns `true` if we will pause after writing the complete header.
     */
     bool
-    split()
+    split() const
     {
         return split_;
     }
@@ -298,7 +298,7 @@ public:
         serialized header octets have been retrieved.
     */
     bool
-    is_header_done()
+    is_header_done() const
     {
         return header_done_;
     }


### PR DESCRIPTION
None of these methods modify `serializer` members, so they ought to be `const`.  This undoes https://github.com/boostorg/beast/commit/8a3df73ffc7b2a1bf89f624fdd9a26c9dcf1fb5c