### PR TITLE
get_executor() works on initiation objects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,24 +221,26 @@ jobs:
     container: ${{ matrix.container }}
 
     steps:
-      - name: Check if running in container
-        if: matrix.container != ''
-        run: echo "GHA_CONTAINER=${{ matrix.container }}" >> $GITHUB_ENV
-      - name: If running in container, upgrade packages
+      - name: Setup container environment
         if: matrix.container != ''
         run: |
-            apt-get -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata && apt-get -o Acquire::Retries=3 install -y sudo software-properties-common wget curl apt-transport-https make apt-file sudo unzip libssl-dev build-essential autotools-dev autoconf automake g++ libc++-helpers python ruby cpio gcc-multilib g++-multilib pkgconf python3 ccache libpython-dev locales
-            sudo apt-add-repository ppa:git-core/ppa
-            sudo apt-get -o Acquire::Retries=3 update && apt-get -o Acquire::Retries=3 -y install git
-            python_version=$(python3 -c 'import sys; print("{0.major}.{0.minor}".format(sys.version_info))')
-            if [[ ${python_version} =~ ^3\.[0-5]$ ]]; then
-                 true
-            else
-                apt-get install -y python3-distutils
-            fi
-            sudo wget https://bootstrap.pypa.io/pip/$python_version/get-pip.py
-            sudo python3 get-pip.py
-            sudo /usr/local/bin/pip install cmake
+          apt-get -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata && apt-get -o Acquire::Retries=3 install -y sudo software-properties-common wget curl apt-transport-https make apt-file sudo unzip libssl-dev build-essential autotools-dev autoconf automake g++ libc++-helpers python ruby cpio gcc-multilib g++-multilib pkgconf python3 ccache libpython-dev locales
+          sudo apt-add-repository ppa:git-core/ppa
+          sudo apt-get -o Acquire::Retries=3 update && apt-get -o Acquire::Retries=3 -y install git
+          python_version=$(python3 -c 'import sys; print("{0.major}.{0.minor}".format(sys.version_info))')
+          if [[ ${python_version} =~ ^3\.[0-5]$ ]]; then
+                true
+          else
+              apt-get install -y python3-distutils
+          fi
+          sudo wget https://bootstrap.pypa.io/pip/$python_version/get-pip.py
+          sudo python3 get-pip.py
+          sudo /usr/local/bin/pip install cmake
+
+          if [[ "${{matrix.container}}" == "ubuntu:16.04" ]] || [[ "${{matrix.container}}" == "ubuntu:18.04" ]]; then
+            echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
+          fi
+
       - uses: actions/checkout@v3
 
       - name: Install packages

--- a/include/boost/beast/_experimental/http/impl/icy_stream.hpp
+++ b/include/boost/beast/_experimental/http/impl/icy_stream.hpp
@@ -167,11 +167,20 @@ public:
 
 struct run_read_op
 {
+    icy_stream* self;
+
+    using executor_type = typename icy_stream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return self->get_executor();
+    }
+
     template<class ReadHandler, class Buffers>
     void
     operator()(
         ReadHandler&& h,
-        icy_stream* s,
         Buffers const& b)
     {
         // If you get an error on the following line it means
@@ -186,7 +195,7 @@ struct run_read_op
         read_op<
             Buffers,
             typename std::decay<ReadHandler>::type>(
-                std::forward<ReadHandler>(h), *s, b);
+                std::forward<ReadHandler>(h), *self, b);
     }
 };
 
@@ -292,9 +301,8 @@ async_read_some(
     return net::async_initiate<
         ReadHandler,
         void(error_code, std::size_t)>(
-            typename ops::run_read_op{},
+            typename ops::run_read_op{this},
             handler,
-            this,
             buffers);
 }
 

--- a/include/boost/beast/core/detail/impl/read.hpp
+++ b/include/boost/beast/core/detail/impl/read.hpp
@@ -104,17 +104,26 @@ public:
 
 //------------------------------------------------------------------------------
 
+template <typename AsyncReadStream>
 struct run_read_op
 {
+    AsyncReadStream* stream;
+
+    using executor_type = typename AsyncReadStream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return stream->get_executor();
+    }
+
     template<
