### PR TITLE
reject 1xx responses with a body in prepare_payload

### DIFF
--- a/include/boost/beast/http/impl/message.hpp
+++ b/include/boost/beast/http/impl/message.hpp
@@ -390,7 +390,7 @@ prepare_payload(std::false_type)
 {
     auto const n = payload_size();
     if( (! n || *n > 0) && (
-        (status_class(this->result()) == status_class::informational ||
+        (to_status_class(this->result()) == status_class::informational ||
         this->result() == status::no_content ||
         this->result() == status::not_modified)))
     {

--- a/test/beast/http/fields.cpp
+++ b/test/beast/http/fields.cpp
@@ -672,6 +672,32 @@ public:
             BEAST_EXPECT(res.count(field::content_length) == 0);
             BEAST_EXPECT(res[field::transfer_encoding] == "chunked");
         }
+
+        // a body is not allowed on 1xx, 204 or 304
+        {
+            for(auto code : {
+                status::continue_,          // 100
+                status::switching_protocols,// 101
+                status::processing,         // 102
+                status::early_hints,        // 103
+                status::no_content,         // 204
+                status::not_modified})      // 304
+            {
+                response<sized_body> res;
+                res.version(11);
+                res.result(code);
+                res.body() = 1;
+                BEAST_THROWS(res.prepare_payload(), std::invalid_argument);
+            }
+
+            // an ordinary 2xx response with a body is unaffected
+            response<sized_body> res;
+            res.version(11);
+            res.result(status::ok);
+            res.body() = 1;
+            res.prepare_payload();
+            BEAST_EXPECT(res[field::content_length] == "1");
+        }
     }
 
     void


### PR DESCRIPTION
prepare_payload on a response is meant to reject a body for the status codes RFC 7230 says cannot carry one, but the 1xx branch never fires. At message.hpp:393 status_class(this->result()) is a functional-style cast rather than a call to to_status_class, so it reinterprets the numeric status (e.g. 100) as a status_class value and compares it against status_class::informational, whose underlying value is 1. The test is false for every real 1xx code, so a 100/101/102/103 response built with a non-empty body sails through and even gets a synthesised Content-Length. 204 and 304 still throw because they are checked explicitly by value; only the whole 1xx class was broken.

The sibling need_eof a few lines up at message.hpp:345 does the same classification correctly with to_status_class, which is what tipped me off. Switching line 393 to to_status_class makes the 1xx case throw invalid_argument like 204/304, so the library no longer emits a 1xx response with a body and a Content-Length that RFC 7230 3.3.2 forbids and that an intermediary can read as message framing. Valid responses are untouched; the case added to testPreparePayload fails on the four 1xx codes before the change and passes after.