### PR TITLE
basic_parser ignores connection and framing fields in trailers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,20 +76,13 @@ jobs:
           - toolset: gcc-15
             cxxstd: 11,14,17,20,23,2c
             os: ubuntu-latest
-            container: ubuntu:25.04
+            container: ubuntu:26.04
             install: g++-15
-          - toolset: clang
-            compiler: clang++-3.5
-            cxxstd: 11
-            os: ubuntu-24.04
-            container: ubuntu:16.04
-            install: clang-3.5
-          - toolset: clang
-            compiler: clang++-3.6
-            cxxstd: 11,14
-            os: ubuntu-24.04
-            container: ubuntu:16.04
-            install: clang-3.6
+          - toolset: gcc-16
+            cxxstd: 11,14,17,20,23,2c
+            os: ubuntu-latest
+            container: ubuntu:26.04
+            install: g++-16
           - toolset: clang
             compiler: clang++-3.7
             cxxstd: 11,14
@@ -200,23 +193,29 @@ jobs:
             compiler: clang++-20
             cxxstd: 11,14,17,20,23,2c
             os: ubuntu-latest
-            container: ubuntu:25.04
+            container: ubuntu:24.04
             install: clang-20
           - toolset: clang
             compiler: clang++-21
             cxxstd: 11,14,17,20,23,2c
             os: ubuntu-latest
-            container: ubuntu:25.10
+            container: ubuntu:26.04
             install: clang-21
+          - toolset: clang
+            compiler: clang++-22
+            cxxstd: 11,14,17,20,23,2c
+            os: ubuntu-latest
+            container: ubuntu:26.04
+            install: clang-22
           - toolset: clang
             os: macos-14
             cxxstd: 11,14,17,20,2b
           - toolset: clang
             os: macos-15
-            cxxstd: 11,14,17,20,2b
+            cxxstd: 11,14,17,20,23,2c
           - toolset: clang
             os: macos-26
-            cxxstd: 11,14,17,20,2b
+            cxxstd: 11,14,17,20,23,2c
 
     needs: [runner-selection]
     runs-on: ${{ fromJSON(needs.runner-selection.outputs.labelmatrix)[matrix.os] }}
@@ -285,6 +284,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - toolset: msvc-14.5
+            cxxstd: 14,17
+            addrmd: 32
+            os: windows-2025-vs2026
+          - toolset: msvc-14.5
+            cxxstd: 20,latest
+            addrmd: 32
+            os: windows-2025-vs2026
+          - toolset: msvc-14.5
+            cxxstd: 14,17
+            addrmd: 64
+            os: windows-2025-vs2026
+          - toolset: msvc-14.5
+            cxxstd: 20,latest
+            addrmd: 64
+            os: windows-2025-vs2026
           - toolset: msvc-14.3
             cxxstd: 14,17
             addrmd: 32
@@ -302,30 +317,25 @@ jobs:
             addrmd: 64
             os: windows-2022
           - toolset: clang-win
-            cxxstd: 14,17,latest
+            cxxstd: 14,17,20,latest
             addrmd: 32
-            os: windows-2022
+            os: windows-2025
             cxxflags: "linkflags=/safeseh:no"
           - toolset: clang-win
-            cxxstd: 14,17,latest
+            cxxstd: 14,17,20,latest
             addrmd: 64
-            os: windows-2022
-
-          # The windows-2022 image comes with GCC 12, which causes a
-          # `file too big` error even when using `-Wa,-mbig-obj` and
-          # `debug-symbols=off`.
-
-          # - toolset: gcc
-          #   cxxstd: "11,14"
-          #   addrmd: 64
-          #   os: windows-2022
-          # - toolset: gcc
-          #   cxxstd: "17,2a"
-          #   addrmd: 64
-          #   os: windows-2022
+            os: windows-2025
+          - toolset: gcc
+            cxxstd: "11,14"
+            addrmd: 64
+            os: windows-2025-no-aws
+          - toolset: gcc
+            cxxstd: "17,2a"
+            addrmd: 64
+            os: windows-2025-no-aws
 
     needs: [runner-selection]
