### PR TITLE
validate quoted-string in parse_chunk_extensions

### DIFF
--- a/include/boost/beast/http/detail/basic_parser.ipp
+++ b/include/boost/beast/http/detail/basic_parser.ipp
@@ -800,6 +800,16 @@ semi:
                     ec = error::need_more;
                     return;
                 }
+                if(! detail::is_qpchar(*it))
+                {
+                    ec = error::bad_chunk_extension;
+                    return;
+                }
+            }
+            else if(! detail::is_qdchar(*it))
+            {
+                ec = error::bad_chunk_extension;
+                return;
             }
         }
         ++it;

--- a/test/beast/http/basic_parser.cpp
+++ b/test/beast/http/basic_parser.cpp
@@ -1679,6 +1679,40 @@ public:
     }
 
     void
+    testChunkExtensions()
+    {
+        // a quoted chunk-ext value is a quoted-string and may only hold
+        // qdtext or a valid quoted-pair, see rfc7230 section 4.1.1
+        auto const ce =
+            [&](string_view chunk, error_code expected)
+            {
+                string_view const hdr =
+                    "POST / HTTP/1.1\r\n"
+                    "Transfer-Encoding: chunked\r\n"
+                    "\r\n";
+                test_parser<true> p;
+                p.eager(true);
+                error_code ec;
+                p.put(net::buffer(hdr.data(), hdr.size()), ec);
+                BEAST_EXPECT(p.is_header_done());
+                p.put(net::buffer(chunk.data(), chunk.size()), ec);
+                BEAST_EXPECTS(ec == expected, ec.message());
+            };
+        // valid
+        ce("1;a=\"xy\"\r\nX\r\n0\r\n\r\n", {});
+        ce("1;a=\"\\\"\"\r\nX\r\n0\r\n\r\n", {});
+        // a bare LF inside the quotes is not qdtext
+        ce("1;a=\"\n\"\r\nX\r\n0\r\n\r\n",
+            error::bad_chunk_extension);
+        // a control character inside the quotes is not qdtext
+        ce("1;a=\"\x01\"\r\nX\r\n0\r\n\r\n",
+            error::bad_chunk_extension);
+        // a quoted-pair must escape a qpchar, not a control character
+        ce("1;a=\"\\\n\"\r\nX\r\n0\r\n\r\n",
+            error::bad_chunk_extension);
+    }
+
+    void
     testUnlimitedBody()
     {
         const char data[] =
@@ -1740,6 +1774,7 @@ public:
         testIssue1267();
         testChunkedOverflow();
         testChunkedBodySize();
+        testChunkExtensions();
         testUnlimitedBody();
         testIssue2201();
     }


### PR DESCRIPTION
**Quoted chunk-ext values skip character validation**

While going over the chunked request path I noticed `parse_chunk_extensions` walks a quoted chunk-ext value looking only for the closing `"` and a backslash escape, without ever checking the octets in between. The rfc7230 quoted-string grammar only permits qdtext inside the quotes and a qpchar after a backslash, yet the loop accepts anything, so NUL, other control characters, DEL and a bare LF all parse cleanly. `param_iter` already validates header-parameter quoted-strings with `is_qdchar`/`is_qpchar`; the chunk parser just never got the same treatment.

The bare LF is what bothers me here. `find_eol` only recognises CRLF as the chunk-line terminator, so Beast keeps `1;a="<LF>"` together as a single line, whereas a peer that accepts a lone LF as a line ending would cut the chunk-size line at the LF and disagree about where the next chunk begins, which is the usual shape of a chunked desync. The added regression case in basic_parser.cpp fails on the unpatched parser and passes after; valid quoted extensions still parse.