### PR TITLE
Annotate facade header with IWYU export annotation

### DIFF
--- a/include/boost/beast.hpp
+++ b/include/boost/beast.hpp
@@ -10,6 +10,8 @@
 #ifndef BOOST_BEAST_HPP
 #define BOOST_BEAST_HPP
 
+// IWYU pragma: begin_exports
+
 #include <boost/beast/core/detail/config.hpp> // must come first
 
 #include <boost/beast/core.hpp>
@@ -17,5 +19,7 @@
 #include <boost/beast/version.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/beast/zlib.hpp>
+
+// IWYU pragma: end_exports
 
 #endif


### PR DESCRIPTION
Without that annotation, tools such as `clang-tidy` or the `clangd` language server (as well as many other tools) will complain about headers not directly providing a symbol if users include `beast.hpp`; With this annotation, they know.

Documentation IWYU
https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-begin_exportsend_exports

Documentation llvm include cleaner/clang-tidy/clangd https://clangd.llvm.org/design/include-cleaner#iwyu-pragmas