-    runs-on: ${{ fromJSON(needs.runner-selection.outputs.labelmatrix)[matrix.os] }}
+    runs-on: ${{ fromJSON(needs.runner-selection.outputs.labelmatrix)[matrix.os] || matrix.os }}
 
     steps:
       - uses: actions/checkout@v4

--- a/include/boost/beast/_experimental/unit_test/suite_list.hpp
+++ b/include/boost/beast/_experimental/unit_test/suite_list.hpp
@@ -14,7 +14,7 @@
 #include <boost/beast/_experimental/unit_test/detail/const_container.hpp>
 #include <boost/assert.hpp>
 #include <boost/type_index.hpp>
-#include <boost/functional/hash.hpp>
+#include <boost/container_hash/hash.hpp>
 #include <typeindex>
 #include <set>
 #include <unordered_set>

--- a/include/boost/beast/http/impl/basic_parser.ipp
+++ b/include/boost/beast/http/impl/basic_parser.ipp
@@ -387,15 +387,19 @@ inner_parse_fields(char const*& in,
         if(ec)
             return;
         auto const f = string_to_field(name);
-        do_field(f, value, ec);
-        if(ec)
-            return;
         if(BOOST_UNLIKELY(state_ == state::trailer_fields))
         {
+            // do_field() applies header-section semantics
+            // (Content-Length, Transfer-Encoding, Connection,
+            // Upgrade) which must not be honored when they appear
+            // in a chunked trailer, see rfc7230 section 4.1.2.
             this->on_trailer_field_impl(f, name, value, ec);
         }
         else
         {
+            do_field(f, value, ec);
+            if(ec)
+                return;
             this->on_field_impl(f, name, value, ec);
         }
         if(ec)

--- a/include/boost/beast/http/parser.hpp
+++ b/include/boost/beast/http/parser.hpp
@@ -498,11 +498,23 @@ private:
         string_view value,
         error_code& ec) override
     {
+        // Drop fields not advertised in the Trailer header
         if(! token_list{m_[field::trailer]}.exists(name_string))
             return;
 
         switch(name)
         {
+        // Drop fields that govern message framing or connection handling
+        case field::connection:
+        case field::proxy_connection:
+        case field::upgrade:
+        case field::transfer_encoding:
+        case field::content_length:
+        case field::trailer:
+        case field::host:
+            return;
+
+        // Safe and well-known trailer fields
         case field::digest:          // RFC 3230, Section 2 (obsolete)
         case field::content_digest:  // RFC 9530, Section 2
         case field::repr_digest:     // RFC 9530, Section 3
@@ -513,6 +525,7 @@ private:
         case field::link:            // RFC 8288, Section 3
         case field::alt_svc:         // RFC 7838, Section 3
             break;
+
         default:
             if(! merge_all_trailers_)
                 return;

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -58,6 +58,7 @@ local requirements =
     <target-os>windows:<define>_WIN32_WINNT=0x0A00
     <target-os>windows,<toolset>gcc:<library>ws2_32
     <target-os>windows,<toolset>gcc:<library>mswsock
+    <target-os>windows,<toolset>gcc:<cxxflags>-Wa,-mbig-obj
     <target-os>windows,<toolset>gcc-cygwin:<define>__USE_W32_SOCKETS
     <target-os>hpux,<toolset>gcc:<define>_XOPEN_SOURCE_EXTENDED
     <target-os>hpux:<library>ipv6

--- a/test/beast/http/parser.cpp
+++ b/test/beast/http/parser.cpp
@@ -441,6 +441,44 @@ public:
             // Upgrade in the trailer must not mark the message as upgrade
             BEAST_EXPECT(! p.upgrade());
         }
+
+        // framing/connection control fields are dropped even when they
+        // are listed in `Trailer` and merge_all_trailers(true) is set
+        {
+            error_code ec;
+            parser_type<false> p;
+            p.eager(true);
+            p.merge_all_trailers(true);
+            p.put(
+                buf("HTTP/1.1 200 OK\r\n"
+                    "Transfer-Encoding: chunked\r\n"
+                    "Trailer: Connection, Proxy-Connection, Upgrade, "
+                        "Transfer-Encoding, Content-Length, Trailer, Host\r\n"
+                    "\r\n"
+                    "0\r\n"
+                    "Connection: close\r\n"
+                    "Proxy-Connection: close\r\n"
+                    "Upgrade: websocket\r\n"
+                    "Transfer-Encoding: gzip\r\n"
+                    "Content-Length: 42\r\n"
+                    "Trailer: Evil\r\n"
+                    "Host: evil.example\r\n"
+                    "\r\n"),
+                ec);
+            BEAST_EXPECT(p.is_done());
+
+            // fields absent from the header must not be added
+            BEAST_EXPECT(! p.get().contains(field::connection));
+            BEAST_EXPECT(! p.get().contains(field::proxy_connection));
+            BEAST_EXPECT(! p.get().contains(field::upgrade));
+            BEAST_EXPECT(! p.get().contains(field::content_length));
+            BEAST_EXPECT(! p.get().contains(field::host));
+
+            // fields present in the header must not be duplicated
+            BEAST_EXPECT(p.get().count(field::transfer_encoding) == 1);
+            BEAST_EXPECT(p.get()[field::transfer_encoding] == "chunked");
+            BEAST_EXPECT(p.get().count(field::trailer) == 1);
+        }
     }
 
     void

