### PR TITLE
reject requests with more than one Host header field

### DIFF
--- a/include/boost/beast/http/basic_parser.hpp
+++ b/include/boost/beast/http/basic_parser.hpp
@@ -110,6 +110,7 @@ class basic_parser
     static unsigned constexpr flagContentLength         = 1<< 10;
     static unsigned constexpr flagChunked               = 1<< 11;
     static unsigned constexpr flagUpgrade               = 1<< 12;
+    static unsigned constexpr flagHost                  = 1<< 13;
 
     static constexpr
     std::uint64_t

--- a/include/boost/beast/http/error.hpp
+++ b/include/boost/beast/http/error.hpp
@@ -170,7 +170,10 @@ enum class error
     header_field_name_too_large,
 
     /// Header field value exceeds @ref basic_fields::max_value_size.
-    header_field_value_too_large
+    header_field_value_too_large,
+
+    /// The request contains more than one Host header field.
+    multiple_host
 };
 
 } // http

--- a/include/boost/beast/http/impl/basic_parser.ipp
+++ b/include/boost/beast/http/impl/basic_parser.ipp
@@ -835,6 +835,21 @@ do_field(field f,
         return;
     }
 
+    // Host
+    if(isRequest && f == field::host)
+    {
+        // RFC 7230 section 5.4: a request that contains more than one
+        // Host header field must be rejected. A duplicate Host lets an
+        // upstream and this parser resolve the request to different
+        // authorities, a request routing / cache poisoning vector.
+        if(f_ & flagHost)
+        {
+            BOOST_BEAST_ASSIGN_EC(ec, error::multiple_host);
+            return;
+        }
+        f_ |= flagHost;
+    }
+
     ec = {};
 }
 

--- a/include/boost/beast/http/impl/error.ipp
+++ b/include/boost/beast/http/impl/error.ipp
@@ -63,6 +63,7 @@ public:
         case error::short_read: return "unexpected eof in body";
         case error::header_field_name_too_large: return "header field name too large";
         case error::header_field_value_too_large: return "header field value too large";
+        case error::multiple_host: return "multiple Host";
 
         default:
             return "beast.http error";

--- a/test/beast/http/basic_parser.cpp
+++ b/test/beast/http/basic_parser.cpp
@@ -828,6 +828,38 @@ public:
     }
 
     void
+    testHostField()
+    {
+        auto const m = [](std::string const& s)
+            { return "GET / HTTP/1.1\r\n" + s + "\r\n"; };
+
+        using P = test_parser<true>;
+
+        // a single Host, and lookalike field names, are fine
+        parsegrind<P>(m("Host: localhost\r\n"),                expect_flags{*this, 0});
+        parsegrind<P>(m("Hostname: x\r\n"),                    expect_flags{*this, 0});
+        parsegrind<P>(m("Host: a\r\n Host: b\r\n"),            expect_flags{*this, 0}); // obs-fold, single field
+
+        // RFC 7230 section 5.4: a request with more than one Host
+        // header field is rejected, whether or not the values agree
+        failgrind<P>(m("Host: localhost\r\n"
+                       "Host: other\r\n"),                     error::multiple_host);
+        failgrind<P>(m("Host: localhost\r\n"
+                       "Host: localhost\r\n"),                 error::multiple_host);
+        failgrind<P>(m("Host: a\r\n"
+                       "Content-Length: 0\r\n"
+                       "Host: b\r\n"),                         error::multiple_host);
+
+        // the rule is request-only; responses are not affected
+        parsegrind<test_parser<false>>(
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Length: 0\r\n"
+            "Host: a\r\n"
+            "Host: b\r\n"
+            "\r\n",                                            expect_flags{*this, 0});
+    }
+
+    void
     testPartial()
     {
         // Make sure the slow-loris defense works and that
@@ -1636,6 +1668,7 @@ public:
         testContentLengthField();
         testTransferEncodingField();
         testUpgradeField();
+        testHostField();
         testPartial();
         testLimits();
         testBody();


### PR DESCRIPTION
basic_parser rejects a duplicate Content-Length but quietly accepts two Host header fields, which RFC 7230 5.4 forbids because a front-end and the back-end can then resolve the request to different authorities, a routing and cache-poisoning vector.

1. do_field acts on Connection, Content-Length, Transfer-Encoding and Upgrade but never looked at Host, so a second Host was merged like any ordinary field.
2. track it with a flagHost bit and fail the request with error::multiple_host on the second occurrence, request-side only so response parsing is unchanged.