### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -51,7 +51,6 @@ else()
   date_time
   move
   describe
-  static_assert
   utility
   variant2
   predef

--- a/tools/get-boost.sh
+++ b/tools/get-boost.sh
@@ -37,7 +37,6 @@ git submodule update --init --depth 20 --jobs 4 \
     libs/optional \
     libs/scope \
     libs/smart_ptr \
-    libs/static_assert \
     libs/static_string \
     libs/system \
     libs/throw_exception \


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.