### PR TITLE
reject 64-bit frame length with the high bit set

### DIFF
--- a/include/boost/beast/websocket/impl/stream_impl.hpp
+++ b/include/boost/beast/websocket/impl/stream_impl.hpp
@@ -851,6 +851,12 @@ parse_fh(
             BOOST_BEAST_ASSIGN_EC(ec, error::bad_size);
             return false;
         }
+        if(fh.len >> 63)
+        {
+            // most significant bit must be 0
+            BOOST_BEAST_ASSIGN_EC(ec, error::bad_size);
+            return false;
+        }
         break;
     }
     }

--- a/test/beast/websocket/read2.cpp
+++ b/test/beast/websocket/read2.cpp
@@ -323,13 +323,13 @@ public:
             doFailTest(w, ws, error::bad_close_code);
         });
 
-        // message size above 2^64
+        // message size 2^63-1
         doTest<deflateSupported>(pmd,
         [&](ws_type_t<deflateSupported>& ws)
         {
             w.write_some(ws, false, sbuf("*"));
             w.write_raw(ws, cbuf(
-                {0x80, 0xff, 0xff, 0xff, 0xff, 0xff,
+                {0x80, 0xff, 0x7f, 0xff, 0xff, 0xff,
                 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}));
             doReadTest(w, ws, close_code::too_big);
         });

--- a/test/beast/websocket/read3.cpp
+++ b/test/beast/websocket/read3.cpp
@@ -337,6 +337,21 @@ public:
         // length not canonical
         bad(string_view("\x81\x7e\x00\x7d", 4));
         bad(string_view("\x81\x7f\x00\x00\x00\x00\x00\x00\xff\xff", 10));
+
+        // 64-bit length with the most significant bit set
+        {
+            echo_server es{log};
+            net::io_context ioc;
+            stream<test::stream> ws{ioc};
+            ws.next_layer().connect(es.stream());
+            ws.handshake("localhost", "/");
+            ws.next_layer().append(
+                string_view("\x81\x7f\xff\xff\xff\xff\xff\xff\xff\xff", 10));
+            error_code ec;
+            multi_buffer b;
+            ws.read(b, ec);
+            BEAST_EXPECTS(ec == error::bad_size, ec.message());
+        }
     }
 
     void

--- a/test/beast/websocket/read3.cpp
+++ b/test/beast/websocket/read3.cpp
@@ -364,9 +364,9 @@ public:
             stream<test::stream> ws{ioc};
             ws.next_layer().connect(es.stream());
             ws.handshake("localhost", "/");
-            // too-big message frame indicates payload of 2^64-1
+            // too-big message frame indicates payload of 2^63-1
             net::write(ws.next_layer(), sbuf(
-                "\x81\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"));
+                "\x81\xff\x7f\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"));
             multi_buffer b;
             error_code ec;
             ws.read(b, ec);


### PR DESCRIPTION
While analysing how parse_fh decodes frame headers I noticed the 64-bit extended payload length is checked only for its minimum canonical encoding (the `fh.len < 65536` test); the most significant bit is never examined. RFC 6455 section 5.2 requires that bit to be 0 in the 64-bit form, so a frame advertising a length of 2^63 or more is malformed framing that a conformant endpoint must reject. Replaying such a header into a client read confirms it is accepted as an ordinary data frame and the stream then starts reading the advertised payload.

The behaviour depends on configuration: with a read message limit the oversize length only surfaces later as message_too_big, but with read_message_max(0) nothing catches it and the read blocks on a payload that can never arrive. I put the check beside the existing canonical-length test because parse_fh is the only place the 64-bit length is decoded, so failing it there with bad_size keeps callers from re-validating the framing themselves.