--- a/test/beast/http/parser.cpp
+++ b/test/beast/http/parser.cpp
@@ -404,6 +404,43 @@ public:
             // standard, not listed in Trailer
             BEAST_EXPECT(! p.get().contains(field::content_digest));
         }
+
+        // rfc7230 section 4.1.2: framing and connection control
+        // fields carried in a trailer must not affect the message
+        {
+            error_code ec;
+            parser_type<false> p;
+            p.eager(true);
+            p.put(
+                buf("HTTP/1.1 200 OK\r\n"
+                    "Transfer-Encoding: chunked\r\n"
+                    "\r\n"
+                    "0\r\n"
+                    "Connection: close\r\n"
+                    "\r\n"),
+                ec);
+            BEAST_EXPECT(p.is_done());
+            // Connection in the trailer must not close the connection
+            BEAST_EXPECT(p.keep_alive());
+        }
+        {
+            error_code ec;
+            parser_type<true> p;
+            p.eager(true);
+            p.put(
+                buf("GET / HTTP/1.1\r\n"
+                    "Host: localhost\r\n"
+                    "Transfer-Encoding: chunked\r\n"
+                    "\r\n"
+                    "0\r\n"
+                    "Connection: upgrade\r\n"
+                    "Upgrade: websocket\r\n"
+                    "\r\n"),
+                ec);
+            BEAST_EXPECT(p.is_done());
+            // Upgrade in the trailer must not mark the message as upgrade
+            BEAST_EXPECT(! p.upgrade());
+        }
     }
 
     void

--- a/test/bench/wsload/wsload.cpp
+++ b/test/bench/wsload/wsload.cpp
@@ -38,7 +38,7 @@ using tcp = boost::asio::ip::tcp;       // from <boost/asio/ip/tcp.hpp>
 
 class test_buffer
 {
-    char data_[4096];
+    char data_[4096] = {};
     net::const_buffer b_;
 
 public:

--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -77,7 +77,6 @@ else()
   detail
   fusion
   function_types
-  functional
   typeof
   )
 

--- a/tools/get-boost.sh
+++ b/tools/get-boost.sh
@@ -61,7 +61,6 @@ git submodule update --init --depth 20 --jobs 4 \
     libs/exception \
     libs/function \
     libs/function_types \
-    libs/functional \
     libs/fusion \
     libs/integer \
     libs/io \


### PR DESCRIPTION
Noticed keep_alive() changing value after is_header_done() had already returned true whilst going through the chunked trailer path.

1. inner_parse_fields runs do_field() over the trailer section as well, so a Connection, Upgrade, Content-Length or Transfer-Encoding field sat in a chunked trailer gets applied to the message.
2. a trailer Connection: close then clears keep-alive and a trailer Upgrade sets upgrade(), both settled after the header section is finished, which rfc7230 4.1.2 does not allow.

Gated do_field() to the header section so trailer fields only reach on_trailer_field_impl. Left unfixed a peer can steer connection reuse and upgrade state from bytes that arrive behind the headers, where a front end that drops trailers would not agree. Regression added covering the keep-alive and upgrade cases.