-        class AsyncReadStream,
         class DynamicBuffer,
         class Condition,
         class ReadHandler>
     void
     operator()(
         ReadHandler&& h,
-        AsyncReadStream* s,
         DynamicBuffer* b,
         Condition&& c)
     {
@@ -133,7 +142,7 @@ struct run_read_op
             typename std::decay<Condition>::type,
             typename std::decay<ReadHandler>::type>(
                 std::forward<ReadHandler>(h),
-                *s,
+                *stream,
                 *b,
                 std::forward<Condition>(c));
     }
@@ -234,9 +243,8 @@ async_read(
     return net::async_initiate<
         ReadHandler,
         void(error_code, std::size_t)>(
-            typename dynamic_read_ops::run_read_op{},
+            typename dynamic_read_ops::run_read_op<AsyncReadStream>{&stream},
             handler,
-            &stream,
             &buffer,
             std::forward<CompletionCondition>(cond));
 }

--- a/include/boost/beast/core/impl/basic_stream.hpp
+++ b/include/boost/beast/core/impl/basic_stream.hpp
@@ -606,11 +606,20 @@ public:
 
 struct run_read_op
 {
+    basic_stream* self;
+
+    using executor_type = typename basic_stream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return self->get_executor();
+    }
+
     template<class ReadHandler, class Buffers>
     void
     operator()(
         ReadHandler&& h,
-        basic_stream* s,
         Buffers const& b)
     {
         // If you get an error on the following line it means
@@ -626,17 +635,26 @@ struct run_read_op
             true,
             Buffers,
             typename std::decay<ReadHandler>::type>(
-                std::forward<ReadHandler>(h), *s, b);
+                std::forward<ReadHandler>(h), *self, b);
     }
 };
 
 struct run_write_op
 {
+    basic_stream* self;
+
+    using executor_type = typename basic_stream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return self->get_executor();
+    }
+
     template<class WriteHandler, class Buffers>
     void
     operator()(
         WriteHandler&& h,
-        basic_stream* s,
         Buffers const& b)
     {
         // If you get an error on the following line it means
@@ -652,17 +670,26 @@ struct run_write_op
             false,
             Buffers,
             typename std::decay<WriteHandler>::type>(
-                std::forward<WriteHandler>(h), *s, b);
+                std::forward<WriteHandler>(h), *self, b);
     }
 };
 
 struct run_connect_op
 {
+    basic_stream* self;
+
+    using executor_type = typename basic_stream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return self->get_executor();
+    }
+
     template<class ConnectHandler>
     void
     operator()(
         ConnectHandler&& h,
-        basic_stream* s,
         endpoint_type const& ep)
     {
         // If you get an error on the following line it means
@@ -675,12 +702,22 @@ struct run_connect_op
             "ConnectHandler type requirements not met");
 
         connect_op<typename std::decay<ConnectHandler>::type>(
-            std::forward<ConnectHandler>(h), *s, ep);
+            std::forward<ConnectHandler>(h), *self, ep);
     }
 };
 
 struct run_connect_range_op
 {
+    basic_stream* self;
+
+    using executor_type = typename basic_stream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return self->get_executor();
+    }
+
     template<
         class RangeConnectHandler,
         class EndpointSequence,
@@ -688,7 +725,6 @@ struct run_connect_range_op
     void
     operator()(
         RangeConnectHandler&& h,
-        basic_stream* s,
         EndpointSequence const& eps,
         Condition const& cond)
     {
@@ -702,12 +738,22 @@ struct run_connect_range_op
             "RangeConnectHandler type requirements not met");
 
         connect_op<typename std::decay<RangeConnectHandler>::type>(
-            std::forward<RangeConnectHandler>(h), *s, eps, cond);
+            std::forward<RangeConnectHandler>(h), *self, eps, cond);
     }
 };
 
 struct run_connect_iter_op
 {
+    basic_stream* self;
+
+    using executor_type = typename basic_stream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return self->get_executor();
+    }
+
     template<
         class IteratorConnectHandler,
         class Iterator,
