### PR TITLE
reject content-length with transfer-encoding regardless of order

### DIFF
--- a/include/boost/beast/http/basic_parser.hpp
+++ b/include/boost/beast/http/basic_parser.hpp
@@ -110,6 +110,7 @@ class basic_parser
     static unsigned constexpr flagContentLength         = 1<< 10;
     static unsigned constexpr flagChunked               = 1<< 11;
     static unsigned constexpr flagUpgrade               = 1<< 12;
+    static unsigned constexpr flagTransferEncoding      = 1<< 13;
 
     static constexpr
     std::uint64_t

--- a/include/boost/beast/http/impl/basic_parser.ipp
+++ b/include/boost/beast/http/impl/basic_parser.ipp
@@ -753,8 +753,11 @@ do_field(field f,
             BOOST_BEAST_ASSIGN_EC(ec, error::multiple_content_length);
         };
 
-        // conflicting field
-        if(f_ & flagChunked)
+        // conflicting field: a Transfer-Encoding was already seen, and a
+        // message must not carry both Transfer-Encoding and Content-Length
+        // regardless of the transfer coding or the order the two fields
+        // arrive in (RFC 7230 3.3.3).
+        if(f_ & (flagChunked | flagTransferEncoding))
             return bad_content_length();
 
         // Content-length may be a comma-separated list of integers
@@ -810,6 +813,11 @@ do_field(field f,
             BOOST_BEAST_ASSIGN_EC(ec, error::bad_transfer_encoding);
             return;
         }
+
+        // Record that a Transfer-Encoding was present so a Content-Length
+        // arriving afterwards is rejected the same way it would be if the
+        // fields arrived in the opposite order.
+        f_ |= flagTransferEncoding;
 
         ec = {};
         auto const v = token_list{value};

--- a/test/beast/http/basic_parser.cpp
+++ b/test/beast/http/basic_parser.cpp
@@ -797,6 +797,19 @@ public:
             "GET / HTTP/1.0\r\n"
             "Transfer-Encoding: gzip, chunked\r\n"
             "\r\n0\r\n\r\n",                            error::bad_transfer_encoding);
+
+        // a message must not carry both Transfer-Encoding and Content-Length,
+        // regardless of the transfer coding or the order the fields arrive in
+        failgrind<test_parser<true>>(
+            "POST / HTTP/1.1\r\n"
+            "Content-Length: 5\r\n"
+            "Transfer-Encoding: gzip\r\n"
+            "\r\n",                                     error::bad_transfer_encoding);
+        failgrind<test_parser<true>>(
+            "POST / HTTP/1.1\r\n"
+            "Transfer-Encoding: gzip\r\n"
+            "Content-Length: 5\r\n"
+            "\r\n",                                     error::bad_content_length);
     }
 
     void


### PR DESCRIPTION
do_field already treats Content-Length and Transfer-Encoding as mutually exclusive, but only catches the conflict for some header orderings. I was going back over the conflict handling after the recent framing work and the two branches are not symmetric: the Transfer-Encoding branch bails out when flagContentLength is set, and the Content-Length branch bails out when flagChunked is set, yet a Transfer-Encoding whose coding does not resolve to chunked (say `Transfer-Encoding: gzip`) records no flag at all. So `Transfer-Encoding: gzip` followed by `Content-Length: 5` is accepted and framed by the Content-Length, while the very same two fields in the opposite order are rejected with bad_transfer_encoding.

Header field order deciding whether a request is rejected is the Content-Length / Transfer-Encoding desync that RFC 7230 3.3.3 forbids: a front-end that honours the Transfer-Encoding and Beast honouring the Content-Length disagree about where the body ends, which is a request smuggling primitive. I record the presence of any Transfer-Encoding in a new flag and reject a following Content-Length, so the conflict is caught at whichever field completes it no matter the order or the coding. The check stays in do_field next to the existing conflict logic so finish_header still sees a consistent flag set. The regression test exercises both orderings.
