### PR TITLE
Remove Boost.Scope dependency from examples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,11 @@ jobs:
             os: ubuntu-24.04
             install: g++-13
             supported: true
+          - toolset: gcc-14
+            cxxstd: "11,14,17,20,2b"
+            os: ubuntu-24.04
+            install: g++-14
+            supported: true
 # clang 3.5 not supported
 # It can't compile the websocket stream code
           - toolset: clang

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,7 +11,6 @@ concurrency:
   group: ${{format('{0}:{1}:{2}', github.repository, github.workflow, github.ref)}}
   cancel-in-progress: true
 
-
 jobs:
   fuzz:
     runs-on: ubuntu-24.04
@@ -41,9 +40,7 @@ jobs:
           cd boost-root
           cp -r $GITHUB_WORKSPACE/* libs/$LIBRARY
           git submodule update --init tools/boostdep
-          python3 tools/boostdep/depinst/depinst.py $LIBRARY
-          ./bootstrap.sh
-          ./b2
+          python tools/boostdep/depinst/depinst.py --git_args "--jobs 3" $LIBRARY
   
       - name: Fuzz corpus
         uses: actions/cache@v3.3.1
@@ -58,13 +55,11 @@ jobs:
       - name: Run fuzzer
         run: |
           cd ../boost-root/libs/beast
-          mkdir build
-          cd build
+          mkdir __build__ && cd __build__
           cmake \
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_C_COMPILER=clang \
             -DBOOST_BEAST_BUILD_EXAMPLES=OFF \
-            -DBOOST_BEAST_BUILD_TESTS=ON \
             -DBOOST_BEAST_BUILD_FUZZERS=ON \
             -DBOOST_BEAST_FUZZER_CORPUS_PATH=${{ github.workspace }}/corpus.tar ..
           make boost_beast_fuzz_all

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,28 +55,28 @@ set(BOOST_SRC_DIR ${DEFAULT_BOOST_SRC_DIR} CACHE STRING "Boost source dir to use
 #-------------------------------------------------
 # The boost super-project requires one explicit dependency per-line.
 set(BOOST_BEAST_DEPENDENCIES
-        Boost::asio
-        Boost::assert
-        Boost::bind
-        Boost::config
-        Boost::container
-        Boost::container_hash
-        Boost::core
-        Boost::endian
-        Boost::intrusive
-        Boost::logic
-        Boost::mp11
-        Boost::optional
-        Boost::preprocessor
-        Boost::smart_ptr
-        Boost::static_assert
-        Boost::static_string
-        Boost::system
-        Boost::throw_exception
-        Boost::type_index
-        Boost::type_traits
-        Boost::winapi
-        )
+    Boost::asio
+    Boost::assert
+    Boost::bind
+    Boost::config
+    Boost::container
+    Boost::container_hash
+    Boost::core
+    Boost::endian
+    Boost::intrusive
+    Boost::logic
+    Boost::mp11
+    Boost::optional
+    Boost::preprocessor
+    Boost::smart_ptr
+    Boost::static_assert
+    Boost::static_string
+    Boost::system
+    Boost::throw_exception
+    Boost::type_index
+    Boost::type_traits
+    Boost::winapi)
+
 foreach (BOOST_BEAST_DEPENDENCY ${BOOST_BEAST_DEPENDENCIES})
     if (BOOST_BEAST_DEPENDENCY MATCHES "^[ ]*Boost::([A-Za-z0-9_]+)[ ]*$")
         list(APPEND BOOST_BEAST_INCLUDE_LIBRARIES ${CMAKE_MATCH_1})
@@ -87,7 +87,7 @@ if (BOOST_BEAST_BUILD_TESTS)
     set(BOOST_BEAST_UNIT_TEST_LIBRARIES filesystem)
 endif ()
 if (BOOST_BEAST_BUILD_EXAMPLES)
-    set(BOOST_BEAST_EXAMPLE_LIBRARIES scope json)
+    set(BOOST_BEAST_EXAMPLE_LIBRARIES json)
 endif ()
 # Complete dependency list
 set(BOOST_INCLUDE_LIBRARIES ${BOOST_BEAST_INCLUDE_LIBRARIES} ${BOOST_BEAST_UNIT_TEST_LIBRARIES} ${BOOST_BEAST_EXAMPLE_LIBRARIES})

--- a/example/advanced/server-flex-awaitable/CMakeLists.txt
+++ b/example/advanced/server-flex-awaitable/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(advanced-server-flex-awaitable
     PRIVATE ${PROJECT_SOURCE_DIR})
 
 target_link_libraries(advanced-server-flex-awaitable
-    PRIVATE Boost::beast Boost::scope OpenSSL::SSL OpenSSL::Crypto)
+    PRIVATE Boost::beast OpenSSL::SSL OpenSSL::Crypto)
 
 set_target_properties(advanced-server-flex-awaitable
     PROPERTIES FOLDER "example-advanced-server")

--- a/example/advanced/server-flex-awaitable/Jamfile
+++ b/example/advanced/server-flex-awaitable/Jamfile
@@ -12,7 +12,6 @@ import ac ;
 project
     : requirements
         [ ac.check-library /boost/beast/test//lib-asio-ssl : <library>/boost/beast/test//lib-asio-ssl/<link>static : <build>no ]
-        <library>/boost/scope//boost_scope
     ;
 
 exe advanced-server-flex-awaitable :

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -86,6 +86,6 @@ add_subdirectory(bench)
 add_subdirectory(doc)
 add_subdirectory(example)
 
-if (BOOST_BEAST_BUILD_FUZZERS AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if (BOOST_BEAST_BUILD_FUZZERS)
     add_subdirectory(fuzz)
 endif ()


### PR DESCRIPTION
Boost.Scope triggers a strange internal compiler error in GCC 14:
```
/workspace/boost/libs/asio/include/boost/asio/impl/co_spawn.hpp: In function ‘boost::asio::awaitable<boost::asio::detail::awaitable_thread_entry_point, Executor> boost::asio::detail::co_spawn_entry_point(boost::asio::awaitable<void, AwaitableExecutor>*, co_spawn_state<Handler, Executor, Function>) [with Handler = boost::asio::cancellation_slot_binder<consign_handler<listen(listen(task_group&, boost::asio::ssl::context&, boost::asio::ip::tcp::endpoint, boost::beast::string_view)::_Z6listenR10task_groupRN5boost4asio3ssl7contextENS2_2ip14basic_endpointINS6_3tcpEEENS1_4core17basic_string_viewIcEE.Frame*)::<lambda(std::__exception_ptr::exception_ptr)>, boost::scope::scope_exit<task_group::adapt<listen(listen(task_group&, boost::asio::ssl::context&, boost::asio::ip::tcp::endpoint, boost::beast::string_view)::_Z6listenR10task_groupRN5boost4asio3ssl7contextENS2_2ip14basic_endpointINS6_3tcpEEENS1_4core17basic_string_viewIcEE.Frame*)::<lambda(std::__exception_ptr::exception_ptr)> >(listen(listen(task_group&, boost::asio::ssl::context&, boost::asio::ip::tcp::endpoint, boost::beast::string_view)::_Z6listenR10task_groupRN5boost4asio3ssl7contextENS2_2ip14basic_endpointINS6_3tcpEEENS1_4core17basic_string_viewIcEE.Frame*)::<lambda(std::__exception_ptr::exception_ptr)>&&)::<lambda()>, boost::scope::always_true> >, boost::asio::cancellation_slot>; Executor = boost::asio::strand<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0> >; Function = awaitable_as_function<void, boost::asio::strand<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0> > >]’:
/workspace/boost/libs/asio/include/boost/asio/impl/co_spawn.hpp:226:1: internal compiler error: in gimplify_var_or_parm_decl, at gimplify.cc:3308
  226 | }
      | ^
0x1431e4c internal_error(char const*, ...)
        ???:0
0x1431f22 fancy_abort(char const*, int, char const*)
        ???:0
0x159c676 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0x159c6ca gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0x159c08e gimplify_stmt(tree_node**, gimple**)
        ???:0
0x159dd72 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0x159d910 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0x159d2da gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0x159d31b gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0x159d3e5 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0x159d31b gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0x159c08e gimplify_stmt(tree_node**, gimple**)
        ???:0
0x159ce0d gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0x159d31b gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0x159d3e5 gimplify_expr(tree_node**, gimple**, gimple**, bool (*)(tree_node*), int)
        ???:0
0x1593e1b gimplify_body(tree_node*, bool)
        ???:0
0x15922bc gimplify_function_tree(tree_node*)
        ???:0
0x15918af cgraph_node::analyze()
        ???:0
0x1b06681 symbol_table::finalize_compilation_unit()
        ???:0
Please submit a full bug report, with preprocessed source (by using -freport-bug).
```