@@ -715,7 +761,6 @@ struct run_connect_iter_op
     void
     operator()(
         IteratorConnectHandler&& h,
-        basic_stream* s,
         Iterator begin, Iterator end,
         Condition const& cond)
     {
@@ -729,7 +774,7 @@ struct run_connect_iter_op
             "IteratorConnectHandler type requirements not met");
 
         connect_op<typename std::decay<IteratorConnectHandler>::type>(
-            std::forward<IteratorConnectHandler>(h), *s, begin, end, cond);
+            std::forward<IteratorConnectHandler>(h), *self, begin, end, cond);
     }
 };
 
@@ -895,9 +940,8 @@ async_connect(
     return net::async_initiate<
         ConnectHandler,
         void(error_code)>(
-            typename ops::run_connect_op{},
+            typename ops::run_connect_op{this},
             handler,
-            this,
             ep);
 }
 
@@ -916,9 +960,8 @@ async_connect(
     return net::async_initiate<
         RangeConnectHandler,
         void(error_code, typename Protocol::endpoint)>(
-            typename ops::run_connect_range_op{},
+            typename ops::run_connect_range_op{this},
             handler,
-            this,
             endpoints,
             detail::any_endpoint{});
 }
@@ -940,9 +983,8 @@ async_connect(
     return net::async_initiate<
         RangeConnectHandler,
         void(error_code, typename Protocol::endpoint)>(
-            typename ops::run_connect_range_op{},
+            typename ops::run_connect_range_op{this},
             handler,
-            this,
             endpoints,
             connect_condition);
 }
@@ -961,9 +1003,8 @@ async_connect(
     return net::async_initiate<
         IteratorConnectHandler,
         void(error_code, Iterator)>(
-            typename ops::run_connect_iter_op{},
+            typename ops::run_connect_iter_op{this},
             handler,
-            this,
             begin, end,
             detail::any_endpoint{});
 }
@@ -984,9 +1025,8 @@ async_connect(
     return net::async_initiate<
         IteratorConnectHandler,
         void(error_code, Iterator)>(
-            typename ops::run_connect_iter_op{},
+            typename ops::run_connect_iter_op{this},
             handler,
-            this,
             begin, end,
             connect_condition);
 }
@@ -1007,9 +1047,8 @@ async_read_some(
     return net::async_initiate<
         ReadHandler,
         void(error_code, std::size_t)>(
-            typename ops::run_read_op{},
+            typename ops::run_read_op{this},
             handler,
-            this,
             buffers);
 }
 
@@ -1027,9 +1066,8 @@ async_write_some(
     return net::async_initiate<
         WriteHandler,
         void(error_code, std::size_t)>(
-            typename ops::run_write_op{},
+            typename ops::run_write_op{this},
             handler,
-            this,
             buffers);
 }
 

--- a/include/boost/beast/core/impl/buffered_read_stream.hpp
+++ b/include/boost/beast/core/impl/buffered_read_stream.hpp
@@ -106,11 +106,20 @@ public:
 
 struct run_read_op
 {
+    buffered_read_stream* self;
+
+    using executor_type = typename buffered_read_stream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return self->get_executor();
+    }
+
     template<class ReadHandler, class Buffers>
     void
     operator()(
         ReadHandler&& h,
-        buffered_read_stream* s,
         Buffers const* b)
     {
         // If you get an error on the following line it means
@@ -125,7 +134,7 @@ struct run_read_op
         read_op<
             Buffers,
             typename std::decay<ReadHandler>::type>(
-                std::forward<ReadHandler>(h), *s, *b);
+                std::forward<ReadHandler>(h), *self, *b);
     }
 };
 
@@ -231,9 +240,8 @@ async_read_some(
     return net::async_initiate<
         ReadHandler,
         void(error_code, std::size_t)>(
-            typename ops::run_read_op{},
+            typename ops::run_read_op{this},
             handler,
-            this,
             &buffers);
 }
 

