### PR TITLE
doc: fix json_body example entry in examples table

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -23,3 +23,5 @@ ignore:
   - extra/**/*
   - test/*
   - test/**/*
+  - tools/*
+  - tools/**/*

--- a/doc/qbk/02_examples/_examples.qbk
+++ b/doc/qbk/02_examples/_examples.qbk
@@ -54,7 +54,9 @@ used to evaluate robustness. All asynchronous clients support timeouts.
         []
 ][
         [HTTP json_body (synchronous)]
-        [[path_link example/http/client/body/json_client.cpp json_client.cpp]]
+        [[path_link example/http/client/body/json_body.hpp json_body.hpp]
+         [path_link example/http/client/body/json_client.cpp json_client.cpp]]
+        []
 ][
         [HTTP client for all methods (synchronous)]
         [[path_link example/http/client/methods/http_client_methods.cpp http_client_methods.cpp]]

--- a/tools/get-boost.sh
+++ b/tools/get-boost.sh
@@ -82,6 +82,7 @@ git submodule update --init --depth 20 --jobs 4 \
     libs/ratio \
     libs/rational \
     libs/regex \
+    libs/static_assert \
     libs/thread \
     libs/tuple \
     libs/type_index \


### PR DESCRIPTION
The json_body example row in the HTTP clients table was missing a link to `json_body.hpp`, which is the actual file that defines the custom body type and is the main point of the example. Also added the missing empty SSL column placeholder `[]` to match the structure of every other row in the table.