### PR TITLE
HTTP: Increase max read buffer size to 128KB

### DIFF
--- a/include/boost/beast/http/impl/read.hpp
+++ b/include/boost/beast/http/impl/read.hpp
@@ -206,7 +206,7 @@ public:
                 {
                     cont_ = true;
                     // VFALCO This was read_size_or_throw
-                    auto const size = read_size(b_, 65536);
+                    auto const size = read_size(b_, 128*1024);
                     if(size == 0)
                     {
                         BOOST_BEAST_ASSIGN_EC(ec, error::buffer_overflow);
@@ -352,7 +352,7 @@ read_some(SyncReadStream& s, DynamicBuffer& b, basic_parser<isRequest>& p, error
 
     do_read:
         // VFALCO This was read_size_or_throw
-        auto const size = read_size(b, 65536);
+        auto const size = read_size(b, 128*1024);
         if(size == 0)
         {
             BOOST_BEAST_ASSIGN_EC(ec, error::buffer_overflow);


### PR DESCRIPTION
Increase the max read buffer size in read_size from 64KB to 128KB. This change aligns with another optimizations in Asio/SSL to reduce io_context contention and CPU utilization by allowing larger reads per operation: https://github.com/chriskohlhoff/asio/pull/1712