--- a/include/boost/beast/core/impl/flat_stream.hpp
+++ b/include/boost/beast/core/impl/flat_stream.hpp
@@ -85,11 +85,20 @@ public:
 
 struct run_write_op
 {
+    flat_stream* self;
+
+    using executor_type = typename flat_stream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return self->get_executor();
+    }
+
     template<class WriteHandler, class Buffers>
     void
     operator()(
         WriteHandler&& h,
-        flat_stream* s,
         Buffers const& b)
     {
         // If you get an error on the following line it means
@@ -103,7 +112,7 @@ struct run_write_op
 
         write_op<
             typename std::decay<WriteHandler>::type>(
-                std::forward<WriteHandler>(h), *s, b);
+                std::forward<WriteHandler>(h), *self, b);
     }
 };
 
@@ -250,9 +259,8 @@ async_write_some(
     return net::async_initiate<
         WriteHandler,
         void(error_code, std::size_t)>(
-            typename ops::run_write_op{},
+            typename ops::run_write_op{this},
             handler,
-            this,
             buffers);
 }
 

--- a/include/boost/beast/http/impl/file_body_win32.hpp
+++ b/include/boost/beast/http/impl/file_body_win32.hpp
@@ -509,17 +509,23 @@ public:
     }
 };
 
+template<class Protocol, class Executor>
 struct run_write_some_win32_op
 {
-    template<
-        class Protocol, class Executor,
-        bool isRequest, class Fields,
-        class WriteHandler>
+    net::basic_stream_socket<Protocol, Executor>* stream;
+
+    using executor_type = typename net::basic_stream_socket<Protocol, Executor>::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return stream->get_executor();
+    }
+
+    template<bool isRequest, class Fields, class WriteHandler>
     void
     operator()(
         WriteHandler&& h,
-        net::basic_stream_socket<
-            Protocol, Executor>* s,
         serializer<isRequest,
             basic_file_body<file_win32>, Fields>* sr)
     {
@@ -536,7 +542,7 @@ struct run_write_some_win32_op
             Protocol, Executor,
             isRequest, Fields,
             typename std::decay<WriteHandler>::type>(
-                std::forward<WriteHandler>(h), *s, *sr);
+                std::forward<WriteHandler>(h), *stream, *sr);
     }
 };
 
@@ -629,9 +635,8 @@ async_write_some(
     return net::async_initiate<
         WriteHandler,
         void(error_code, std::size_t)>(
-            detail::run_write_some_win32_op{},
+            detail::run_write_some_win32_op<Protocol, Executor>{&sock},
             handler,
-            &sock,
             &sr);
 }
 

--- a/include/boost/beast/http/impl/write.hpp
+++ b/include/boost/beast/http/impl/write.hpp
@@ -299,16 +299,25 @@ public:
     }
 };
 
+template <typename AsyncWriteStream>
 struct run_write_some_op
 {
+    AsyncWriteStream* stream;
+
+    using executor_type = typename AsyncWriteStream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return stream->get_executor();
+    }
+
     template<
         class WriteHandler,
-        class Stream,
         bool isRequest, class Body, class Fields>
     void
     operator()(
         WriteHandler&& h,
-        Stream* s,
         serializer<isRequest, Body, Fields>* sr)
     {
         // If you get an error on the following line it means
@@ -322,23 +331,32 @@ struct run_write_some_op
 
         write_some_op<
             typename std::decay<WriteHandler>::type,
-            Stream,
+            AsyncWriteStream,
             isRequest, Body, Fields>(
-                std::forward<WriteHandler>(h), *s, *sr);
+                std::forward<WriteHandler>(h), *stream, *sr);
     }
 };
 
+template <typename AsyncWriteStream>
 struct run_write_op
 {
+    AsyncWriteStream* stream;
+
+    using executor_type = typename AsyncWriteStream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return stream->get_executor();
+    }
+
     template<
         class WriteHandler,
-        class Stream,
         class Predicate,
         bool isRequest, class Body, class Fields>
     void
     operator()(
         WriteHandler&& h,
-        Stream* s,
         Predicate const&,
         serializer<isRequest, Body, Fields>* sr)
     {
@@ -353,24 +371,33 @@ struct run_write_op
 
         write_op<
             typename std::decay<WriteHandler>::type,
-            Stream,
+            AsyncWriteStream,
             Predicate,
             isRequest, Body, Fields>(
-                std::forward<WriteHandler>(h), *s, *sr);
+                std::forward<WriteHandler>(h), *stream, *sr);
     }
 };
 
