### PR TITLE
Fix cancellation slot retrieval in saved_handler::emplace.

### DIFF
--- a/include/boost/beast/core/impl/saved_handler.hpp
+++ b/include/boost/beast/core/impl/saved_handler.hpp
@@ -153,7 +153,7 @@ emplace(Handler&& handler, Allocator const& alloc,
     auto tmp = boost::exchange(s.p, nullptr);
     p_ = tmp;
 
-    auto c_slot = net::get_associated_cancellation_slot(handler);
+    auto c_slot = net::get_associated_cancellation_slot(tmp->v_.h);
     if (c_slot.is_connected())
     {
         class cancel_op


### PR DESCRIPTION
Bug introduced in a3d00a6d0c551026dc7e763f0297f974d3b062a4