### PR TITLE
Fix GCC zero-as-null-pointer-constant warnings

### DIFF
--- a/include/boost/beast/http/write.hpp
+++ b/include/boost/beast/http/write.hpp
@@ -702,7 +702,7 @@ async_write(
             executor_type<AsyncWriteStream>>{}
 #ifndef BOOST_BEAST_DOXYGEN
     , typename std::enable_if<
-        is_mutable_body_writer<Body>::value>::type* = 0
+        is_mutable_body_writer<Body>::value>::type* = nullptr
 #endif
     );
 
@@ -776,7 +776,7 @@ async_write(
             executor_type<AsyncWriteStream>>{}
 #ifndef BOOST_BEAST_DOXYGEN
     , typename std::enable_if<
-        ! is_mutable_body_writer<Body>::value>::type* = 0
+        ! is_mutable_body_writer<Body>::value>::type* = nullptr
 #endif
     );
 

--- a/include/boost/beast/websocket/impl/stream_impl.hpp
+++ b/include/boost/beast/websocket/impl/stream_impl.hpp
@@ -501,7 +501,7 @@ private:
     template<class Executor>
     static net::execution_context&
     get_context(Executor const& ex,
-        typename std::enable_if< net::execution::is_executor<Executor>::value >::type* = 0)
+        typename std::enable_if< net::execution::is_executor<Executor>::value >::type* = nullptr)
     {
         return net::query(ex, net::execution::context);
     }
@@ -509,7 +509,7 @@ private:
     template<class Executor>
     static net::execution_context&
     get_context(Executor const& ex,
-        typename std::enable_if< !net::execution::is_executor<Executor>::value >::type* = 0)
+        typename std::enable_if< !net::execution::is_executor<Executor>::value >::type* = nullptr)
     {
         return ex.context();
     }

--- a/include/boost/beast/websocket/stream.hpp
+++ b/include/boost/beast/websocket/stream.hpp
@@ -1499,10 +1499,10 @@ public:
 #ifndef BOOST_BEAST_DOXYGEN
         , typename std::enable_if<
             net::is_const_buffer_sequence<
-            ConstBufferSequence>::value>::type* = 0
+            ConstBufferSequence>::value>::type* = nullptr
         , typename std::enable_if<
             ! http::detail::is_header<
-            ConstBufferSequence>::value>::type* = 0
+            ConstBufferSequence>::value>::type* = nullptr
 #endif
     );
 


### PR DESCRIPTION
Probably a GCC bug as I have boost as system include. Maybe related to using C++20 coroutines.