+template <typename AsyncWriteStream>
 struct run_write_msg_op
 {
+    AsyncWriteStream* stream;
+
+    using executor_type = typename AsyncWriteStream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return stream->get_executor();
+    }
+
     template<
         class WriteHandler,
-        class Stream,
         bool isRequest, class Body, class Fields,
         class... Args>
     void
     operator()(
         WriteHandler&& h,
-        Stream* s,
         message<isRequest, Body, Fields>* m,
         std::false_type,
         Args&&... args)
@@ -386,21 +413,19 @@ struct run_write_msg_op
 
         write_msg_op<
             typename std::decay<WriteHandler>::type,
-            Stream,
+            AsyncWriteStream,
             isRequest, Body, Fields>(
-                std::forward<WriteHandler>(h), *s, *m,
+                std::forward<WriteHandler>(h), *stream, *m,
                 std::forward<Args>(args)...);
     }
 
     template<
         class WriteHandler,
-        class Stream,
         bool isRequest, class Body, class Fields,
         class... Args>
     void
     operator()(
         WriteHandler&& h,
-        Stream* s,
         message<isRequest, Body, Fields> const* m,
         std::true_type,
         Args&&... args)
@@ -416,9 +441,9 @@ struct run_write_msg_op
 
         write_msg_op<
             typename std::decay<WriteHandler>::type,
-            Stream,
+            AsyncWriteStream,
             isRequest, Body, Fields>(
-                std::forward<WriteHandler>(h), *s, *m,
+                std::forward<WriteHandler>(h), *stream, *m,
                 std::forward<Args>(args)...);
     }
 };
@@ -513,9 +538,8 @@ async_write_some_impl(
     return net::async_initiate<
         WriteHandler,
         void(error_code, std::size_t)>(
-            run_write_some_op{},
+            run_write_some_op<AsyncWriteStream>{&stream},
             handler,
-            &stream,
             &sr);
 }
 
@@ -666,9 +690,8 @@ async_write_header(
     return net::async_initiate<
         WriteHandler,
         void(error_code, std::size_t)>(
-            detail::run_write_op{},
+            detail::run_write_op<AsyncWriteStream>{&stream},
             handler,
-            &stream,
             detail::serializer_is_header_done{},
             &sr);
 }
@@ -739,9 +762,8 @@ async_write(
     return net::async_initiate<
         WriteHandler,
         void(error_code, std::size_t)>(
-            detail::run_write_op{},
+            detail::run_write_op<AsyncWriteStream>{&stream},
             handler,
-            &stream,
             detail::serializer_is_done{},
             &sr);
 }
@@ -860,9 +882,8 @@ async_write(
     return net::async_initiate<
         WriteHandler,
         void(error_code, std::size_t)>(
-            detail::run_write_msg_op{},
+            detail::run_write_msg_op<AsyncWriteStream>{&stream},
             handler,
-            &stream,
             &msg,
             std::false_type{});
 }
@@ -889,9 +910,8 @@ async_write(
     return net::async_initiate<
         WriteHandler,
         void(error_code, std::size_t)>(
-            detail::run_write_msg_op{},
+            detail::run_write_msg_op<AsyncWriteStream>{&stream},
             handler,
-            &stream,
             &msg,
             std::true_type{});
 }

--- a/include/boost/beast/websocket/impl/accept.hpp
+++ b/include/boost/beast/websocket/impl/accept.hpp
@@ -368,6 +368,16 @@ template<class NextLayer, bool deflateSupported>
 struct stream<NextLayer, deflateSupported>::
     run_response_op
 {
+    boost::shared_ptr<impl_type> const& self;
+
+    using executor_type = typename stream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return self->stream().get_executor();
+    }
+
     template<
         class AcceptHandler,
         class Body, class Allocator,
@@ -375,7 +385,6 @@ struct stream<NextLayer, deflateSupported>::
     void
     operator()(
         AcceptHandler&& h,
-        boost::shared_ptr<impl_type> const& sp,
         http::request<Body,
             http::basic_fields<Allocator>> const* m,
         Decorator const& d)
