### PR TITLE
accept websocket close code 1014 (bad gateway)

### DIFF
--- a/include/boost/beast/websocket/detail/frame.hpp
+++ b/include/boost/beast/websocket/detail/frame.hpp
@@ -106,13 +106,13 @@ is_valid_close_code(std::uint16_t v)
     case close_code::internal_error:    // 1011
     case close_code::service_restart:   // 1012
     case close_code::try_again_later:   // 1013
+    case close_code::bad_gateway:       // 1014
         return true;
 
     // explicitly reserved
     case close_code::reserved1:         // 1004
     case close_code::no_status:         // 1005
     case close_code::abnormal:          // 1006
-    case close_code::reserved2:         // 1014
     case close_code::reserved3:         // 1015
         return false;
     }

--- a/include/boost/beast/websocket/rfc6455.hpp
+++ b/include/boost/beast/websocket/rfc6455.hpp
@@ -107,6 +107,9 @@ enum close_code : std::uint16_t
     /// The server is terminating the connection due to a temporary condition, e.g. it is overloaded and is casting off some of its clients.
     try_again_later = 1013,
 
+    /// The endpoint, acting as a gateway or proxy, received an invalid response from an upstream server, analogous to HTTP status 502.
+    bad_gateway     = 1014,
+
     //----
     //
     // The following are illegal on the wire
@@ -137,13 +140,7 @@ enum close_code : std::uint16_t
     abnormal        = 1006,
 
     /** Reserved for future use by the WebSocket standard.
-        
-        This code is reserved and may not be sent.
-    */
-    reserved2       = 1014,
 
-    /** Reserved for future use by the WebSocket standard.
-       
         This code is reserved and may not be sent.
     */
     reserved3       = 1015

--- a/test/beast/websocket/frame.cpp
+++ b/test/beast/websocket/frame.cpp
@@ -27,11 +27,13 @@ public:
         BEAST_EXPECT(! is_valid_close_code(1004));
         BEAST_EXPECT(! is_valid_close_code(1005));
         BEAST_EXPECT(! is_valid_close_code(1006));
+        BEAST_EXPECT(! is_valid_close_code(1015));
         BEAST_EXPECT(! is_valid_close_code(1016));
         BEAST_EXPECT(! is_valid_close_code(2000));
         BEAST_EXPECT(! is_valid_close_code(2999));
         BEAST_EXPECT(is_valid_close_code(1000));
         BEAST_EXPECT(is_valid_close_code(1002));
+        BEAST_EXPECT(is_valid_close_code(1014));
         BEAST_EXPECT(is_valid_close_code(3000));
         BEAST_EXPECT(is_valid_close_code(4000));
         BEAST_EXPECT(is_valid_close_code(5000));


### PR DESCRIPTION
While going over how the websocket layer validates incoming close frames I compared `is_valid_close_code` in `websocket/detail/frame.hpp` against the IANA WebSocket Close Code registry and found 1014 sitting in the reserved group alongside 1004/1005/1006/1015 and reported as invalid. Its neighbours 1012 (`service_restart`) and 1013 (`try_again_later`) were registered in the same batch after the original RFC 6455 table and are already accepted, so the grouping is just stale: 1014 was genuinely reserved when this code was written and has since been assigned to "Bad Gateway", the upstream-failure analogue of HTTP 502. A peer such as a gateway or reverse proxy that signals an upstream failure with 1014 therefore has its Close frame rejected in `read_close` with `error::bad_close_code`, and the connection is failed with a protocol error (1002) rather than completing the closing handshake, so the real reason for the closure is lost.

The fix accepts 1014 on receipt and renames the `reserved2` enumerator to `bad_gateway` so it reads beside `service_restart` and `try_again_later` and matches how 1012/1013 are already handled. Received close codes are only ever vetted through `is_valid_close_code`, so the change stays in that one helper; 1015 keeps returning false because it remains reserved and must not appear on the wire. The test gains assertions for both sides of the boundary so 1014 cannot quietly slip back into the reserved set.