### PR TITLE
reject chunked transfer-encoding in HTTP/1.0 requests

### DIFF
--- a/include/boost/beast/http/impl/basic_parser.ipp
+++ b/include/boost/beast/http/impl/basic_parser.ipp
@@ -432,6 +432,16 @@ finish_header(error_code& ec, std::true_type)
     // RFC 7230 section 3.3
     // https://tools.ietf.org/html/rfc7230#section-3.3
 
+    // chunked is an HTTP/1.1 transfer coding; an HTTP/1.0 request that
+    // resolves to chunked framing cannot be delimited reliably by a
+    // recipient that ignores Transfer-Encoding per HTTP/1.0, so reject
+    // it here instead of consuming the body as chunks.
+    if((f_ & flagChunked) && ! (f_ & flagHTTP11))
+    {
+        BOOST_BEAST_ASSIGN_EC(ec, error::bad_transfer_encoding);
+        return;
+    }
+
     if(f_ & flagSkipBody)
     {
         state_ = state::complete;

--- a/test/beast/http/basic_parser.cpp
+++ b/test/beast/http/basic_parser.cpp
@@ -786,6 +786,17 @@ public:
             "Content-Length: 1\r\n"
             "Transfer-Encoding: chunked\r\n"
             "\r\n",                                     error::bad_transfer_encoding);
+
+        // chunked is an HTTP/1.1 transfer coding; reject a request that
+        // resolves to chunked framing over HTTP/1.0
+        failgrind<test_parser<true>>(
+            "GET / HTTP/1.0\r\n"
+            "Transfer-Encoding: chunked\r\n"
+            "\r\n0\r\n\r\n",                            error::bad_transfer_encoding);
+        failgrind<test_parser<true>>(
+            "GET / HTTP/1.0\r\n"
+            "Transfer-Encoding: gzip, chunked\r\n"
+            "\r\n0\r\n\r\n",                            error::bad_transfer_encoding);
     }
 
     void


### PR DESCRIPTION
HTTP/1.0 has no chunked transfer coding, yet the parser honoured it on a request and framed the body as chunks. I was tracing how `finish_header` decides the body style and the version flag sits right next to the framing decision but is never read.

1. `do_field` sets the chunked flag whenever Transfer-Encoding resolves to chunked as the final coding, with no regard for the request version.
2. `finish_header` then switches into chunk parsing, so `POST / HTTP/1.0` carrying `Transfer-Encoding: chunked` is consumed as a chunked message.

Reject at `finish_header` when the chunked flag is set on anything below HTTP/1.1. The risk if left alone is desync: a front-end that follows HTTP/1.0 and ignores Transfer-Encoding will disagree with Beast about where the body ends, which is a request smuggling primitive. Responses are left untouched since reading a 1.0 chunked response to EOF is the usual interop fudge. Closes #837.