@@ -391,7 +400,7 @@ struct stream<NextLayer, deflateSupported>::
 
         response_op<
             typename std::decay<AcceptHandler>::type>(
-                std::forward<AcceptHandler>(h), sp, *m, d);
+                std::forward<AcceptHandler>(h), self, *m, d);
     }
 };
 
@@ -399,6 +408,16 @@ template<class NextLayer, bool deflateSupported>
 struct stream<NextLayer, deflateSupported>::
     run_accept_op
 {
+    boost::shared_ptr<impl_type> const& self;
+
+    using executor_type = typename stream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return self->stream().get_executor();
+    }
+
     template<
         class AcceptHandler,
         class Decorator,
@@ -406,7 +425,6 @@ struct stream<NextLayer, deflateSupported>::
     void
     operator()(
         AcceptHandler&& h,
-        boost::shared_ptr<impl_type> const& sp,
         Decorator const& d,
         Buffers const& b)
     {
@@ -423,7 +441,7 @@ struct stream<NextLayer, deflateSupported>::
             typename std::decay<AcceptHandler>::type,
             Decorator>(
                 std::forward<AcceptHandler>(h),
-                sp,
+                self,
                 d,
                 b);
     }
@@ -615,9 +633,8 @@ async_accept(
     return net::async_initiate<
         AcceptHandler,
         void(error_code)>(
-            run_accept_op{},
+            run_accept_op{impl_},
             handler,
-            impl_,
             &default_decorate_res,
             net::const_buffer{});
 }
@@ -648,9 +665,8 @@ async_accept(
     return net::async_initiate<
         AcceptHandler,
         void(error_code)>(
-            run_accept_op{},
+            run_accept_op{impl_},
             handler,
-            impl_,
             &default_decorate_res,
             buffers);
 }
@@ -671,9 +687,8 @@ async_accept(
     return net::async_initiate<
         AcceptHandler,
         void(error_code)>(
-            run_response_op{},
+            run_response_op{impl_},
             handler,
-            impl_,
             &req,
             &default_decorate_res);
 }

--- a/include/boost/beast/websocket/impl/close.hpp
+++ b/include/boost/beast/websocket/impl/close.hpp
@@ -302,11 +302,20 @@ template<class NextLayer, bool deflateSupported>
 struct stream<NextLayer, deflateSupported>::
     run_close_op
 {
+    boost::shared_ptr<impl_type> const& self;
+
+    using executor_type = typename stream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return self->stream().get_executor();
+    }
+
     template<class CloseHandler>
     void
     operator()(
         CloseHandler&& h,
-        boost::shared_ptr<impl_type> const& sp,
         close_reason const& cr)
     {
         // If you get an error on the following line it means
@@ -321,7 +330,7 @@ struct stream<NextLayer, deflateSupported>::
         close_op<
             typename std::decay<CloseHandler>::type>(
                 std::forward<CloseHandler>(h),
-                sp,
+                self,
                 cr);
     }
 };
@@ -458,9 +467,8 @@ async_close(close_reason const& cr, CloseHandler&& handler)
     return net::async_initiate<
         CloseHandler,
         void(error_code)>(
-            run_close_op{},
+            run_close_op{impl_},
             handler,
-            impl_,
             cr);
 }
 

--- a/include/boost/beast/websocket/impl/handshake.hpp
+++ b/include/boost/beast/websocket/impl/handshake.hpp
@@ -188,10 +188,19 @@ template<class NextLayer, bool deflateSupported>
 struct stream<NextLayer, deflateSupported>::
     run_handshake_op
 {
+    boost::shared_ptr<impl_type> const& self;
+
+    using executor_type = typename stream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return self->stream().get_executor();
+    }
+
     template<class HandshakeHandler>
     void operator()(
         HandshakeHandler&& h,
-        boost::shared_ptr<impl_type> const& sp,
         request_type&& req,
         detail::sec_ws_key_type key,
         response_type* res_p)
