### PR TITLE
Add missing "return"

### DIFF
--- a/example/websocket/server/async-ssl/websocket_server_async_ssl.cpp
+++ b/example/websocket/server/async-ssl/websocket_server_async_ssl.cpp
@@ -151,7 +151,7 @@ public:
             return;
 
         if(ec)
-            fail(ec, "read");
+            return fail(ec, "read");
 
         // Echo the message
         ws_.text(ws_.got_text());


### PR DESCRIPTION
Hi. Aren't we supposed to return in case of an error? Similarly to what we do in other examples, for example in `websocket_server_async_local.cpp`. 