@@ -208,7 +217,7 @@ struct stream<NextLayer, deflateSupported>::
         handshake_op<
             typename std::decay<HandshakeHandler>::type>(
                 std::forward<HandshakeHandler>(h),
-                    sp, std::move(req), key, res_p);
+                    self, std::move(req), key, res_p);
     }
 };
 
@@ -311,9 +320,8 @@ async_handshake(
     return net::async_initiate<
         HandshakeHandler,
         void(error_code)>(
-            run_handshake_op{},
+            run_handshake_op{impl_},
             handler,
-            impl_,
             std::move(req),
             key,
             nullptr);
@@ -338,9 +346,8 @@ async_handshake(
     return net::async_initiate<
         HandshakeHandler,
         void(error_code)>(
-            run_handshake_op{},
+            run_handshake_op{impl_},
             handler,
-            impl_,
             std::move(req),
             key,
             &res);

--- a/include/boost/beast/websocket/impl/ping.hpp
+++ b/include/boost/beast/websocket/impl/ping.hpp
@@ -245,11 +245,20 @@ template<class NextLayer, bool deflateSupported>
 struct stream<NextLayer, deflateSupported>::
     run_ping_op
 {
+    boost::shared_ptr<impl_type> const& self;
+
+    using executor_type = typename stream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return self->stream().get_executor();
+    }
+
     template<class WriteHandler>
     void
     operator()(
         WriteHandler&& h,
-        boost::shared_ptr<impl_type> const& sp,
         detail::opcode op,
         ping_data const& p)
     {
@@ -265,7 +274,7 @@ struct stream<NextLayer, deflateSupported>::
         ping_op<
             typename std::decay<WriteHandler>::type>(
                 std::forward<WriteHandler>(h),
-                sp,
+                self,
                 op,
                 p);
     }
@@ -336,9 +345,8 @@ async_ping(ping_data const& payload, PingHandler&& handler)
     return net::async_initiate<
         PingHandler,
         void(error_code)>(
-            run_ping_op{},
+            run_ping_op{impl_},
             handler,
-            impl_,
             detail::opcode::ping,
             payload);
 }
@@ -354,9 +362,8 @@ async_pong(ping_data const& payload, PongHandler&& handler)
     return net::async_initiate<
         PongHandler,
         void(error_code)>(
-            run_ping_op{},
+            run_ping_op{impl_},
             handler,
-            impl_,
             detail::opcode::pong,
             payload);
 }

--- a/include/boost/beast/websocket/impl/write.hpp
+++ b/include/boost/beast/websocket/impl/write.hpp
@@ -559,13 +559,22 @@ template<class NextLayer, bool deflateSupported>
 struct stream<NextLayer, deflateSupported>::
     run_write_some_op
 {
+    boost::shared_ptr<impl_type> const& self;
+
+    using executor_type = typename stream::executor_type;
+
+    executor_type
+    get_executor() const noexcept
+    {
+        return self->stream().get_executor();
+    }
+
     template<
         class WriteHandler,
         class ConstBufferSequence>
     void
     operator()(
         WriteHandler&& h,
-        boost::shared_ptr<impl_type> const& sp,
         bool fin,
         ConstBufferSequence const& b)
     {
@@ -582,7 +591,7 @@ struct stream<NextLayer, deflateSupported>::
             typename std::decay<WriteHandler>::type,
             ConstBufferSequence>(
                 std::forward<WriteHandler>(h),
-                sp,
+                self,
                 fin,
                 b);
     }
@@ -836,9 +845,8 @@ async_write_some(bool fin,
     return net::async_initiate<
         WriteHandler,
         void(error_code, std::size_t)>(
-            run_write_some_op{},
+            run_write_some_op{impl_},
             handler,
-            impl_,
             fin,
             bs);
 }
@@ -892,9 +900,8 @@ async_write(
     return net::async_initiate<
         WriteHandler,
         void(error_code, std::size_t)>(
-            run_write_some_op{},
+            run_write_some_op{impl_},
             handler,
-            impl_,
             true,
             bs);
 }


### PR DESCRIPTION
This is required for the new `asio::cancel_at` and `asio::cancel_after` completion token adapters to work.